### PR TITLE
feat: add NIC ipaddress to list fields and MachineStatusService

### DIFF
--- a/client.go
+++ b/client.go
@@ -110,6 +110,7 @@ type Client struct {
 	ClusterTiers            ClusterTierServiceInterface
 	MachineDrivePhys        MachineDrivePhysServiceInterface
 	ClusterStatsHistory     ClusterStatsHistoryServiceInterface
+	MachineStatus           MachineStatusServiceInterface
 	MachineStats            MachineStatsServiceInterface
 	MachineDriveStats       MachineDriveStatsServiceInterface
 	MachineNICs             MachineNICServiceInterface
@@ -372,6 +373,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c.ClusterTiers = &ClusterTierService{client: c}
 	c.MachineDrivePhys = &MachineDrivePhysService{client: c}
 	c.ClusterStatsHistory = &ClusterStatsHistoryService{client: c}
+	c.MachineStatus = &MachineStatusService{client: c}
 	c.MachineStats = &MachineStatsService{client: c}
 	c.MachineDriveStats = &MachineDriveStatsService{client: c}
 	c.MachineNICs = &MachineNICService{client: c}

--- a/interfaces.go
+++ b/interfaces.go
@@ -850,6 +850,14 @@ type ClusterStatsHistoryServiceInterface interface {
 	GetLong(ctx context.Context, id int) (*ClusterStatsHistory, error)
 }
 
+// MachineStatusServiceInterface defines the interface for machine status operations (read-only).
+// Machine status provides runtime state, power state, node assignment, and guest agent information.
+type MachineStatusServiceInterface interface {
+	List(ctx context.Context, opts ...ListOption) ([]MachineStatus, error)
+	Get(ctx context.Context, machineKey int) (*MachineStatus, error)
+	GetByKey(ctx context.Context, key int) (*MachineStatus, error)
+}
+
 // MachineStatsServiceInterface defines the interface for machine stats operations (read-only).
 // Machine stats provide per-node CPU, RAM, and temperature metrics.
 type MachineStatsServiceInterface interface {
@@ -964,6 +972,7 @@ var (
 	_ ClusterTierServiceInterface             = (*ClusterTierService)(nil)
 	_ MachineDrivePhysServiceInterface        = (*MachineDrivePhysService)(nil)
 	_ ClusterStatsHistoryServiceInterface     = (*ClusterStatsHistoryService)(nil)
+	_ MachineStatusServiceInterface           = (*MachineStatusService)(nil)
 	_ MachineStatsServiceInterface            = (*MachineStatsService)(nil)
 	_ MachineDriveStatsServiceInterface       = (*MachineDriveStatsService)(nil)
 	_ MachineNICServiceInterface              = (*MachineNICService)(nil)

--- a/machine_status.go
+++ b/machine_status.go
@@ -1,0 +1,64 @@
+package vergeos
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// MachineStatusService handles machine status operations.
+type MachineStatusService struct {
+	client *Client
+}
+
+// List returns all machine statuses.
+func (s *MachineStatusService) List(ctx context.Context, opts ...ListOption) ([]MachineStatus, error) {
+	options := applyListOptions(opts)
+	if options.Fields == "most" {
+		options.Fields = machineStatusListFields
+	}
+	params := options.toQueryParams()
+
+	var statuses []MachineStatus
+	if err := s.client.get(ctx, "/machine_status", params, &statuses); err != nil {
+		return nil, err
+	}
+
+	return statuses, nil
+}
+
+// Get returns the status for a specific machine by its machine key.
+func (s *MachineStatusService) Get(ctx context.Context, machineKey int) (*MachineStatus, error) {
+	// machine_status is keyed by machine, so we filter by machine eq <key>.
+	params := url.Values{}
+	params.Set("fields", machineStatusGetFields)
+	params.Set("filter", fmt.Sprintf("machine eq %d", machineKey))
+
+	var statuses []MachineStatus
+	if err := s.client.get(ctx, "/machine_status", params, &statuses); err != nil {
+		return nil, err
+	}
+
+	if len(statuses) == 0 {
+		return nil, &NotFoundError{Resource: "MachineStatus", ID: machineKey}
+	}
+
+	return &statuses[0], nil
+}
+
+// GetByKey returns the status by its direct row key.
+func (s *MachineStatusService) GetByKey(ctx context.Context, key int) (*MachineStatus, error) {
+	params := url.Values{}
+	params.Set("fields", machineStatusGetFields)
+
+	var status MachineStatus
+	endpoint := fmt.Sprintf("/machine_status/%d", key)
+	if err := s.client.get(ctx, endpoint, params, &status); err != nil {
+		if IsNotFoundError(err) {
+			return nil, &NotFoundError{Resource: "MachineStatus", ID: key}
+		}
+		return nil, err
+	}
+
+	return &status, nil
+}

--- a/types_machine_status.go
+++ b/types_machine_status.go
@@ -1,0 +1,128 @@
+package vergeos
+
+import "encoding/json"
+
+// MachineStatus represents the runtime status of a VergeOS machine (VM).
+// This includes power state, node assignment, and guest agent information.
+type MachineStatus struct {
+	// Key is the status row key.
+	Key FlexInt `json:"$key,omitempty"`
+	// Machine is the machine ID this status belongs to.
+	Machine int `json:"machine,omitempty"`
+	// Running indicates whether the machine is currently running.
+	Running bool `json:"running"`
+	// Migratable indicates whether the machine can be migrated.
+	Migratable bool `json:"migratable"`
+	// Status is the machine status string (running, stopped, etc.).
+	Status string `json:"status,omitempty"`
+	// StatusInfo provides additional status details.
+	StatusInfo string `json:"status_info,omitempty"`
+	// State is the overall state (online, offline, warning, error).
+	State string `json:"state,omitempty"`
+	// PowerState indicates the power state of the machine.
+	PowerState bool `json:"powerstate"`
+	// Node is the node ID where the machine is running.
+	Node FlexInt `json:"node,omitempty"`
+	// NodeName is the display name of the node.
+	NodeName string `json:"node_name,omitempty"`
+	// MigratedNode is the node ID after migration.
+	MigratedNode FlexInt `json:"migrated_node,omitempty"`
+	// MigrationDestination is the target node for in-progress migration.
+	MigrationDestination FlexInt `json:"migration_destination,omitempty"`
+	// Started is the timestamp when the machine was started (Unix epoch).
+	Started int64 `json:"started,omitempty"`
+	// LocalTime is the local time reported by the machine (Unix epoch).
+	LocalTime int64 `json:"local_time,omitempty"`
+	// LastUpdate is the timestamp of the last status update (Unix epoch).
+	LastUpdate int64 `json:"last_update,omitempty"`
+	// RunningCores is the number of CPU cores allocated to the running machine.
+	RunningCores int `json:"running_cores,omitempty"`
+	// RunningRAM is the RAM in MB allocated to the running machine.
+	RunningRAM int `json:"running_ram,omitempty"`
+	// AgentVersion is the guest agent version string.
+	AgentVersion string `json:"agent_version,omitempty"`
+	// AgentFeatures contains guest agent supported features.
+	AgentFeatures json.RawMessage `json:"agent_features,omitempty"`
+	// AgentGuestInfo contains guest OS information reported by the agent,
+	// including network configuration, filesystem info, memory, and hostname.
+	AgentGuestInfo *GuestInfo `json:"agent_guest_info,omitempty"`
+}
+
+// GuestInfo contains guest OS information reported by the VergeOS guest agent.
+type GuestInfo struct {
+	// OSInfo contains operating system details.
+	OSInfo *GuestOSInfo `json:"osinfo,omitempty"`
+	// Network contains network interface information keyed by interface identifier.
+	Network map[string]*GuestNetworkInterface `json:"network,omitempty"`
+	// FSInfo contains filesystem information keyed by mount identifier.
+	FSInfo map[string]*GuestFSInfo `json:"fsinfo,omitempty"`
+	// MemInfo contains memory usage information.
+	MemInfo *GuestMemInfo `json:"meminfo,omitempty"`
+	// Hostname is the guest hostname.
+	Hostname string `json:"hostname,omitempty"`
+	// LastRefresh is the timestamp of the last agent refresh (Unix epoch).
+	LastRefresh int64 `json:"last_refresh,omitempty"`
+}
+
+// GuestOSInfo contains operating system information from the guest agent.
+type GuestOSInfo struct {
+	Name          string `json:"name,omitempty"`
+	PrettyName    string `json:"pretty-name,omitempty"`
+	Version       string `json:"version,omitempty"`
+	ID            string `json:"id,omitempty"`
+	KernelRelease string `json:"kernel-release,omitempty"`
+	KernelVersion string `json:"kernel-version,omitempty"`
+	Machine       string `json:"machine,omitempty"`
+}
+
+// GuestNetworkInterface contains network interface information from the guest agent.
+type GuestNetworkInterface struct {
+	// Name is the interface name (e.g., "enp1s1", "eth0").
+	Name string `json:"name,omitempty"`
+	// HardwareAddress is the MAC address.
+	HardwareAddress string `json:"hardware-address,omitempty"`
+	// IPAddresses contains the IP addresses assigned to this interface.
+	IPAddresses []GuestIPAddress `json:"ip-addresses,omitempty"`
+}
+
+// GuestIPAddress represents an IP address on a guest network interface.
+type GuestIPAddress struct {
+	// Type is the address type ("ipv4" or "ipv6").
+	Type string `json:"ip-address-type,omitempty"`
+	// Address is the IP address string.
+	Address string `json:"ip-address,omitempty"`
+	// Prefix is the subnet prefix length.
+	Prefix int `json:"prefix,omitempty"`
+}
+
+// GuestFSInfo contains filesystem information from the guest agent.
+type GuestFSInfo struct {
+	// Name is the device name.
+	Name string `json:"name,omitempty"`
+	// Type is the filesystem type (e.g., "ext4").
+	Type string `json:"type,omitempty"`
+	// TotalBytes is the total filesystem size in bytes.
+	TotalBytes int64 `json:"total-bytes,omitempty"`
+	// UsedBytes is the used space in bytes.
+	UsedBytes int64 `json:"used-bytes,omitempty"`
+	// MountPoint is the mount point path.
+	MountPoint string `json:"mountpoint,omitempty"`
+}
+
+// GuestMemInfo contains memory information from the guest agent.
+type GuestMemInfo struct {
+	// RAMTotal is the total RAM in MB.
+	RAMTotal int `json:"ram_total,omitempty"`
+	// RAMUsed is the used RAM in MB.
+	RAMUsed int `json:"ram_used,omitempty"`
+	// VRAMTotal is the total VRAM in MB.
+	VRAMTotal int `json:"vram_total,omitempty"`
+	// VRAMUsed is the used VRAM in MB.
+	VRAMUsed int `json:"vram_used,omitempty"`
+}
+
+// machineStatusListFields are the fields to request when listing machine status.
+const machineStatusListFields = "$key,machine,running,migratable,status,status_info,state,powerstate,node,node#name as node_name,migrated_node,migration_destination,started,local_time,last_update,running_cores,running_ram,agent_version,agent_features,agent_guest_info"
+
+// machineStatusGetFields are the fields to request when getting a single machine status.
+const machineStatusGetFields = machineStatusListFields

--- a/types_vm_nic.go
+++ b/types_vm_nic.go
@@ -110,7 +110,7 @@ type vnetAddressRequest struct {
 }
 
 // nicListFields are the fields to request when listing NICs.
-const nicListFields = "$key,machine,orderid,name,description,interface,driver,model,vendor,port,enabled,disable_mq,vnet,macaddress,asset,device"
+const nicListFields = "$key,machine,orderid,name,description,interface,driver,model,vendor,port,enabled,disable_mq,vnet,macaddress,ipaddress,asset,device"
 
 // nicGetFields are the fields to request when getting a single NIC (includes power state).
-const nicGetFields = nicListFields + ",ipaddress,status#status as powerState"
+const nicGetFields = nicListFields + ",status#status as powerState"


### PR DESCRIPTION
## Summary

- Add `ipaddress` to `nicListFields` so `VMNICService.List()` returns IP addresses without a separate `Get()` per NIC. Aligns with pyvergeos `NIC_DEFAULT_FIELDS`.
- New `MachineStatusService` with `List()`, `Get(machineKey)`, `GetByKey(key)` for accessing machine runtime state and guest agent information (network, OS, filesystem, memory).
- Enables IP discovery via guest agent for VMs on networks where VergeOS does not manage DHCP — needed by the CSI driver for NAS service IP resolution.

## Changes

1. `types_vm_nic.go` — Added `ipaddress` to `nicListFields`, removed redundant `ipaddress` from `nicGetFields`
2. `types_machine_status.go` — New types: `MachineStatus`, `GuestInfo`, `GuestNetworkInterface`, `GuestIPAddress`, `GuestOSInfo`, `GuestFSInfo`, `GuestMemInfo`
3. `machine_status.go` — New `MachineStatusService` implementation
4. `interfaces.go` — New `MachineStatusServiceInterface` + compile-time check
5. `client.go` — Wire `MachineStatus` field on `Client`

## Test plan

- [x] `go build ./...` passes
- [x] Manual verification against VergeOS API  with guest agent running on NAS VM (machine=73)
- [x] Verify `VMNICService.List()` now includes `ipaddress` in responses — confirmed field present (empty as expected when DHCP not VergeOS-managed)
- [x] Verify `MachineStatusService.Get(machineKey=xx)` returns `AgentGuestInfo` with network data — confirmed: hostname=`k8s-nas`, interface `enp1s1` with IPv4 `192.168.0.10`, agent version `26.1.2`