### PR TITLE
Add TenantStatus and TenantStatsHistoryShort services

### DIFF
--- a/client.go
+++ b/client.go
@@ -67,6 +67,8 @@ type Client struct {
 	Tenants                 TenantServiceInterface
 	TenantNodes             TenantNodeServiceInterface
 	TenantStorage           TenantStorageServiceInterface
+	TenantStatus            TenantStatusServiceInterface
+	TenantStatsHistoryShort TenantStatsHistoryShortServiceInterface
 	TenantSnapshots         TenantSnapshotServiceInterface
 	TenantLayer2Networks    TenantLayer2NetworkServiceInterface
 	SnapshotProfiles        SnapshotProfileServiceInterface
@@ -330,6 +332,8 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c.Tenants = &TenantService{client: c}
 	c.TenantNodes = &TenantNodeService{client: c}
 	c.TenantStorage = &TenantStorageService{client: c}
+	c.TenantStatus = &TenantStatusService{client: c}
+	c.TenantStatsHistoryShort = &TenantStatsHistoryShortService{client: c}
 	c.TenantSnapshots = &TenantSnapshotService{client: c}
 	c.TenantLayer2Networks = &TenantLayer2NetworkService{client: c}
 	c.SnapshotProfiles = &SnapshotProfileService{client: c}

--- a/interfaces.go
+++ b/interfaces.go
@@ -326,6 +326,22 @@ type TenantStorageServiceInterface interface {
 	Delete(ctx context.Context, id int) error
 }
 
+// TenantStatusServiceInterface defines the interface for tenant status operations (read-only).
+type TenantStatusServiceInterface interface {
+	List(ctx context.Context, opts ...ListOption) ([]TenantStatus, error)
+	Get(ctx context.Context, tenantKey int) (*TenantStatus, error)
+	GetByKey(ctx context.Context, key int) (*TenantStatus, error)
+}
+
+// TenantStatsHistoryShortServiceInterface defines the interface for tenant short-term statistics history operations (read-only).
+// This provides high-resolution historical metrics for tenant monitoring.
+type TenantStatsHistoryShortServiceInterface interface {
+	List(ctx context.Context, opts ...ListOption) ([]TenantStatsHistoryShort, error)
+	ListByTenant(ctx context.Context, tenantID int, opts ...ListOption) ([]TenantStatsHistoryShort, error)
+	GetLatest(ctx context.Context, tenantID int) (*TenantStatsHistoryShort, error)
+	Get(ctx context.Context, id int) (*TenantStatsHistoryShort, error)
+}
+
 // SnapshotProfileServiceInterface defines the interface for SnapshotProfile operations.
 type SnapshotProfileServiceInterface interface {
 	List(ctx context.Context, opts ...ListOption) ([]SnapshotProfile, error)

--- a/tenant.go
+++ b/tenant.go
@@ -422,6 +422,124 @@ type tenantNodeAction struct {
 	Params     map[string]interface{} `json:"params,omitempty"`
 }
 
+// TenantStatusService handles tenant status read operations.
+// Each tenant has exactly one status record.
+type TenantStatusService struct {
+	client *Client
+}
+
+// List returns all tenant statuses.
+func (s *TenantStatusService) List(ctx context.Context, opts ...ListOption) ([]TenantStatus, error) {
+	options := applyListOptions(opts)
+	if options.Fields == "most" {
+		options.Fields = tenantStatusListFields
+	}
+	params := options.toQueryParams()
+
+	var statuses []TenantStatus
+	if err := s.client.get(ctx, "/tenant_status", params, &statuses); err != nil {
+		return nil, err
+	}
+
+	return statuses, nil
+}
+
+// Get returns the status for a specific tenant by its tenant key.
+func (s *TenantStatusService) Get(ctx context.Context, tenantKey int) (*TenantStatus, error) {
+	params := url.Values{}
+	params.Set("fields", tenantStatusGetFields)
+	params.Set("filter", fmt.Sprintf("tenant eq %d", tenantKey))
+
+	var statuses []TenantStatus
+	if err := s.client.get(ctx, "/tenant_status", params, &statuses); err != nil {
+		return nil, err
+	}
+
+	if len(statuses) == 0 {
+		return nil, &NotFoundError{Resource: "TenantStatus", ID: tenantKey}
+	}
+
+	return &statuses[0], nil
+}
+
+// GetByKey returns the status by its direct row key.
+func (s *TenantStatusService) GetByKey(ctx context.Context, key int) (*TenantStatus, error) {
+	params := url.Values{}
+	params.Set("fields", tenantStatusGetFields)
+
+	var status TenantStatus
+	endpoint := fmt.Sprintf("/tenant_status/%d", key)
+	if err := s.client.get(ctx, endpoint, params, &status); err != nil {
+		if IsNotFoundError(err) {
+			return nil, &NotFoundError{Resource: "TenantStatus", ID: key}
+		}
+		return nil, err
+	}
+
+	return &status, nil
+}
+
+// TenantStatsHistoryShortService handles tenant short-term statistics history read operations.
+// This service provides high-resolution historical metrics for tenant monitoring.
+type TenantStatsHistoryShortService struct {
+	client *Client
+}
+
+// List returns short-term historical stats for all tenants.
+func (s *TenantStatsHistoryShortService) List(ctx context.Context, opts ...ListOption) ([]TenantStatsHistoryShort, error) {
+	options := applyListOptions(opts)
+
+	if options.Fields == "most" {
+		options.Fields = tenantStatsHistoryShortFields
+	}
+
+	params := options.toQueryParams()
+
+	var stats []TenantStatsHistoryShort
+	if err := s.client.get(ctx, "/tenant_stats_history_short", params, &stats); err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}
+
+// ListByTenant returns short-term historical stats for a specific tenant.
+func (s *TenantStatsHistoryShortService) ListByTenant(ctx context.Context, tenantID int, opts ...ListOption) ([]TenantStatsHistoryShort, error) {
+	opts = append(opts, WithFilter(fmt.Sprintf("tenant eq %d", tenantID)))
+	return s.List(ctx, opts...)
+}
+
+// GetLatest returns the most recent short-term stats record for a tenant.
+func (s *TenantStatsHistoryShortService) GetLatest(ctx context.Context, tenantID int) (*TenantStatsHistoryShort, error) {
+	stats, err := s.ListByTenant(ctx, tenantID, WithSort("-timestamp"), WithLimit(1))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(stats) == 0 {
+		return nil, &NotFoundError{Resource: "TenantStatsHistoryShort", ID: fmt.Sprintf("tenant=%d", tenantID)}
+	}
+
+	return &stats[0], nil
+}
+
+// Get returns a single short-term stats record by ID.
+func (s *TenantStatsHistoryShortService) Get(ctx context.Context, id int) (*TenantStatsHistoryShort, error) {
+	params := url.Values{}
+	params.Set("fields", tenantStatsHistoryShortFields)
+
+	var stats TenantStatsHistoryShort
+	endpoint := fmt.Sprintf("/tenant_stats_history_short/%d", id)
+	if err := s.client.get(ctx, endpoint, params, &stats); err != nil {
+		if IsNotFoundError(err) {
+			return nil, &NotFoundError{Resource: "TenantStatsHistoryShort", ID: id}
+		}
+		return nil, err
+	}
+
+	return &stats, nil
+}
+
 // TenantStorageService handles tenant storage allocation operations.
 type TenantStorageService struct {
 	client *Client

--- a/test/integration/tenants_test.go
+++ b/test/integration/tenants_test.go
@@ -336,6 +336,131 @@ func TestTenantLayer2List(t *testing.T) {
 	})
 }
 
+// TestTenantStatusList tests the TenantStatus service.
+func TestTenantStatusList(t *testing.T) {
+	client := setupTestClient(t)
+	ctx := context.Background()
+
+	t.Log("Testing TenantStatus service...")
+
+	// List all tenant statuses
+	statuses, err := client.TenantStatus.List(ctx)
+	if err != nil {
+		t.Fatalf("TenantStatus.List failed: %v", err)
+	}
+
+	t.Logf("Found %d tenant statuses", len(statuses))
+
+	if len(statuses) == 0 {
+		t.Log("No tenant statuses found - this is expected on systems without tenants")
+		return
+	}
+
+	// Log first status to verify field mapping
+	first := statuses[0]
+	t.Logf("First tenant status: Key=%d, Tenant=%d, Status=%q, State=%q, Running=%v",
+		int(first.Key), first.Tenant, first.Status, first.State, first.Running)
+
+	// Test Get by tenant key
+	t.Run("Get", func(t *testing.T) {
+		if first.Tenant == 0 {
+			t.Skip("No tenant reference available")
+		}
+		fetched, err := client.TenantStatus.Get(ctx, first.Tenant)
+		if err != nil {
+			t.Errorf("TenantStatus.Get(%d) failed: %v", first.Tenant, err)
+		} else {
+			t.Logf("TenantStatus.Get succeeded: Status=%q, State=%q, Running=%v, Starting=%v, Stopping=%v",
+				fetched.Status, fetched.State, fetched.Running, fetched.Starting, fetched.Stopping)
+		}
+	})
+
+	// Test GetByKey
+	t.Run("GetByKey", func(t *testing.T) {
+		if first.Key == 0 {
+			t.Skip("No status key available")
+		}
+		fetched, err := client.TenantStatus.GetByKey(ctx, int(first.Key))
+		if err != nil {
+			t.Errorf("TenantStatus.GetByKey(%d) failed: %v", int(first.Key), err)
+		} else {
+			t.Logf("TenantStatus.GetByKey succeeded: Tenant=%d, Status=%q", fetched.Tenant, fetched.Status)
+		}
+	})
+
+	prettyPrint(t, "Sample TenantStatus", first)
+}
+
+// TestTenantStatsHistoryShort tests the TenantStatsHistoryShort service.
+func TestTenantStatsHistoryShort(t *testing.T) {
+	client := setupTestClient(t)
+	ctx := context.Background()
+
+	// Get tenants for testing
+	tenants, err := client.Tenants.List(ctx)
+	if err != nil {
+		t.Fatalf("Tenants.List failed: %v", err)
+	}
+	if len(tenants) == 0 {
+		t.Skip("No tenants found - skipping TenantStatsHistoryShort tests")
+	}
+	tenantID := int(tenants[0].Key)
+	t.Logf("Testing with tenant %d (%s)", tenantID, tenants[0].Name)
+
+	t.Run("List", func(t *testing.T) {
+		stats, err := client.TenantStatsHistoryShort.List(ctx, vergeos.WithLimit(5))
+		if err != nil {
+			t.Fatalf("TenantStatsHistoryShort.List failed: %v", err)
+		}
+		t.Logf("Found %d short-term history records (limited to 5)", len(stats))
+
+		if len(stats) > 0 {
+			first := stats[0]
+			t.Logf("First record: Key=%d, Tenant=%d, Timestamp=%d",
+				int(first.Key), first.Tenant, first.Timestamp)
+			t.Logf("Resources: RAMUsed=%d, VRAMUsed=%d, TotalCPU=%d, CoreCount=%d, IPCount=%d",
+				first.RAMUsed, first.VRAMUsed, first.TotalCPU, first.CoreCount, first.IPCount)
+			prettyPrint(t, "Sample TenantStatsHistoryShort", first)
+		}
+	})
+
+	t.Run("ListByTenant", func(t *testing.T) {
+		stats, err := client.TenantStatsHistoryShort.ListByTenant(ctx, tenantID, vergeos.WithLimit(5))
+		if err != nil {
+			t.Fatalf("TenantStatsHistoryShort.ListByTenant(%d) failed: %v", tenantID, err)
+		}
+		t.Logf("Found %d short-term records for tenant %d", len(stats), tenantID)
+	})
+
+	t.Run("GetLatest", func(t *testing.T) {
+		latest, err := client.TenantStatsHistoryShort.GetLatest(ctx, tenantID)
+		if err != nil {
+			if vergeos.IsNotFoundError(err) {
+				t.Logf("No recent stats for tenant %d (this is normal for new/idle tenants)", tenantID)
+			} else {
+				t.Fatalf("TenantStatsHistoryShort.GetLatest(%d) failed: %v", tenantID, err)
+			}
+		} else {
+			t.Logf("Latest stats for tenant %d: Timestamp=%d, RAMUsed=%d, RAMAllocated=%d, RAMPct=%d%%",
+				tenantID, latest.Timestamp, latest.RAMUsed, latest.RAMAllocated, latest.RAMPct)
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		stats, err := client.TenantStatsHistoryShort.List(ctx, vergeos.WithLimit(1))
+		if err != nil || len(stats) == 0 {
+			t.Skip("No stats history records available")
+		}
+
+		first := stats[0]
+		fetched, err := client.TenantStatsHistoryShort.Get(ctx, int(first.Key))
+		if err != nil {
+			t.Fatalf("TenantStatsHistoryShort.Get(%d) failed: %v", int(first.Key), err)
+		}
+		t.Logf("TenantStatsHistoryShort.Get succeeded: Tenant=%d, Timestamp=%d", fetched.Tenant, fetched.Timestamp)
+	})
+}
+
 // TestTenantsCRUD tests Create/Update/Delete operations for Tenant services.
 func TestTenantsCRUD(t *testing.T) {
 	client := setupTestClient(t)

--- a/types_tenant.go
+++ b/types_tenant.go
@@ -252,3 +252,146 @@ const tenantStorageListFields = "$key,tenant,tier,provisioned,used,allocated,use
 
 // tenantStorageGetFields are the fields to request when getting a single storage allocation.
 const tenantStorageGetFields = tenantStorageListFields
+
+// TenantStatus contains tenant runtime status information.
+// Each tenant has exactly one status record, accessed via the /tenant_status endpoint.
+type TenantStatus struct {
+	// Key is the status row key.
+	Key FlexInt `json:"$key,omitempty"`
+	// Tenant is the parent tenant ID.
+	Tenant int `json:"tenant,omitempty"`
+	// Running indicates whether the tenant is currently running.
+	Running bool `json:"running"`
+	// Starting indicates whether the tenant is currently starting.
+	Starting bool `json:"starting"`
+	// Stopping indicates whether the tenant is currently stopping.
+	Stopping bool `json:"stopping"`
+	// Migrating indicates whether the tenant is currently migrating.
+	Migrating bool `json:"migrating"`
+	// Started is the timestamp when the tenant was started (Unix epoch).
+	Started int64 `json:"started,omitempty"`
+	// Stopped is the timestamp when the tenant was stopped (Unix epoch).
+	Stopped int64 `json:"stopped,omitempty"`
+	// Status is the tenant status string.
+	// Valid values: "online", "starting", "migrating", "errormigrating", "reduced",
+	// "error", "nodesoffline", "stopping", "offline", "provisioning", "restarting"
+	Status string `json:"status,omitempty"`
+	// State is the simplified state (online, offline, warning, error).
+	State string `json:"state,omitempty"`
+	// LastUpdate is the timestamp of the last status update (Unix epoch).
+	LastUpdate int64 `json:"last_update,omitempty"`
+}
+
+// tenantStatusListFields are the fields to request when listing tenant statuses.
+const tenantStatusListFields = "$key,tenant,running,starting,stopping,migrating,started,stopped,status,state,last_update"
+
+// tenantStatusGetFields are the fields to request when getting a single tenant status.
+const tenantStatusGetFields = tenantStatusListFields
+
+// TenantStatsHistoryShort contains short-term historical statistics for a tenant.
+// These are high-resolution time-series records that auto-expire based on system settings.
+type TenantStatsHistoryShort struct {
+	// Key is the unique identifier for this record.
+	Key FlexInt `json:"$key,omitempty"`
+	// Tenant is the parent tenant ID.
+	Tenant int `json:"tenant,omitempty"`
+	// Timestamp is the record timestamp (Unix epoch).
+	Timestamp uint32 `json:"timestamp,omitempty"`
+
+	// RAM metrics
+	// RAMUsed is the RAM currently used in MB.
+	RAMUsed uint32 `json:"ram_used,omitempty"`
+	// VRAMUsed is the virtual RAM currently used in MB.
+	VRAMUsed uint32 `json:"vram_used,omitempty"`
+	// RAMAllocated is the RAM allocated in MB.
+	RAMAllocated uint32 `json:"ram_allocated,omitempty"`
+	// RAMPct is the RAM usage percentage.
+	RAMPct uint32 `json:"ram_pct,omitempty"`
+
+	// CPU metrics
+	// TotalCPU is the total CPU usage.
+	TotalCPU uint32 `json:"total_cpu,omitempty"`
+	// CoreCount is the number of CPU cores.
+	CoreCount uint32 `json:"core_count,omitempty"`
+
+	// Network metrics
+	// IPCount is the number of IP addresses.
+	IPCount uint32 `json:"ip_count,omitempty"`
+
+	// Storage tier 0 metrics
+	// Tier0Provisioned is the provisioned storage for tier 0 in bytes.
+	Tier0Provisioned uint64 `json:"tier0_provisioned,omitempty"`
+	// Tier0Used is the used storage for tier 0 in bytes.
+	Tier0Used uint64 `json:"tier0_used,omitempty"`
+	// Tier0Pct is the tier 0 usage percentage.
+	Tier0Pct uint32 `json:"tier0_pct,omitempty"`
+	// Tier0Allocated is the allocated storage for tier 0 in bytes.
+	Tier0Allocated uint64 `json:"tier0_allocated,omitempty"`
+
+	// Storage tier 1 metrics
+	// Tier1Provisioned is the provisioned storage for tier 1 in bytes.
+	Tier1Provisioned uint64 `json:"tier1_provisioned,omitempty"`
+	// Tier1Used is the used storage for tier 1 in bytes.
+	Tier1Used uint64 `json:"tier1_used,omitempty"`
+	// Tier1Pct is the tier 1 usage percentage.
+	Tier1Pct uint32 `json:"tier1_pct,omitempty"`
+	// Tier1Allocated is the allocated storage for tier 1 in bytes.
+	Tier1Allocated uint64 `json:"tier1_allocated,omitempty"`
+
+	// Storage tier 2 metrics
+	// Tier2Provisioned is the provisioned storage for tier 2 in bytes.
+	Tier2Provisioned uint64 `json:"tier2_provisioned,omitempty"`
+	// Tier2Used is the used storage for tier 2 in bytes.
+	Tier2Used uint64 `json:"tier2_used,omitempty"`
+	// Tier2Pct is the tier 2 usage percentage.
+	Tier2Pct uint32 `json:"tier2_pct,omitempty"`
+	// Tier2Allocated is the allocated storage for tier 2 in bytes.
+	Tier2Allocated uint64 `json:"tier2_allocated,omitempty"`
+
+	// Storage tier 3 metrics
+	// Tier3Provisioned is the provisioned storage for tier 3 in bytes.
+	Tier3Provisioned uint64 `json:"tier3_provisioned,omitempty"`
+	// Tier3Used is the used storage for tier 3 in bytes.
+	Tier3Used uint64 `json:"tier3_used,omitempty"`
+	// Tier3Pct is the tier 3 usage percentage.
+	Tier3Pct uint32 `json:"tier3_pct,omitempty"`
+	// Tier3Allocated is the allocated storage for tier 3 in bytes.
+	Tier3Allocated uint64 `json:"tier3_allocated,omitempty"`
+
+	// Storage tier 4 metrics
+	// Tier4Provisioned is the provisioned storage for tier 4 in bytes.
+	Tier4Provisioned uint64 `json:"tier4_provisioned,omitempty"`
+	// Tier4Used is the used storage for tier 4 in bytes.
+	Tier4Used uint64 `json:"tier4_used,omitempty"`
+	// Tier4Pct is the tier 4 usage percentage.
+	Tier4Pct uint32 `json:"tier4_pct,omitempty"`
+	// Tier4Allocated is the allocated storage for tier 4 in bytes.
+	Tier4Allocated uint64 `json:"tier4_allocated,omitempty"`
+
+	// Storage tier 5 metrics
+	// Tier5Provisioned is the provisioned storage for tier 5 in bytes.
+	Tier5Provisioned uint64 `json:"tier5_provisioned,omitempty"`
+	// Tier5Used is the used storage for tier 5 in bytes.
+	Tier5Used uint64 `json:"tier5_used,omitempty"`
+	// Tier5Pct is the tier 5 usage percentage.
+	Tier5Pct uint32 `json:"tier5_pct,omitempty"`
+	// Tier5Allocated is the allocated storage for tier 5 in bytes.
+	Tier5Allocated uint64 `json:"tier5_allocated,omitempty"`
+
+	// GPU metrics
+	// VGPUsUsed is the number of vGPUs in use.
+	VGPUsUsed uint16 `json:"vgpus_used,omitempty"`
+	// GPUsUsed is the number of physical GPUs in use.
+	GPUsUsed uint16 `json:"gpus_used,omitempty"`
+	// VGPUsTotal is the total number of vGPUs available.
+	VGPUsTotal uint16 `json:"vgpus_total,omitempty"`
+	// GPUsTotal is the total number of physical GPUs available.
+	GPUsTotal uint16 `json:"gpus_total,omitempty"`
+	// VGPUsPct is the vGPU usage percentage.
+	VGPUsPct uint16 `json:"vgpus_pct,omitempty"`
+	// GPUsPct is the GPU usage percentage.
+	GPUsPct uint16 `json:"gpus_pct,omitempty"`
+}
+
+// tenantStatsHistoryShortFields lists all fields for tenant stats history short queries.
+const tenantStatsHistoryShortFields = "$key,tenant,timestamp,ram_used,vram_used,total_cpu,core_count,ip_count,ram_allocated,ram_pct,tier0_provisioned,tier0_used,tier0_pct,tier0_allocated,tier1_provisioned,tier1_used,tier1_pct,tier1_allocated,tier2_provisioned,tier2_used,tier2_pct,tier2_allocated,tier3_provisioned,tier3_used,tier3_pct,tier3_allocated,tier4_provisioned,tier4_used,tier4_pct,tier4_allocated,tier5_provisioned,tier5_used,tier5_pct,tier5_allocated,vgpus_used,gpus_used,vgpus_total,gpus_total,vgpus_pct,gpus_pct"


### PR DESCRIPTION
## Summary
- Add `TenantStatusService` with `List`, `Get` (by tenant FK), and `GetByKey` methods for `/tenant_status` endpoint
- Add `TenantStatsHistoryShortService` with `List`, `ListByTenant`, `GetLatest`, and `Get` methods for `/tenant_stats_history_short` endpoint
- Add integration tests covering all new methods, verified against live system

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — unit tests pass
- [x] Integration tests pass against live VergeOS (midgard)