### PR TITLE
🐛 fix: prevent chunk upload connection reuse (#10)

### DIFF
--- a/file.go
+++ b/file.go
@@ -282,6 +282,11 @@ func (s *FileService) uploadChunk(ctx context.Context, id int, data []byte, offs
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("User-Agent", s.client.userAgent)
 
+	// Disable connection reuse for chunk uploads. VergeOS 26.0.x closes
+	// connections between chunks, causing "use of closed network connection"
+	// errors when the HTTP client attempts to reuse them.
+	req.Close = true
+
 	// Set body
 	req.Body = io.NopCloser(newBytesReader(data))
 	req.ContentLength = int64(len(data))


### PR DESCRIPTION
## Summary
- Fixes #10
- Adds `req.Close = true` to `uploadChunk` to prevent connection reuse between chunks

## Context
VergeOS 26.0.x closes TCP connections between chunk uploads, causing `use of closed
network connection` errors. This was fixed server-side in VergeOS 26.1.x — uploads
work without this change on current versions.

The original issue proposed creating a new `http.Client` and `http.Transport` per chunk.
That's unnecessary and would slow down transfers by forcing a new TLS handshake for every
256KB chunk (~16,000 handshakes for a 4GB file). A single `req.Close = true` achieves the
same connection isolation without bypassing the user's configured transport.

This fix is being added solely to prevent this single vector of regression in future
VergeOS server versions.

## Test plan
- [x] Reproduced failure on VergeOS 26.0.x (failed at chunk ~221)
- [x] Verified fix on VergeOS 26.0.x (1GB upload passes)
- [x] Verified no regression on VergeOS 26.1.x (existing upload tests pass)