### PR TITLE
Fix all confirmed issues from codebase audit

### DIFF
--- a/alarm.go
+++ b/alarm.go
@@ -69,7 +69,7 @@ func (s *AlarmService) Get(ctx context.Context, id int) (*Alarm, error) {
 	endpoint := fmt.Sprintf("/alarms/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &alarm); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Alarm", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Alarm", ID: id}
 		}
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (s *AlarmService) Update(ctx context.Context, id int, req *AlarmUpdateReque
 	endpoint := fmt.Sprintf("/alarms/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Alarm", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Alarm", ID: id}
 		}
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (s *AlarmService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/alarms/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "Alarm", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "Alarm", ID: id}
 		}
 		return err
 	}

--- a/alarm.go
+++ b/alarm.go
@@ -41,21 +41,21 @@ func (s *AlarmService) ListActive(ctx context.Context, opts ...ListOption) ([]Al
 // ListByOwner returns all alarms for a specific owner resource.
 // owner should be a resource path like "vms/123" or "nodes/1".
 func (s *AlarmService) ListByOwner(ctx context.Context, owner string, opts ...ListOption) ([]Alarm, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("owner eq '%s'", owner))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("owner eq '%s'", escapeFilterValue(owner)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }
 
 // ListByLevel returns all alarms with a specific severity level.
 func (s *AlarmService) ListByLevel(ctx context.Context, level string, opts ...ListOption) ([]Alarm, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("level eq '%s'", level))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("level eq '%s'", escapeFilterValue(level)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }
 
 // ListByAlarmType returns all alarms of a specific alarm type.
 func (s *AlarmService) ListByAlarmType(ctx context.Context, alarmTypeKey string, opts ...ListOption) ([]Alarm, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("alarm_type eq '%s'", alarmTypeKey))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("alarm_type eq '%s'", escapeFilterValue(alarmTypeKey)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }
@@ -175,7 +175,7 @@ func (s *AlarmTypeService) Get(ctx context.Context, key string) (*AlarmType, err
 
 // ListByLevel returns all alarm types with a specific default severity level.
 func (s *AlarmTypeService) ListByLevel(ctx context.Context, level string, opts ...ListOption) ([]AlarmType, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("level eq '%s'", level))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("level eq '%s'", escapeFilterValue(level)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }

--- a/alarm.go
+++ b/alarm.go
@@ -111,7 +111,7 @@ func (s *AlarmService) Unsnooze(ctx context.Context, id int) error {
 // Resolve resolves an alarm if it is resolvable.
 func (s *AlarmService) Resolve(ctx context.Context, id int) error {
 	endpoint := "/alarm_actions"
-	body := map[string]interface{}{
+	body := map[string]any{
 		"alarm":  id,
 		"action": "resolve",
 	}

--- a/alarm_test.go
+++ b/alarm_test.go
@@ -205,7 +205,7 @@ func TestAlarmService_Unsnooze(t *testing.T) {
 func TestAlarmService_Resolve(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/alarm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "resolve" {
 				t.Errorf("expected action 'resolve', got %v", body["action"])

--- a/api_key.go
+++ b/api_key.go
@@ -92,7 +92,7 @@ func (s *UserAPIKeyService) Create(ctx context.Context, req *UserAPIKeyCreateReq
 
 	// Extract token from response if available
 	var token string
-	if respMap, ok := resp.Response.(map[string]interface{}); ok {
+	if respMap, ok := resp.Response.(map[string]any); ok {
 		if t, ok := respMap["token"].(string); ok {
 			token = t
 		}

--- a/api_key.go
+++ b/api_key.go
@@ -45,7 +45,7 @@ func (s *UserAPIKeyService) Get(ctx context.Context, id int) (*UserAPIKey, error
 	endpoint := fmt.Sprintf("/user_api_keys/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &key); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "UserAPIKey", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "UserAPIKey", ID: id}
 		}
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (s *UserAPIKeyService) Update(ctx context.Context, id int, req *UserAPIKeyU
 	endpoint := fmt.Sprintf("/user_api_keys/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "UserAPIKey", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "UserAPIKey", ID: id}
 		}
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (s *UserAPIKeyService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/user_api_keys/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "UserAPIKey", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "UserAPIKey", ID: id}
 		}
 		return err
 	}

--- a/api_key.go
+++ b/api_key.go
@@ -56,8 +56,7 @@ func (s *UserAPIKeyService) Get(ctx context.Context, id int) (*UserAPIKey, error
 // GetByName returns an API key by name within a user's keys.
 func (s *UserAPIKeyService) GetByName(ctx context.Context, userID int, name string) (*UserAPIKey, error) {
 	keys, err := s.List(ctx,
-		WithFilter(fmt.Sprintf("user eq %d", userID)),
-		WithFilter(fmt.Sprintf("name eq '%s'", name)),
+		WithFilter(fmt.Sprintf("user eq %d and name eq '%s'", userID, name)),
 	)
 	if err != nil {
 		return nil, err

--- a/api_key.go
+++ b/api_key.go
@@ -56,7 +56,7 @@ func (s *UserAPIKeyService) Get(ctx context.Context, id int) (*UserAPIKey, error
 // GetByName returns an API key by name within a user's keys.
 func (s *UserAPIKeyService) GetByName(ctx context.Context, userID int, name string) (*UserAPIKey, error) {
 	keys, err := s.List(ctx,
-		WithFilter(fmt.Sprintf("user eq %d and name eq '%s'", userID, name)),
+		WithFilter(fmt.Sprintf("user eq %d and name eq '%s'", userID, escapeFilterValue(name))),
 	)
 	if err != nil {
 		return nil, err

--- a/api_key_test.go
+++ b/api_key_test.go
@@ -134,7 +134,7 @@ func TestUserAPIKeyService_Create(t *testing.T) {
 			}
 			jsonResponse(w, 200, apiResponse{
 				Key:      float64(5),
-				Response: map[string]interface{}{"token": "secret-token-123"},
+				Response: map[string]any{"token": "secret-token-123"},
 			})
 		},
 		"GET /api/v4/user_api_keys/5": func(w http.ResponseWriter, r *http.Request) {

--- a/certificate.go
+++ b/certificate.go
@@ -39,7 +39,7 @@ func (s *CertificateService) Get(ctx context.Context, id int) (*Certificate, err
 	endpoint := fmt.Sprintf("/certificates/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &cert); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Certificate", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Certificate", ID: id}
 		}
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (s *CertificateService) GetWithKeys(ctx context.Context, id int) (*Certific
 	endpoint := fmt.Sprintf("/certificates/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &cert); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Certificate", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Certificate", ID: id}
 		}
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (s *CertificateService) Update(ctx context.Context, id int, req *Certificat
 	endpoint := fmt.Sprintf("/certificates/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Certificate", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Certificate", ID: id}
 		}
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (s *CertificateService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/certificates/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "Certificate", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "Certificate", ID: id}
 		}
 		return err
 	}

--- a/certificate.go
+++ b/certificate.go
@@ -48,7 +48,7 @@ func (s *CertificateService) Get(ctx context.Context, id int) (*Certificate, err
 
 // GetByDomain returns a certificate by its primary domain.
 func (s *CertificateService) GetByDomain(ctx context.Context, domain string) (*Certificate, error) {
-	certs, err := s.List(ctx, WithFilter(fmt.Sprintf("domain eq '%s'", domain)))
+	certs, err := s.List(ctx, WithFilter(fmt.Sprintf("domain eq '%s'", escapeFilterValue(domain))))
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func (s *CertificateService) ListValid(ctx context.Context, opts ...ListOption) 
 
 // ListByType returns certificates of a specific type (manual, letsencrypt, self_signed).
 func (s *CertificateService) ListByType(ctx context.Context, certType string, opts ...ListOption) ([]Certificate, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("type eq '%s'", certType))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("type eq '%s'", escapeFilterValue(certType)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }

--- a/certificate.go
+++ b/certificate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"time"
 )
 
 // CertificateService handles SSL/TLS certificate operations.
@@ -132,9 +133,8 @@ func (s *CertificateService) Renew(ctx context.Context, id int) (*Certificate, e
 
 // ListExpiring returns certificates that will expire within the specified number of days.
 func (s *CertificateService) ListExpiring(ctx context.Context, days int, opts ...ListOption) ([]Certificate, error) {
-	// Calculate Unix timestamp for 'days' from now
-	// This is a simple filter approach - exact implementation depends on API support
-	filterOpts := []ListOption{WithFilter("valid eq true")}
+	expiresBy := time.Now().Add(time.Duration(days) * 24 * time.Hour).Unix()
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("valid eq true and expires le %d", expiresBy))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }

--- a/certificate_test.go
+++ b/certificate_test.go
@@ -156,7 +156,7 @@ func TestCertificateService_Create(t *testing.T) {
 			if req.DomainName != "example.com" {
 				t.Errorf("expected domain 'example.com', got %q", req.DomainName)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/certificates/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, Certificate{Key: 1, Domain: "example.com", Type: "self_signed"})

--- a/client.go
+++ b/client.go
@@ -402,13 +402,13 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 
 // apiResponse represents the standard VergeOS API response structure.
 type apiResponse struct {
-	Key      interface{} `json:"$key,omitempty"`
-	Response interface{} `json:"response,omitempty"`
+	Key      any `json:"$key,omitempty"`
+	Response any `json:"response,omitempty"`
 	Err      string      `json:"err,omitempty"`
 }
 
 // request performs an HTTP request to the VergeOS API.
-func (c *Client) request(ctx context.Context, method, endpoint string, body interface{}, params url.Values) (*http.Response, error) {
+func (c *Client) request(ctx context.Context, method, endpoint string, body any, params url.Values) (*http.Response, error) {
 	// Build URL
 	u := fmt.Sprintf("%s%s%s", c.baseURL, apiBasePath, endpoint)
 	if len(params) > 0 {
@@ -452,7 +452,7 @@ func (c *Client) request(ctx context.Context, method, endpoint string, body inte
 }
 
 // do performs an HTTP request and decodes the response.
-func (c *Client) do(ctx context.Context, method, endpoint string, body interface{}, params url.Values, result interface{}) error {
+func (c *Client) do(ctx context.Context, method, endpoint string, body any, params url.Values, result any) error {
 	resp, err := c.request(ctx, method, endpoint, body, params)
 	if err != nil {
 		return err
@@ -503,17 +503,17 @@ func (c *Client) do(ctx context.Context, method, endpoint string, body interface
 }
 
 // get performs a GET request.
-func (c *Client) get(ctx context.Context, endpoint string, params url.Values, result interface{}) error {
+func (c *Client) get(ctx context.Context, endpoint string, params url.Values, result any) error {
 	return c.do(ctx, http.MethodGet, endpoint, nil, params, result)
 }
 
 // post performs a POST request and returns the created resource's key.
-func (c *Client) post(ctx context.Context, endpoint string, body interface{}, result interface{}) error {
+func (c *Client) post(ctx context.Context, endpoint string, body any, result any) error {
 	return c.do(ctx, http.MethodPost, endpoint, body, nil, result)
 }
 
 // put performs a PUT request.
-func (c *Client) put(ctx context.Context, endpoint string, body interface{}, result interface{}) error {
+func (c *Client) put(ctx context.Context, endpoint string, body any, result any) error {
 	return c.do(ctx, http.MethodPut, endpoint, body, nil, result)
 }
 
@@ -524,7 +524,7 @@ func (c *Client) delete(ctx context.Context, endpoint string) error {
 
 // getAbsolute performs a GET request to an absolute path (not under /api/v4/).
 // This is used for endpoints like /version.json that are outside the API path.
-func (c *Client) getAbsolute(ctx context.Context, path string, params url.Values, result interface{}) error {
+func (c *Client) getAbsolute(ctx context.Context, path string, params url.Values, result any) error {
 	// Build URL with absolute path
 	u := c.baseURL + path
 	if len(params) > 0 {

--- a/client.go
+++ b/client.go
@@ -22,6 +22,8 @@ const (
 	apiBasePath = "/api/v4"
 	// defaultUserAgent is the default User-Agent header.
 	defaultUserAgent = "govergeos/1.0"
+	// maxResponseSize is the maximum response body size (100 MB).
+	maxResponseSize = 100 << 20
 )
 
 // Client is the VergeOS API client.
@@ -457,8 +459,8 @@ func (c *Client) do(ctx context.Context, method, endpoint string, body interface
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	// Read response body
-	respBody, err := io.ReadAll(resp.Body)
+	// Read response body (bounded to prevent OOM from misbehaving servers)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
 	if err != nil {
 		return fmt.Errorf("vergeos: failed to read response body: %w", err)
 	}
@@ -553,7 +555,7 @@ func (c *Client) getAbsolute(ctx context.Context, path string, params url.Values
 
 	// Check for HTTP errors
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
 		if resp.StatusCode == 401 || resp.StatusCode == 403 {
 			return &AuthError{Message: string(body)}
 		}

--- a/client.go
+++ b/client.go
@@ -152,18 +152,27 @@ func WithAPIKey(apiKey string) ClientOption {
 	}
 }
 
+// cloneOrNewTransport returns a clone of the existing transport if it is an
+// *http.Transport, or a fresh transport with sensible defaults otherwise.
+func cloneOrNewTransport(rt http.RoundTripper) *http.Transport {
+	if t, ok := rt.(*http.Transport); ok {
+		return t.Clone()
+	}
+	return &http.Transport{
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 20,
+		IdleConnTimeout:     90 * time.Second,
+	}
+}
+
 // WithInsecureTLS configures whether to skip TLS certificate verification.
 // This is useful for self-signed certificates.
 func WithInsecureTLS(insecure bool) ClientOption {
 	return func(c *Client) error {
 		if insecure {
-			transport := &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
-				MaxIdleConns:        100,
-				MaxIdleConnsPerHost: 20,
-				IdleConnTimeout:     90 * time.Second,
+			transport := cloneOrNewTransport(c.httpClient.Transport)
+			transport.TLSClientConfig = &tls.Config{
+				InsecureSkipVerify: true,
 			}
 			c.httpClient.Transport = transport
 		}
@@ -249,13 +258,9 @@ func WithEnvConfig() ClientOption {
 		// Only apply if VERGEOS_VERIFY_SSL is explicitly set to false
 		verifySSL := os.Getenv("VERGEOS_VERIFY_SSL")
 		if strings.ToLower(verifySSL) == "false" || verifySSL == "0" {
-			transport := &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
-				MaxIdleConns:        100,
-				MaxIdleConnsPerHost: 20,
-				IdleConnTimeout:     90 * time.Second,
+			transport := cloneOrNewTransport(c.httpClient.Transport)
+			transport.TLSClientConfig = &tls.Config{
+				InsecureSkipVerify: true,
 			}
 			c.httpClient.Transport = transport
 		}

--- a/client.go
+++ b/client.go
@@ -459,7 +459,7 @@ func (c *Client) do(ctx context.Context, method, endpoint string, body interface
 	}
 
 	// Check for HTTP errors
-	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// Try to parse error message from response
 		var apiResp apiResponse
 		errMsg := string(respBody)
@@ -547,7 +547,7 @@ func (c *Client) getAbsolute(ctx context.Context, path string, params url.Values
 	defer func() { _ = resp.Body.Close() }()
 
 	// Check for HTTP errors
-	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
 		if resp.StatusCode == 401 || resp.StatusCode == 403 {
 			return &AuthError{Message: string(body)}

--- a/cloud_snapshot.go
+++ b/cloud_snapshot.go
@@ -87,7 +87,7 @@ func (s *CloudSnapshotService) Create(ctx context.Context, req *CloudSnapshotCre
 	}
 
 	// Cloud snapshots use table_actions/create endpoint
-	tableAction := map[string]interface{}{
+	tableAction := map[string]any{
 		"name": req.Name,
 	}
 	if req.Description != "" {
@@ -173,7 +173,7 @@ func (s *CloudSnapshotService) Clone(ctx context.Context, id int, opts *CloudSna
 	action := cloudSnapshotAction{
 		CloudSnapshot: id,
 		Action:        "clone",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"name": opts.Name,
 		},
 	}

--- a/cloud_snapshot.go
+++ b/cloud_snapshot.go
@@ -66,7 +66,7 @@ func (s *CloudSnapshotService) Get(ctx context.Context, id int) (*CloudSnapshot,
 
 // GetByName returns a cloud snapshot by name.
 func (s *CloudSnapshotService) GetByName(ctx context.Context, name string) (*CloudSnapshot, error) {
-	snapshots, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	snapshots, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/cloud_snapshot.go
+++ b/cloud_snapshot.go
@@ -56,7 +56,7 @@ func (s *CloudSnapshotService) Get(ctx context.Context, id int) (*CloudSnapshot,
 	endpoint := fmt.Sprintf("/cloud_snapshots/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &snapshot); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "CloudSnapshot", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "CloudSnapshot", ID: id}
 		}
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (s *CloudSnapshotService) Update(ctx context.Context, id int, req *CloudSna
 	endpoint := fmt.Sprintf("/cloud_snapshots/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "CloudSnapshot", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "CloudSnapshot", ID: id}
 		}
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (s *CloudSnapshotService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/cloud_snapshots/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "CloudSnapshot", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "CloudSnapshot", ID: id}
 		}
 		return err
 	}
@@ -261,7 +261,7 @@ func (s *CloudSnapshotVMService) Get(ctx context.Context, id int) (*CloudSnapsho
 	endpoint := fmt.Sprintf("/cloud_snapshot_vms/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &vm); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "CloudSnapshotVM", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "CloudSnapshotVM", ID: id}
 		}
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func (s *CloudSnapshotTenantService) Get(ctx context.Context, id int) (*CloudSna
 	endpoint := fmt.Sprintf("/cloud_snapshot_tenants/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &tenant); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "CloudSnapshotTenant", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "CloudSnapshotTenant", ID: id}
 		}
 		return nil, err
 	}

--- a/cloud_snapshot_test.go
+++ b/cloud_snapshot_test.go
@@ -163,12 +163,12 @@ func TestCloudSnapshotService_GetByName_NotFound(t *testing.T) {
 func TestCloudSnapshotService_Create(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/cloud_snapshots": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["name"] != "manual-snap" {
 				t.Errorf("expected name 'manual-snap', got %v", body["name"])
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/cloud_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, CloudSnapshot{Key: 1, Name: "manual-snap", Status: "normal"})
@@ -296,7 +296,7 @@ func TestCloudSnapshotService_Delete_NotFound(t *testing.T) {
 func TestCloudSnapshotService_Refresh(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/cloud_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "refresh" {
 				t.Errorf("expected action 'refresh', got %v", body["action"])
@@ -314,12 +314,12 @@ func TestCloudSnapshotService_Refresh(t *testing.T) {
 func TestCloudSnapshotService_Clone(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/cloud_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "clone" {
 				t.Errorf("expected action 'clone', got %v", body["action"])
 			}
-			params, ok := body["params"].(map[string]interface{})
+			params, ok := body["params"].(map[string]any)
 			if !ok {
 				t.Fatal("expected params in body")
 			}
@@ -363,7 +363,7 @@ func TestCloudSnapshotService_Clone_MissingName(t *testing.T) {
 func TestCloudSnapshotService_RequestFromProvider(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/cloud_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "request" {
 				t.Errorf("expected action 'request', got %v", body["action"])
@@ -381,7 +381,7 @@ func TestCloudSnapshotService_RequestFromProvider(t *testing.T) {
 func TestCloudSnapshotService_FindTenants(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/cloud_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "find_tenants" {
 				t.Errorf("expected action 'find_tenants', got %v", body["action"])
@@ -399,7 +399,7 @@ func TestCloudSnapshotService_FindTenants(t *testing.T) {
 func TestCloudSnapshotService_FindVMs(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/cloud_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "find_vms" {
 				t.Errorf("expected action 'find_vms', got %v", body["action"])

--- a/cloudinit.go
+++ b/cloudinit.go
@@ -108,7 +108,7 @@ func (s *CloudInitService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/cloudinit_files/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "CloudInit", ID: id}
 		}
 		return err
 	}

--- a/cloudinit.go
+++ b/cloudinit.go
@@ -49,7 +49,7 @@ func (s *CloudInitService) Get(ctx context.Context, id int) (*CloudInitFile, err
 
 // GetByName returns a cloud-init file by name.
 func (s *CloudInitService) GetByName(ctx context.Context, name string) (*CloudInitFile, error) {
-	files, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	files, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/cloudinit_test.go
+++ b/cloudinit_test.go
@@ -243,7 +243,10 @@ func TestCloudInitService_Delete_NotFound(t *testing.T) {
 
 	// Delete returns nil for not found (already deleted)
 	err := client.CloudInitFiles.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("Delete should not error for not found, got: %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted cloud-init")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }

--- a/cloudinit_test.go
+++ b/cloudinit_test.go
@@ -124,7 +124,7 @@ func TestCloudInitService_Create(t *testing.T) {
 			if req.Name != "user-data" {
 				t.Errorf("expected name 'user-data', got %q", req.Name)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/cloudinit_files/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, CloudInitFile{ID: 1, Name: "user-data", Contents: "#cloud-config"})

--- a/cluster.go
+++ b/cluster.go
@@ -133,7 +133,7 @@ func (s *ClusterService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/clusters/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "Cluster", ID: id}
 		}
 		return err
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -48,7 +48,7 @@ func (s *ClusterService) Get(ctx context.Context, id int) (*Cluster, error) {
 
 // GetByName returns a cluster by name.
 func (s *ClusterService) GetByName(ctx context.Context, name string) (*Cluster, error) {
-	clusters, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	clusters, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -271,7 +271,10 @@ func TestClusterService_Delete_NotFound(t *testing.T) {
 
 	// Cluster.Delete returns nil for 404 (already deleted)
 	err := client.Clusters.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("expected nil for not-found delete, got: %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted cluster")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -58,6 +58,27 @@ func (e *ValidationError) Error() string {
 	return fmt.Sprintf("vergeos: validation error: %s", e.Message)
 }
 
+// TimeoutError is returned when a polling operation exceeds its retry limit.
+type TimeoutError struct {
+	Resource string
+	ID       int
+	Action   string
+}
+
+// Error implements the error interface.
+func (e *TimeoutError) Error() string {
+	return fmt.Sprintf("vergeos: timeout waiting for %s %d to %s", e.Resource, e.ID, e.Action)
+}
+
+// IsTimeoutError returns true if the error is a TimeoutError.
+func IsTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var timeoutErr *TimeoutError
+	return errors.As(err, &timeoutErr)
+}
+
 // IsNotFoundError returns true if the error is a NotFoundError or a 404 API error.
 func IsNotFoundError(err error) bool {
 	if err == nil {

--- a/errors.go
+++ b/errors.go
@@ -23,7 +23,7 @@ func (e *APIError) Error() string {
 // NotFoundError is returned when a resource is not found.
 type NotFoundError struct {
 	Resource string
-	ID       interface{}
+	ID       any
 }
 
 // Error implements the error interface.

--- a/file.go
+++ b/file.go
@@ -56,7 +56,7 @@ func (s *FileService) Get(ctx context.Context, id int) (*File, error) {
 
 // GetByName returns a file by name.
 func (s *FileService) GetByName(ctx context.Context, name string) (*File, error) {
-	files, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	files, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/file.go
+++ b/file.go
@@ -1,6 +1,7 @@
 package vergeos
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -294,7 +295,7 @@ func (s *FileService) uploadChunk(ctx context.Context, id int, data []byte, offs
 	req.Close = true
 
 	// Set body
-	req.Body = io.NopCloser(newBytesReader(data))
+	req.Body = io.NopCloser(bytes.NewReader(data))
 	req.ContentLength = int64(len(data))
 
 	// Execute request
@@ -315,23 +316,4 @@ func (s *FileService) uploadChunk(ctx context.Context, id int, data []byte, offs
 	}
 
 	return nil
-}
-
-// bytesReader wraps a byte slice to implement io.Reader.
-type bytesReader struct {
-	data   []byte
-	offset int
-}
-
-func newBytesReader(data []byte) *bytesReader {
-	return &bytesReader{data: data}
-}
-
-func (r *bytesReader) Read(p []byte) (n int, err error) {
-	if r.offset >= len(r.data) {
-		return 0, io.EOF
-	}
-	n = copy(p, r.data[r.offset:])
-	r.offset += n
-	return n, nil
 }

--- a/file.go
+++ b/file.go
@@ -106,7 +106,13 @@ func (s *FileService) Update(ctx context.Context, id int, req *FileUpdateRequest
 // Files that are referenced by VM drives cannot be deleted until the reference is removed.
 func (s *FileService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/files/%d", id)
-	return s.client.delete(ctx, endpoint)
+	if err := s.client.delete(ctx, endpoint); err != nil {
+		if IsNotFoundError(err) {
+			return &NotFoundError{Resource: "File", ID: id}
+		}
+		return err
+	}
+	return nil
 }
 
 // Download downloads a file from VergeOS and returns an io.ReadCloser.

--- a/group.go
+++ b/group.go
@@ -62,6 +62,9 @@ func (s *GroupService) GetByName(ctx context.Context, name string) (*Group, erro
 
 // Create creates a new group and returns it.
 func (s *GroupService) Create(ctx context.Context, req *GroupCreateRequest) (*Group, error) {
+	if req == nil {
+		return nil, &ValidationError{Message: "create request is required"}
+	}
 	var result struct {
 		Key FlexInt `json:"$key"`
 	}

--- a/group.go
+++ b/group.go
@@ -88,5 +88,11 @@ func (s *GroupService) Update(ctx context.Context, id int, req *GroupUpdateReque
 // Delete deletes a group by ID.
 func (s *GroupService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/groups/%d", id)
-	return s.client.delete(ctx, endpoint)
+	if err := s.client.delete(ctx, endpoint); err != nil {
+		if IsNotFoundError(err) {
+			return &NotFoundError{Resource: "Group", ID: id}
+		}
+		return err
+	}
+	return nil
 }

--- a/group.go
+++ b/group.go
@@ -48,7 +48,7 @@ func (s *GroupService) Get(ctx context.Context, id int) (*Group, error) {
 
 // GetByName returns a group by name.
 func (s *GroupService) GetByName(ctx context.Context, name string) (*Group, error) {
-	groups, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	groups, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/interfaces.go
+++ b/interfaces.go
@@ -54,7 +54,7 @@ type VMNICServiceInterface interface {
 
 // VMDriveServiceInterface defines the interface for VM Drive operations.
 type VMDriveServiceInterface interface {
-	List(ctx context.Context, vmID int) ([]VMDrive, error)
+	List(ctx context.Context, machineID int) ([]VMDrive, error)
 	ListAll(ctx context.Context, opts ...ListOption) ([]VMDrive, error)
 	Get(ctx context.Context, driveID int) (*VMDrive, error)
 	Create(ctx context.Context, vmID int, req *VMDriveCreateRequest) (*VMDrive, error)
@@ -66,7 +66,7 @@ type VMDriveServiceInterface interface {
 
 // VMDeviceServiceInterface defines the interface for VM Device operations.
 type VMDeviceServiceInterface interface {
-	List(ctx context.Context, vmID int) ([]VMDevice, error)
+	List(ctx context.Context, machineID int) ([]VMDevice, error)
 	Get(ctx context.Context, deviceID int) (*VMDevice, error)
 	Create(ctx context.Context, vmID int, req *VMDeviceCreateRequest) (*VMDevice, error)
 	Update(ctx context.Context, deviceID int, req *VMDeviceUpdateRequest) (*VMDevice, error)

--- a/interfaces.go
+++ b/interfaces.go
@@ -995,4 +995,6 @@ var (
 	_ UpdateSettingsServiceInterface          = (*UpdateSettingsService)(nil)
 	_ UpdateBranchServiceInterface            = (*UpdateBranchService)(nil)
 	_ UpdateSourcePackageServiceInterface     = (*UpdateSourcePackageService)(nil)
+	_ TenantStatusServiceInterface            = (*TenantStatusService)(nil)
+	_ TenantStatsHistoryShortServiceInterface = (*TenantStatsHistoryShortService)(nil)
 )

--- a/interfaces.go
+++ b/interfaces.go
@@ -822,8 +822,8 @@ type TenantLayer2NetworkServiceInterface interface {
 	Create(ctx context.Context, req *TenantLayer2NetworkCreateRequest) (*TenantLayer2Network, error)
 	Update(ctx context.Context, id int, req *TenantLayer2NetworkUpdateRequest) (*TenantLayer2Network, error)
 	Delete(ctx context.Context, id int) error
-	Enable(ctx context.Context, id int) (*TenantLayer2Network, error)
-	Disable(ctx context.Context, id int) (*TenantLayer2Network, error)
+	Enable(ctx context.Context, id int) error
+	Disable(ctx context.Context, id int) error
 	Assign(ctx context.Context, tenantID, vnetID int) (*TenantLayer2Network, error)
 	Unassign(ctx context.Context, tenantID, vnetID int) error
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -55,6 +55,7 @@ type VMNICServiceInterface interface {
 // VMDriveServiceInterface defines the interface for VM Drive operations.
 type VMDriveServiceInterface interface {
 	List(ctx context.Context, vmID int) ([]VMDrive, error)
+	ListAll(ctx context.Context, opts ...ListOption) ([]VMDrive, error)
 	Get(ctx context.Context, driveID int) (*VMDrive, error)
 	Create(ctx context.Context, vmID int, req *VMDriveCreateRequest) (*VMDrive, error)
 	Update(ctx context.Context, driveID int, req *VMDriveUpdateRequest) (*VMDrive, error)

--- a/log.go
+++ b/log.go
@@ -84,7 +84,7 @@ func (s *LogService) Get(ctx context.Context, id int) (*Log, error) {
 	endpoint := fmt.Sprintf("/logs/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &log); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Log", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Log", ID: id}
 		}
 		return nil, err
 	}

--- a/log.go
+++ b/log.go
@@ -37,13 +37,13 @@ func (s *LogService) List(ctx context.Context, opts ...ListOption) ([]Log, error
 
 // ListByLevel returns logs filtered by level.
 func (s *LogService) ListByLevel(ctx context.Context, level string, opts ...ListOption) ([]Log, error) {
-	opts = append(opts, WithFilter(fmt.Sprintf("level eq '%s'", level)))
+	opts = append(opts, WithFilter(fmt.Sprintf("level eq '%s'", escapeFilterValue(level))))
 	return s.List(ctx, opts...)
 }
 
 // ListByObjectType returns logs filtered by object type.
 func (s *LogService) ListByObjectType(ctx context.Context, objectType string, opts ...ListOption) ([]Log, error) {
-	opts = append(opts, WithFilter(fmt.Sprintf("object_type eq '%s'", objectType)))
+	opts = append(opts, WithFilter(fmt.Sprintf("object_type eq '%s'", escapeFilterValue(objectType))))
 	return s.List(ctx, opts...)
 }
 
@@ -65,7 +65,7 @@ func (s *LogService) ListWarnings(ctx context.Context, opts ...ListOption) ([]Lo
 
 // ListByUser returns logs filtered by username.
 func (s *LogService) ListByUser(ctx context.Context, username string, opts ...ListOption) ([]Log, error) {
-	opts = append(opts, WithFilter(fmt.Sprintf("user eq '%s'", username)))
+	opts = append(opts, WithFilter(fmt.Sprintf("user eq '%s'", escapeFilterValue(username))))
 	return s.List(ctx, opts...)
 }
 

--- a/machine_status_test.go
+++ b/machine_status_test.go
@@ -2,6 +2,7 @@ package vergeos
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 )
@@ -103,6 +104,47 @@ func TestMachineStatusService_GetByKey(t *testing.T) {
 	}
 	if status.NodeName != "node1" {
 		t.Errorf("expected node_name 'node1', got %q", status.NodeName)
+	}
+}
+
+func TestGuestInfo_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"empty array", `[]`, false},
+		{"empty array with spaces", `[ ]`, false},
+		{"valid object", `{"hostname":"test","last_refresh":1234}`, false},
+		{"empty object", `{}`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var g GuestInfo
+			err := json.Unmarshal([]byte(tt.input), &g)
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestGuestInfo_UnmarshalJSON_InMachineStatus(t *testing.T) {
+	// Simulate the full MachineStatus response where agent_guest_info is []
+	input := `{"$key":1,"machine":10,"running":true,"agent_guest_info":[]}`
+	var ms MachineStatus
+	if err := json.Unmarshal([]byte(input), &ms); err != nil {
+		t.Fatalf("unexpected error unmarshaling MachineStatus with empty guest info: %v", err)
+	}
+	if ms.AgentGuestInfo == nil {
+		t.Fatal("expected AgentGuestInfo to be non-nil (allocated but zero-value)")
+	}
+	if ms.AgentGuestInfo.Hostname != "" {
+		t.Errorf("expected empty hostname, got %q", ms.AgentGuestInfo.Hostname)
 	}
 }
 

--- a/member.go
+++ b/member.go
@@ -102,7 +102,7 @@ func (s *MemberService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/members/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "Member", ID: id}
 		}
 		return err
 	}

--- a/member.go
+++ b/member.go
@@ -121,7 +121,7 @@ func (s *MemberService) Add(ctx context.Context, groupID int, member string) (*M
 func (s *MemberService) Remove(ctx context.Context, groupID int, member string) error {
 	// Find the membership
 	members, err := s.List(ctx,
-		WithFilter(fmt.Sprintf("parent_group eq %d and member eq '%s'", groupID, member)),
+		WithFilter(fmt.Sprintf("parent_group eq %d and member eq '%s'", groupID, escapeFilterValue(member))),
 	)
 	if err != nil {
 		return err

--- a/member_test.go
+++ b/member_test.go
@@ -233,10 +233,13 @@ func TestMemberService_Delete_NotFound(t *testing.T) {
 		},
 	}))
 
-	// Delete of already-deleted resource returns nil
+	// Delete of non-existent resource returns NotFoundError
 	err := client.Members.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("expected nil for already-deleted member, got %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted member")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }
 

--- a/nas_service.go
+++ b/nas_service.go
@@ -63,7 +63,7 @@ func (s *NASServiceService) GetByVM(ctx context.Context, vmID int) (*NASService,
 
 // GetByName returns a NAS service by name.
 func (s *NASServiceService) GetByName(ctx context.Context, name string) (*NASService, error) {
-	services, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	services, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (s *NASServiceUserService) Get(ctx context.Context, id string) (*NASService
 
 // GetByName returns a NAS service user by name within a specific service.
 func (s *NASServiceUserService) GetByName(ctx context.Context, serviceID int, name string) (*NASServiceUser, error) {
-	users, err := s.List(ctx, WithFilter(fmt.Sprintf("service eq %d and name eq '%s'", serviceID, name)))
+	users, err := s.List(ctx, WithFilter(fmt.Sprintf("service eq %d and name eq '%s'", serviceID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/network.go
+++ b/network.go
@@ -202,7 +202,7 @@ func (s *NetworkService) waitForPowerState(ctx context.Context, id int, desiredS
 		}
 	}
 
-	return fmt.Errorf("vergeos: timeout waiting for network %d to become %s", id, stateDesc)
+	return &TimeoutError{Resource: "Network", ID: id, Action: "become " + stateDesc}
 }
 
 // Kill forcefully powers off a network (hard power off).

--- a/network.go
+++ b/network.go
@@ -186,12 +186,6 @@ func (s *NetworkService) waitForPowerState(ctx context.Context, id int, desiredS
 	}
 
 	for i := 0; i < networkPowerStateMaxRetries; i++ {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(networkPowerStatePollInterval):
-		}
-
 		network, err := s.Get(ctx, id)
 		if err != nil {
 			return err
@@ -199,6 +193,12 @@ func (s *NetworkService) waitForPowerState(ctx context.Context, id int, desiredS
 
 		if network.PowerState == desiredState {
 			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(networkPowerStatePollInterval):
 		}
 	}
 

--- a/network.go
+++ b/network.go
@@ -345,7 +345,7 @@ func (s *NetworkService) Ping(ctx context.Context, networkID int, target string,
 	if count <= 0 {
 		count = 4
 	}
-	params := map[string]interface{}{
+	params := map[string]any{
 		"address": target,
 		"count":   count,
 	}
@@ -358,7 +358,7 @@ func (s *NetworkService) Ping(ctx context.Context, networkID int, target string,
 
 // Traceroute runs a traceroute diagnostic on a network.
 func (s *NetworkService) Traceroute(ctx context.Context, networkID int, target string) (*NetworkQuery, error) {
-	params := map[string]interface{}{
+	params := map[string]any{
 		"address": target,
 	}
 	return s.RunQueryWait(ctx, &NetworkQueryRequest{
@@ -370,7 +370,7 @@ func (s *NetworkService) Traceroute(ctx context.Context, networkID int, target s
 
 // DNSLookup runs a DNS lookup diagnostic on a network.
 func (s *NetworkService) DNSLookup(ctx context.Context, networkID int, hostname string) (*NetworkQuery, error) {
-	params := map[string]interface{}{
+	params := map[string]any{
 		"hostname": hostname,
 	}
 	return s.RunQueryWait(ctx, &NetworkQueryRequest{

--- a/network.go
+++ b/network.go
@@ -115,7 +115,7 @@ func (s *NetworkService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnets/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "Network", ID: id}
 		}
 		return err
 	}

--- a/network_test.go
+++ b/network_test.go
@@ -288,12 +288,12 @@ func TestNetworkService_Kill(t *testing.T) {
 func TestNetworkService_Reset(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vnet_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "reset" {
 				t.Errorf("expected action 'reset', got %v", body["action"])
 			}
-			params, ok := body["params"].(map[string]interface{})
+			params, ok := body["params"].(map[string]any)
 			if !ok {
 				t.Fatal("expected params to be a map")
 			}
@@ -313,9 +313,9 @@ func TestNetworkService_Reset(t *testing.T) {
 func TestNetworkService_Reset_NoApply(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vnet_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
-			params, _ := body["params"].(map[string]interface{})
+			params, _ := body["params"].(map[string]any)
 			if params["apply"] != false {
 				t.Errorf("expected apply=false, got %v", params["apply"])
 			}

--- a/network_test.go
+++ b/network_test.go
@@ -252,8 +252,11 @@ func TestNetworkService_Delete_NotFound(t *testing.T) {
 
 	// Delete returns nil for not-found (idempotent)
 	err := client.Networks.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("Delete should succeed for not-found, got: %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted network")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }
 

--- a/node.go
+++ b/node.go
@@ -18,7 +18,7 @@ const (
 type nodeAction struct {
 	Node   int         `json:"node"`
 	Action string      `json:"action"`
-	Params interface{} `json:"params"`
+	Params any `json:"params"`
 }
 
 // NodeService handles node read operations.

--- a/node.go
+++ b/node.go
@@ -70,7 +70,7 @@ func (s *NodeService) Get(ctx context.Context, id int) (*Node, error) {
 
 // GetByName returns a node by name.
 func (s *NodeService) GetByName(ctx context.Context, name string) (*Node, error) {
-	nodes, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	nodes, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package vergeos
 import (
 	"fmt"
 	"net/url"
+	"strings"
 )
 
 // ListOptions contains options for list operations.
@@ -107,4 +108,11 @@ func (opts *ListOptions) toQueryParams() url.Values {
 	}
 
 	return params
+}
+
+// escapeFilterValue escapes single quotes in a string value for use in
+// VergeOS API filter expressions. A value containing an unescaped single
+// quote would break the filter syntax.
+func escapeFilterValue(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
 }

--- a/options.go
+++ b/options.go
@@ -30,7 +30,11 @@ type ListOption func(*ListOptions)
 //   - "name eq 'vm1' and enabled eq true"
 func WithFilter(filter string) ListOption {
 	return func(opts *ListOptions) {
-		opts.Filter = filter
+		if opts.Filter != "" {
+			opts.Filter = opts.Filter + " and " + filter
+		} else {
+			opts.Filter = filter
+		}
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -48,13 +48,25 @@ func TestApplyListOptions_AllOptions(t *testing.T) {
 	}
 }
 
-func TestApplyListOptions_LastOneWins(t *testing.T) {
+func TestApplyListOptions_FilterCombination(t *testing.T) {
 	opts := applyListOptions([]ListOption{
 		WithFilter("first"),
 		WithFilter("second"),
 	})
-	if opts.Filter != "second" {
-		t.Errorf("expected last filter to win, got %q", opts.Filter)
+	if opts.Filter != "first and second" {
+		t.Errorf("expected combined filter, got %q", opts.Filter)
+	}
+}
+
+func TestApplyListOptions_TripleFilterCombination(t *testing.T) {
+	opts := applyListOptions([]ListOption{
+		WithFilter("a eq 1"),
+		WithFilter("b eq 2"),
+		WithFilter("c eq 3"),
+	})
+	expected := "a eq 1 and b eq 2 and c eq 3"
+	if opts.Filter != expected {
+		t.Errorf("expected %q, got %q", expected, opts.Filter)
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -171,3 +171,23 @@ func TestWithOffset(t *testing.T) {
 		t.Errorf("got %d", opts.Offset)
 	}
 }
+
+func TestEscapeFilterValue(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"normal", "normal"},
+		{"it's", "it''s"},
+		{"can't won't", "can''t won''t"},
+		{"no quotes", "no quotes"},
+		{"", ""},
+		{"'", "''"},
+	}
+	for _, tt := range tests {
+		got := escapeFilterValue(tt.input)
+		if got != tt.want {
+			t.Errorf("escapeFilterValue(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/permission.go
+++ b/permission.go
@@ -38,13 +38,13 @@ func (s *PermissionService) ListByIdentity(ctx context.Context, identityID int, 
 
 // ListByTable returns all permissions for a specific resource type.
 func (s *PermissionService) ListByTable(ctx context.Context, table string, opts ...ListOption) ([]Permission, error) {
-	opts = append([]ListOption{WithFilter(fmt.Sprintf("table eq '%s'", table))}, opts...)
+	opts = append([]ListOption{WithFilter(fmt.Sprintf("table eq '%s'", escapeFilterValue(table)))}, opts...)
 	return s.List(ctx, opts...)
 }
 
 // ListByResource returns all permissions for a specific resource instance.
 func (s *PermissionService) ListByResource(ctx context.Context, table string, rowID int64, opts ...ListOption) ([]Permission, error) {
-	opts = append([]ListOption{WithFilter(fmt.Sprintf("table eq '%s' and row eq %d", table, rowID))}, opts...)
+	opts = append([]ListOption{WithFilter(fmt.Sprintf("table eq '%s' and row eq %d", escapeFilterValue(table), rowID))}, opts...)
 	return s.List(ctx, opts...)
 }
 
@@ -67,7 +67,7 @@ func (s *PermissionService) Get(ctx context.Context, id int) (*Permission, error
 
 // GetByIdentityAndResource returns the permission for a specific identity and resource.
 func (s *PermissionService) GetByIdentityAndResource(ctx context.Context, identityID int, table string, rowID int64) (*Permission, error) {
-	permissions, err := s.List(ctx, WithFilter(fmt.Sprintf("identity eq %d and table eq '%s' and row eq %d", identityID, table, rowID)))
+	permissions, err := s.List(ctx, WithFilter(fmt.Sprintf("identity eq %d and table eq '%s' and row eq %d", identityID, escapeFilterValue(table), rowID)))
 	if err != nil {
 		return nil, err
 	}

--- a/permission_test.go
+++ b/permission_test.go
@@ -174,7 +174,7 @@ func TestPermissionService_Create(t *testing.T) {
 			if req.Row != 100 {
 				t.Errorf("expected row 100, got %d", req.Row)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, Permission{Key: 1, Identity: 10, Table: "vms", Row: 100, Read: true})
@@ -352,7 +352,7 @@ func TestPermissionService_Grant(t *testing.T) {
 			if req.Delete == nil || *req.Delete {
 				t.Error("expected delete=false")
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, Permission{Key: 1, Identity: 10, Table: "vms", Row: 100, List: true, Read: true, Modify: true})
@@ -382,7 +382,7 @@ func TestPermissionService_GrantReadOnly(t *testing.T) {
 			if req.Delete != nil && *req.Delete {
 				t.Error("expected delete=false")
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, Permission{Key: 1, Identity: 10, Table: "vms", Row: 100, List: true, Read: true})
@@ -418,7 +418,7 @@ func TestPermissionService_GrantFullAccess(t *testing.T) {
 			if req.Delete == nil || !*req.Delete {
 				t.Error("expected delete=true")
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, Permission{Key: 1, Identity: 10, Table: "vms", Row: 100, List: true, Read: true, Create: true, Modify: true, Delete: true})

--- a/resourcegroup.go
+++ b/resourcegroup.go
@@ -48,7 +48,7 @@ func (s *ResourceGroupService) Get(ctx context.Context, id int) (*ResourceGroup,
 
 // GetByName returns a resource group by name.
 func (s *ResourceGroupService) GetByName(ctx context.Context, name string) (*ResourceGroup, error) {
-	groups, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	groups, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/settings.go
+++ b/settings.go
@@ -48,7 +48,7 @@ func (s *SettingsService) Get(ctx context.Context, id int) (*Setting, error) {
 
 // GetByKey returns a setting by key name.
 func (s *SettingsService) GetByKey(ctx context.Context, key string) (*Setting, error) {
-	settings, err := s.List(ctx, WithFilter(fmt.Sprintf("key eq '%s'", key)))
+	settings, err := s.List(ctx, WithFilter(fmt.Sprintf("key eq '%s'", escapeFilterValue(key))))
 	if err != nil {
 		return nil, err
 	}

--- a/site.go
+++ b/site.go
@@ -38,7 +38,7 @@ func (s *SiteService) Get(ctx context.Context, id int) (*Site, error) {
 	endpoint := fmt.Sprintf("/sites/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &site); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Site", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Site", ID: id}
 		}
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (s *SiteService) Update(ctx context.Context, id int, req *SiteUpdateRequest
 	endpoint := fmt.Sprintf("/sites/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Site", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Site", ID: id}
 		}
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (s *SiteService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/sites/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "Site", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "Site", ID: id}
 		}
 		return err
 	}
@@ -224,7 +224,7 @@ func (s *SiteSyncIncomingService) Get(ctx context.Context, id int) (*SiteSyncInc
 	endpoint := fmt.Sprintf("/site_syncs_incoming/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &sync); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SiteSyncIncoming", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SiteSyncIncoming", ID: id}
 		}
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func (s *SiteSyncIncomingService) Update(ctx context.Context, id int, req *SiteS
 	endpoint := fmt.Sprintf("/site_syncs_incoming/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SiteSyncIncoming", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SiteSyncIncoming", ID: id}
 		}
 		return nil, err
 	}
@@ -305,7 +305,7 @@ func (s *SiteSyncIncomingService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/site_syncs_incoming/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "SiteSyncIncoming", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "SiteSyncIncoming", ID: id}
 		}
 		return err
 	}
@@ -376,7 +376,7 @@ func (s *SiteSyncOutgoingService) Get(ctx context.Context, id int) (*SiteSyncOut
 	endpoint := fmt.Sprintf("/site_syncs_outgoing/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &sync); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SiteSyncOutgoing", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SiteSyncOutgoing", ID: id}
 		}
 		return nil, err
 	}
@@ -432,7 +432,7 @@ func (s *SiteSyncOutgoingService) Update(ctx context.Context, id int, req *SiteS
 	endpoint := fmt.Sprintf("/site_syncs_outgoing/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SiteSyncOutgoing", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SiteSyncOutgoing", ID: id}
 		}
 		return nil, err
 	}
@@ -445,7 +445,7 @@ func (s *SiteSyncOutgoingService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/site_syncs_outgoing/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "SiteSyncOutgoing", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "SiteSyncOutgoing", ID: id}
 		}
 		return err
 	}
@@ -560,7 +560,7 @@ func (s *SiteSyncProfilePeriodService) Get(ctx context.Context, id int) (*SiteSy
 	endpoint := fmt.Sprintf("/site_syncs_outgoing_profile_periods/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &period); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SiteSyncProfilePeriod", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SiteSyncProfilePeriod", ID: id}
 		}
 		return nil, err
 	}
@@ -605,7 +605,7 @@ func (s *SiteSyncProfilePeriodService) Update(ctx context.Context, id int, req *
 	endpoint := fmt.Sprintf("/site_syncs_outgoing_profile_periods/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SiteSyncProfilePeriod", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SiteSyncProfilePeriod", ID: id}
 		}
 		return nil, err
 	}
@@ -618,7 +618,7 @@ func (s *SiteSyncProfilePeriodService) Delete(ctx context.Context, id int) error
 	endpoint := fmt.Sprintf("/site_syncs_outgoing_profile_periods/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "SiteSyncProfilePeriod", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "SiteSyncProfilePeriod", ID: id}
 		}
 		return err
 	}

--- a/site.go
+++ b/site.go
@@ -48,7 +48,7 @@ func (s *SiteService) Get(ctx context.Context, id int) (*Site, error) {
 
 // GetByName returns a site by name.
 func (s *SiteService) GetByName(ctx context.Context, name string) (*Site, error) {
-	sites, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	sites, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (s *SiteService) GetByName(ctx context.Context, name string) (*Site, error)
 
 // GetBySiteID returns a site by its 40-character SHA1 site ID.
 func (s *SiteService) GetBySiteID(ctx context.Context, siteID string) (*Site, error) {
-	sites, err := s.List(ctx, WithFilter(fmt.Sprintf("id eq '%s'", siteID)))
+	sites, err := s.List(ctx, WithFilter(fmt.Sprintf("id eq '%s'", escapeFilterValue(siteID))))
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +235,7 @@ func (s *SiteSyncIncomingService) Get(ctx context.Context, id int) (*SiteSyncInc
 // GetByName returns an incoming sync by name within a site.
 func (s *SiteSyncIncomingService) GetByName(ctx context.Context, siteID int, name string) (*SiteSyncIncoming, error) {
 	syncs, err := s.List(ctx,
-		WithFilter(fmt.Sprintf("site eq %d and name eq '%s'", siteID, name)),
+		WithFilter(fmt.Sprintf("site eq %d and name eq '%s'", siteID, escapeFilterValue(name))),
 	)
 	if err != nil {
 		return nil, err
@@ -248,7 +248,7 @@ func (s *SiteSyncIncomingService) GetByName(ctx context.Context, siteID int, nam
 
 // GetBySyncID returns an incoming sync by its 40-character sync ID.
 func (s *SiteSyncIncomingService) GetBySyncID(ctx context.Context, syncID string) (*SiteSyncIncoming, error) {
-	syncs, err := s.List(ctx, WithFilter(fmt.Sprintf("sync_id eq '%s'", syncID)))
+	syncs, err := s.List(ctx, WithFilter(fmt.Sprintf("sync_id eq '%s'", escapeFilterValue(syncID))))
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +387,7 @@ func (s *SiteSyncOutgoingService) Get(ctx context.Context, id int) (*SiteSyncOut
 // GetByName returns an outgoing sync by name within a site.
 func (s *SiteSyncOutgoingService) GetByName(ctx context.Context, siteID int, name string) (*SiteSyncOutgoing, error) {
 	syncs, err := s.List(ctx,
-		WithFilter(fmt.Sprintf("site eq %d and name eq '%s'", siteID, name)),
+		WithFilter(fmt.Sprintf("site eq %d and name eq '%s'", siteID, escapeFilterValue(name))),
 	)
 	if err != nil {
 		return nil, err

--- a/site.go
+++ b/site.go
@@ -484,7 +484,7 @@ func (s *SiteSyncOutgoingService) Throttle(ctx context.Context, id int, throttle
 	action := siteSyncOutgoingAction{
 		SiteSyncOutgoing: id,
 		Action:           "throttle",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"throttle": throttle,
 		},
 	}

--- a/site_test.go
+++ b/site_test.go
@@ -131,7 +131,7 @@ func TestSiteService_Create(t *testing.T) {
 			if req.URL == "" {
 				t.Error("expected url in request body")
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/sites/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, Site{Key: 1, Name: "new-site", URL: "https://remote.example.com"})
@@ -243,7 +243,7 @@ func TestSiteService_Delete_NotFound(t *testing.T) {
 func TestSiteService_Refresh(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "refresh" {
 				t.Errorf("expected action 'refresh', got %v", body["action"])
@@ -261,7 +261,7 @@ func TestSiteService_Refresh(t *testing.T) {
 func TestSiteService_RefreshSettings(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "refresh_settings" {
 				t.Errorf("expected action 'refresh_settings', got %v", body["action"])
@@ -279,7 +279,7 @@ func TestSiteService_RefreshSettings(t *testing.T) {
 func TestSiteService_Reauthenticate(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "reauthenticate" {
 				t.Errorf("expected action 'reauthenticate', got %v", body["action"])
@@ -297,7 +297,7 @@ func TestSiteService_Reauthenticate(t *testing.T) {
 func TestSiteService_RunUpdates(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "run_updates" {
 				t.Errorf("expected action 'run_updates', got %v", body["action"])
@@ -315,7 +315,7 @@ func TestSiteService_RunUpdates(t *testing.T) {
 func TestSiteService_ClearSyncedLogs(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "clear_synced_logs" {
 				t.Errorf("expected action 'clear_synced_logs', got %v", body["action"])
@@ -471,7 +471,7 @@ func TestSiteSyncIncomingService_Create(t *testing.T) {
 			if req.Name != "new-inc-sync" {
 				t.Errorf("expected name 'new-inc-sync', got %q", req.Name)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/site_syncs_incoming/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, SiteSyncIncoming{Key: 1, Name: "new-inc-sync", Site: 10})
@@ -594,7 +594,7 @@ func TestSiteSyncIncomingService_Delete_NotFound(t *testing.T) {
 func TestSiteSyncIncomingService_Enable(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_syncs_incoming_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "enable" {
 				t.Errorf("expected action 'enable', got %v", body["action"])
@@ -612,7 +612,7 @@ func TestSiteSyncIncomingService_Enable(t *testing.T) {
 func TestSiteSyncIncomingService_Disable(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_syncs_incoming_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "disable" {
 				t.Errorf("expected action 'disable', got %v", body["action"])
@@ -745,7 +745,7 @@ func TestSiteSyncOutgoingService_Create(t *testing.T) {
 			if req.Site != 10 {
 				t.Errorf("expected site 10, got %d", req.Site)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/site_syncs_outgoing/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, SiteSyncOutgoing{Key: 1, Name: "new-out-sync", Site: 10})
@@ -868,7 +868,7 @@ func TestSiteSyncOutgoingService_Delete_NotFound(t *testing.T) {
 func TestSiteSyncOutgoingService_Enable(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_syncs_outgoing_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "enable" {
 				t.Errorf("expected action 'enable', got %v", body["action"])
@@ -886,7 +886,7 @@ func TestSiteSyncOutgoingService_Enable(t *testing.T) {
 func TestSiteSyncOutgoingService_Disable(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_syncs_outgoing_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "disable" {
 				t.Errorf("expected action 'disable', got %v", body["action"])
@@ -904,12 +904,12 @@ func TestSiteSyncOutgoingService_Disable(t *testing.T) {
 func TestSiteSyncOutgoingService_Throttle(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_syncs_outgoing_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "throttle" {
 				t.Errorf("expected action 'throttle', got %v", body["action"])
 			}
-			params, ok := body["params"].(map[string]interface{})
+			params, ok := body["params"].(map[string]any)
 			if !ok {
 				t.Fatal("expected params in body")
 			}
@@ -929,7 +929,7 @@ func TestSiteSyncOutgoingService_Throttle(t *testing.T) {
 func TestSiteSyncOutgoingService_DisableThrottle(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_syncs_outgoing_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "throttle_disable" {
 				t.Errorf("expected action 'throttle_disable', got %v", body["action"])
@@ -947,7 +947,7 @@ func TestSiteSyncOutgoingService_DisableThrottle(t *testing.T) {
 func TestSiteSyncOutgoingService_RefreshSnapshots(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_syncs_outgoing_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "refresh" {
 				t.Errorf("expected action 'refresh', got %v", body["action"])
@@ -1051,7 +1051,7 @@ func TestSiteSyncProfilePeriodService_Create(t *testing.T) {
 			if req.Retention != 86400 {
 				t.Errorf("expected retention 86400, got %d", req.Retention)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/site_syncs_outgoing_profile_periods/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, SiteSyncProfilePeriod{Key: 1, SiteSyncsOutgoing: 5, ProfilePeriod: 3, Retention: 86400})

--- a/snapshot_profile.go
+++ b/snapshot_profile.go
@@ -39,7 +39,7 @@ func (s *SnapshotProfileService) Get(ctx context.Context, id int) (*SnapshotProf
 	endpoint := fmt.Sprintf("/snapshot_profiles/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &profile); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SnapshotProfile", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SnapshotProfile", ID: id}
 		}
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (s *SnapshotProfileService) Update(ctx context.Context, id int, req *Snapsh
 	endpoint := fmt.Sprintf("/snapshot_profiles/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SnapshotProfile", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SnapshotProfile", ID: id}
 		}
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (s *SnapshotProfileService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/snapshot_profiles/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "SnapshotProfile", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "SnapshotProfile", ID: id}
 		}
 		return err
 	}
@@ -155,7 +155,7 @@ func (s *SnapshotProfilePeriodService) Get(ctx context.Context, id int) (*Snapsh
 	endpoint := fmt.Sprintf("/snapshot_profile_periods/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &period); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SnapshotProfilePeriod", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SnapshotProfilePeriod", ID: id}
 		}
 		return nil, err
 	}
@@ -215,7 +215,7 @@ func (s *SnapshotProfilePeriodService) Update(ctx context.Context, id int, req *
 	endpoint := fmt.Sprintf("/snapshot_profile_periods/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SnapshotProfilePeriod", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SnapshotProfilePeriod", ID: id}
 		}
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (s *SnapshotProfilePeriodService) Delete(ctx context.Context, id int) error
 	endpoint := fmt.Sprintf("/snapshot_profile_periods/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "SnapshotProfilePeriod", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "SnapshotProfilePeriod", ID: id}
 		}
 		return err
 	}

--- a/snapshot_profile.go
+++ b/snapshot_profile.go
@@ -49,7 +49,7 @@ func (s *SnapshotProfileService) Get(ctx context.Context, id int) (*SnapshotProf
 
 // GetByName returns a snapshot profile by name.
 func (s *SnapshotProfileService) GetByName(ctx context.Context, name string) (*SnapshotProfile, error) {
-	profiles, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	profiles, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (s *SnapshotProfilePeriodService) Get(ctx context.Context, id int) (*Snapsh
 
 // GetByName returns a snapshot profile period by name within a specific profile.
 func (s *SnapshotProfilePeriodService) GetByName(ctx context.Context, profileID int, name string) (*SnapshotProfilePeriod, error) {
-	periods, err := s.List(ctx, WithFilter(fmt.Sprintf("profile eq %d and name eq '%s'", profileID, name)))
+	periods, err := s.List(ctx, WithFilter(fmt.Sprintf("profile eq %d and name eq '%s'", profileID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/snapshot_profile_test.go
+++ b/snapshot_profile_test.go
@@ -109,7 +109,7 @@ func TestSnapshotProfileService_Create(t *testing.T) {
 			if req.Name != "weekly" {
 				t.Errorf("expected name 'weekly', got %q", req.Name)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 3})
+			jsonResponse(w, 200, map[string]any{"$key": 3})
 		},
 		"GET /api/v4/snapshot_profiles/3": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, SnapshotProfile{Key: 3, Name: "weekly"})
@@ -359,7 +359,7 @@ func TestSnapshotProfilePeriodService_Create(t *testing.T) {
 			if req.Profile != 5 {
 				t.Errorf("expected profile 5, got %d", req.Profile)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 10})
+			jsonResponse(w, 200, map[string]any{"$key": 10})
 		},
 		"GET /api/v4/snapshot_profile_periods/10": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, SnapshotProfilePeriod{Key: 10, Profile: 5, Name: "hourly", Frequency: "hourly", Retention: 86400})

--- a/system.go
+++ b/system.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 )
 
 // SystemService handles system information operations.
@@ -18,13 +19,18 @@ func (s *SystemService) GetInfo(ctx context.Context) (*SystemInfo, error) {
 	// Build URL for version.json (not under /api/v4/)
 	u := fmt.Sprintf("%s/version.json", s.client.baseURL)
 
-	req, err := s.client.httpClient.Get(u)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("vergeos: failed to create version request: %w", err)
+	}
+
+	resp, err := s.client.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("vergeos: failed to get version info: %w", err)
 	}
-	defer func() { _ = req.Body.Close() }()
+	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(req.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("vergeos: failed to read version response: %w", err)
 	}

--- a/tag.go
+++ b/tag.go
@@ -49,7 +49,7 @@ func (s *TagService) Get(ctx context.Context, id int) (*Tag, error) {
 
 // GetByName returns a tag by name.
 func (s *TagService) GetByName(ctx context.Context, name string) (*Tag, error) {
-	tags, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	tags, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/tag_category.go
+++ b/tag_category.go
@@ -49,7 +49,7 @@ func (s *TagCategoryService) Get(ctx context.Context, id int) (*TagCategory, err
 
 // GetByName returns a tag category by name.
 func (s *TagCategoryService) GetByName(ctx context.Context, name string) (*TagCategory, error) {
-	categories, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	categories, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/tag_category_test.go
+++ b/tag_category_test.go
@@ -125,7 +125,7 @@ func TestTagCategoryService_Create(t *testing.T) {
 			if req.Name != "environment" {
 				t.Errorf("expected name 'environment', got %q", req.Name)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/tag_categories/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, TagCategory{Key: 1, Name: "environment", TaggableVMs: true})

--- a/tagmember.go
+++ b/tagmember.go
@@ -115,7 +115,7 @@ func (s *TagMemberService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/tag_members/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "TagMember", ID: id}
 		}
 		return err
 	}

--- a/tagmember.go
+++ b/tagmember.go
@@ -39,7 +39,7 @@ func (s *TagMemberService) ListByTag(ctx context.Context, tagID int) ([]TagMembe
 // ListByMember returns all tag members for a specific object.
 // member should be in format "object_type/object_id" (e.g., "vms/123").
 func (s *TagMemberService) ListByMember(ctx context.Context, member string) ([]TagMember, error) {
-	return s.List(ctx, WithFilter(fmt.Sprintf("member eq '%s'", member)))
+	return s.List(ctx, WithFilter(fmt.Sprintf("member eq '%s'", escapeFilterValue(member))))
 }
 
 // Get returns a single tag member by ID.
@@ -136,7 +136,7 @@ func (s *TagMemberService) Assign(ctx context.Context, tagID int, member string)
 func (s *TagMemberService) Unassign(ctx context.Context, tagID int, member string) error {
 	// Find the tag member
 	members, err := s.List(ctx,
-		WithFilter(fmt.Sprintf("tag eq %d and member eq '%s'", tagID, member)),
+		WithFilter(fmt.Sprintf("tag eq %d and member eq '%s'", tagID, escapeFilterValue(member))),
 	)
 	if err != nil {
 		return err

--- a/tagmember_test.go
+++ b/tagmember_test.go
@@ -112,7 +112,7 @@ func TestTagMemberService_Create(t *testing.T) {
 			if req.Member != "vms/123" {
 				t.Errorf("expected member 'vms/123', got %q", req.Member)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/tag_members/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, TagMember{Key: 1, Tag: 10, Member: "vms/123"})
@@ -294,7 +294,7 @@ func TestTagMemberService_Assign(t *testing.T) {
 			if req.Member != "vms/123" {
 				t.Errorf("expected member 'vms/123', got %q", req.Member)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 5})
+			jsonResponse(w, 200, map[string]any{"$key": 5})
 		},
 		"GET /api/v4/tag_members/5": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, TagMember{Key: 5, Tag: 10, Member: "vms/123"})

--- a/tagmember_test.go
+++ b/tagmember_test.go
@@ -275,8 +275,11 @@ func TestTagMemberService_Delete_NotFound(t *testing.T) {
 
 	// Delete returns nil for not found (already deleted)
 	err := client.TagMembers.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("Delete should not error for not found, got: %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted tag member")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }
 

--- a/task.go
+++ b/task.go
@@ -40,7 +40,7 @@ func (s *TaskService) ListRunning(ctx context.Context, opts ...ListOption) ([]Ta
 // ListByOwner returns all tasks for a specific owner resource.
 // owner should be a resource path like "vms/123".
 func (s *TaskService) ListByOwner(ctx context.Context, owner string, opts ...ListOption) ([]Task, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("owner eq '%s'", owner))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("owner eq '%s'", escapeFilterValue(owner)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }
@@ -71,7 +71,7 @@ func (s *TaskService) Get(ctx context.Context, id int) (*Task, error) {
 
 // GetByID returns a task by its 40-character SHA1 ID.
 func (s *TaskService) GetByID(ctx context.Context, taskID string) (*Task, error) {
-	tasks, err := s.List(ctx, WithFilter(fmt.Sprintf("id eq '%s'", taskID)))
+	tasks, err := s.List(ctx, WithFilter(fmt.Sprintf("id eq '%s'", escapeFilterValue(taskID))))
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (s *TaskService) GetByID(ctx context.Context, taskID string) (*Task, error)
 
 // GetByName returns a task by name for a specific owner.
 func (s *TaskService) GetByName(ctx context.Context, owner, name string) (*Task, error) {
-	tasks, err := s.List(ctx, WithFilter(fmt.Sprintf("owner eq '%s' and name eq '%s'", owner, name)))
+	tasks, err := s.List(ctx, WithFilter(fmt.Sprintf("owner eq '%s' and name eq '%s'", escapeFilterValue(owner), escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/task.go
+++ b/task.go
@@ -61,7 +61,7 @@ func (s *TaskService) Get(ctx context.Context, id int) (*Task, error) {
 	endpoint := fmt.Sprintf("/tasks/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &task); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Task", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Task", ID: id}
 		}
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func (s *TaskService) Update(ctx context.Context, id int, req *TaskUpdateRequest
 	endpoint := fmt.Sprintf("/tasks/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Task", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Task", ID: id}
 		}
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func (s *TaskService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/tasks/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "Task", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "Task", ID: id}
 		}
 		return err
 	}

--- a/task.go
+++ b/task.go
@@ -158,7 +158,7 @@ func (s *TaskService) Delete(ctx context.Context, id int) error {
 // Execute triggers immediate execution of a task.
 func (s *TaskService) Execute(ctx context.Context, id int, opts *TaskExecuteOptions) error {
 	endpoint := "/task_actions"
-	body := map[string]interface{}{
+	body := map[string]any{
 		"task":   id,
 		"action": "execute",
 	}

--- a/task_test.go
+++ b/task_test.go
@@ -205,7 +205,7 @@ func TestTaskService_Create(t *testing.T) {
 			if req.Owner != "vms/123" {
 				t.Errorf("expected owner 'vms/123', got %q", req.Owner)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/tasks/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, Task{Key: 1, Name: "daily-snapshot", Owner: "vms/123", Action: "snapshot"})
@@ -368,7 +368,7 @@ func TestTaskService_Delete_NotFound(t *testing.T) {
 func TestTaskService_Execute(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/task_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "execute" {
 				t.Errorf("expected action 'execute', got %v", body["action"])
@@ -390,9 +390,9 @@ func TestTaskService_Execute(t *testing.T) {
 func TestTaskService_Execute_WithParams(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/task_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
-			params, ok := body["params"].(map[string]interface{})
+			params, ok := body["params"].(map[string]any)
 			if !ok {
 				t.Error("expected params in request body")
 			}
@@ -404,7 +404,7 @@ func TestTaskService_Execute_WithParams(t *testing.T) {
 	}))
 
 	err := client.Tasks.Execute(context.Background(), 1, &TaskExecuteOptions{
-		Params: map[string]interface{}{"force": true},
+		Params: map[string]any{"force": true},
 	})
 	if err != nil {
 		t.Fatalf("Execute with params failed: %v", err)

--- a/tenant.go
+++ b/tenant.go
@@ -39,7 +39,7 @@ func (s *TenantService) Get(ctx context.Context, id int) (*Tenant, error) {
 	endpoint := fmt.Sprintf("/tenants/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &tenant); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Tenant", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Tenant", ID: id}
 		}
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (s *TenantService) Update(ctx context.Context, id int, req *TenantUpdateReq
 	endpoint := fmt.Sprintf("/tenants/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Tenant", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Tenant", ID: id}
 		}
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (s *TenantService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/tenants/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "Tenant", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "Tenant", ID: id}
 		}
 		return err
 	}
@@ -264,7 +264,7 @@ func (s *TenantNodeService) Get(ctx context.Context, id int) (*TenantNode, error
 	endpoint := fmt.Sprintf("/tenant_nodes/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &node); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "TenantNode", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "TenantNode", ID: id}
 		}
 		return nil, err
 	}
@@ -324,7 +324,7 @@ func (s *TenantNodeService) Update(ctx context.Context, id int, req *TenantNodeU
 	endpoint := fmt.Sprintf("/tenant_nodes/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "TenantNode", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "TenantNode", ID: id}
 		}
 		return nil, err
 	}
@@ -338,7 +338,7 @@ func (s *TenantNodeService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/tenant_nodes/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "TenantNode", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "TenantNode", ID: id}
 		}
 		return err
 	}
@@ -581,7 +581,7 @@ func (s *TenantStorageService) Get(ctx context.Context, id int) (*TenantStorage,
 	endpoint := fmt.Sprintf("/tenant_storage/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &storage); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "TenantStorage", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "TenantStorage", ID: id}
 		}
 		return nil, err
 	}
@@ -628,7 +628,7 @@ func (s *TenantStorageService) Update(ctx context.Context, id int, req *TenantSt
 	endpoint := fmt.Sprintf("/tenant_storage/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "TenantStorage", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "TenantStorage", ID: id}
 		}
 		return nil, err
 	}
@@ -642,7 +642,7 @@ func (s *TenantStorageService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/tenant_storage/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "TenantStorage", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "TenantStorage", ID: id}
 		}
 		return err
 	}

--- a/tenant.go
+++ b/tenant.go
@@ -49,7 +49,7 @@ func (s *TenantService) Get(ctx context.Context, id int) (*Tenant, error) {
 
 // GetByName returns a tenant by name.
 func (s *TenantService) GetByName(ctx context.Context, name string) (*Tenant, error) {
-	tenants, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	tenants, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +274,7 @@ func (s *TenantNodeService) Get(ctx context.Context, id int) (*TenantNode, error
 
 // GetByName returns a tenant node by name within a specific tenant.
 func (s *TenantNodeService) GetByName(ctx context.Context, tenantID int, name string) (*TenantNode, error) {
-	nodes, err := s.List(ctx, WithFilter(fmt.Sprintf("tenant eq %d and name eq '%s'", tenantID, name)))
+	nodes, err := s.List(ctx, WithFilter(fmt.Sprintf("tenant eq %d and name eq '%s'", tenantID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/tenant.go
+++ b/tenant.go
@@ -127,7 +127,7 @@ func (s *TenantService) PowerOnWithNode(ctx context.Context, id int, preferredNo
 		Action: "poweron",
 	}
 	if preferredNode > 0 {
-		action.Params = map[string]interface{}{
+		action.Params = map[string]any{
 			"preferred_node": preferredNode,
 		}
 	}
@@ -176,7 +176,7 @@ func (s *TenantService) Clone(ctx context.Context, id int, opts *TenantCloneOpti
 	action := tenantAction{
 		Tenant: id,
 		Action: "clone",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"name":       opts.Name,
 			"no_vnet":    opts.NoVNet,
 			"no_storage": opts.NoStorage,
@@ -220,7 +220,7 @@ func (s *TenantService) IsolateOff(ctx context.Context, id int) error {
 type tenantAction struct {
 	Tenant int                    `json:"tenant"`
 	Action string                 `json:"action"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 // TenantNodeService handles tenant node operations.
@@ -404,7 +404,7 @@ func (s *TenantNodeService) Migrate(ctx context.Context, id int, targetNode int)
 		Action:     "migrate",
 	}
 	if targetNode > 0 {
-		action.Params = map[string]interface{}{
+		action.Params = map[string]any{
 			"node": targetNode,
 		}
 	}
@@ -419,7 +419,7 @@ func (s *TenantNodeService) Migrate(ctx context.Context, id int, targetNode int)
 type tenantNodeAction struct {
 	TenantNode int                    `json:"tenant_node"`
 	Action     string                 `json:"action"`
-	Params     map[string]interface{} `json:"params,omitempty"`
+	Params     map[string]any `json:"params,omitempty"`
 }
 
 // TenantStatusService handles tenant status read operations.

--- a/tenant_layer2.go
+++ b/tenant_layer2.go
@@ -128,15 +128,17 @@ func (s *TenantLayer2NetworkService) Delete(ctx context.Context, id int) error {
 }
 
 // Enable enables a tenant layer2 network assignment.
-func (s *TenantLayer2NetworkService) Enable(ctx context.Context, id int) (*TenantLayer2Network, error) {
+func (s *TenantLayer2NetworkService) Enable(ctx context.Context, id int) error {
 	enabled := true
-	return s.Update(ctx, id, &TenantLayer2NetworkUpdateRequest{Enabled: &enabled})
+	_, err := s.Update(ctx, id, &TenantLayer2NetworkUpdateRequest{Enabled: &enabled})
+	return err
 }
 
 // Disable disables a tenant layer2 network assignment.
-func (s *TenantLayer2NetworkService) Disable(ctx context.Context, id int) (*TenantLayer2Network, error) {
+func (s *TenantLayer2NetworkService) Disable(ctx context.Context, id int) error {
 	enabled := false
-	return s.Update(ctx, id, &TenantLayer2NetworkUpdateRequest{Enabled: &enabled})
+	_, err := s.Update(ctx, id, &TenantLayer2NetworkUpdateRequest{Enabled: &enabled})
+	return err
 }
 
 // Assign is a convenience method to assign a network to a tenant.

--- a/tenant_layer2.go
+++ b/tenant_layer2.go
@@ -51,7 +51,7 @@ func (s *TenantLayer2NetworkService) Get(ctx context.Context, id int) (*TenantLa
 	endpoint := fmt.Sprintf("/tenant_layer2_vnets/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &network); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "TenantLayer2Network", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "TenantLayer2Network", ID: id}
 		}
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (s *TenantLayer2NetworkService) Update(ctx context.Context, id int, req *Te
 	endpoint := fmt.Sprintf("/tenant_layer2_vnets/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "TenantLayer2Network", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "TenantLayer2Network", ID: id}
 		}
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (s *TenantLayer2NetworkService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/tenant_layer2_vnets/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "TenantLayer2Network", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "TenantLayer2Network", ID: id}
 		}
 		return err
 	}

--- a/tenant_layer2_test.go
+++ b/tenant_layer2_test.go
@@ -292,12 +292,9 @@ func TestTenantLayer2NetworkService_Enable(t *testing.T) {
 		},
 	}))
 
-	network, err := client.TenantLayer2Networks.Enable(context.Background(), 1)
+	err := client.TenantLayer2Networks.Enable(context.Background(), 1)
 	if err != nil {
 		t.Fatalf("Enable failed: %v", err)
-	}
-	if !network.Enabled {
-		t.Error("expected enabled to be true")
 	}
 }
 
@@ -316,12 +313,9 @@ func TestTenantLayer2NetworkService_Disable(t *testing.T) {
 		},
 	}))
 
-	network, err := client.TenantLayer2Networks.Disable(context.Background(), 1)
+	err := client.TenantLayer2Networks.Disable(context.Background(), 1)
 	if err != nil {
 		t.Fatalf("Disable failed: %v", err)
-	}
-	if network.Enabled {
-		t.Error("expected enabled to be false")
 	}
 }
 

--- a/tenant_snapshot.go
+++ b/tenant_snapshot.go
@@ -51,7 +51,7 @@ func (s *TenantSnapshotService) Get(ctx context.Context, id int) (*TenantSnapsho
 	endpoint := fmt.Sprintf("/tenant_snapshots/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &snapshot); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "TenantSnapshot", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "TenantSnapshot", ID: id}
 		}
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func (s *TenantSnapshotService) Update(ctx context.Context, id int, req *TenantS
 	endpoint := fmt.Sprintf("/tenant_snapshots/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "TenantSnapshot", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "TenantSnapshot", ID: id}
 		}
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (s *TenantSnapshotService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/tenant_snapshots/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "TenantSnapshot", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "TenantSnapshot", ID: id}
 		}
 		return err
 	}

--- a/tenant_snapshot.go
+++ b/tenant_snapshot.go
@@ -131,5 +131,5 @@ func (s *TenantSnapshotService) SetExpires(ctx context.Context, id int, expires 
 type tenantSnapshotAction struct {
 	Tenant int                    `json:"tenant"`
 	Action string                 `json:"action"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	Params map[string]any `json:"params,omitempty"`
 }

--- a/tenant_snapshot.go
+++ b/tenant_snapshot.go
@@ -62,7 +62,7 @@ func (s *TenantSnapshotService) Get(ctx context.Context, id int) (*TenantSnapsho
 // GetByName returns a tenant snapshot by name within a specific tenant.
 func (s *TenantSnapshotService) GetByName(ctx context.Context, tenantID int, name string) (*TenantSnapshot, error) {
 	snapshots, err := s.List(ctx,
-		WithFilter(fmt.Sprintf("tenant eq %d and name eq '%s'", tenantID, name)),
+		WithFilter(fmt.Sprintf("tenant eq %d and name eq '%s'", tenantID, escapeFilterValue(name))),
 	)
 	if err != nil {
 		return nil, err

--- a/tenant_snapshot_test.go
+++ b/tenant_snapshot_test.go
@@ -210,7 +210,7 @@ func TestTenantSnapshotService_Delete_NotFound(t *testing.T) {
 func TestTenantSnapshotService_Refresh(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/tenant_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "refresh" {
 				t.Errorf("expected action 'refresh', got %v", body["action"])

--- a/test/integration/version_test.go
+++ b/test/integration/version_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -48,7 +49,7 @@ func TestVersionEnforcement(t *testing.T) {
 		t.Log("NewClient succeeded - server version check passed (v26 confirmed)")
 
 		// Verify client is functional by making a simple API call
-		version, err := client.System.GetVersion(nil)
+		version, err := client.System.GetVersion(context.Background())
 		if err != nil {
 			t.Fatalf("System.GetVersion failed after successful client creation: %v", err)
 		}

--- a/testhelper_test.go
+++ b/testhelper_test.go
@@ -111,7 +111,7 @@ func initServices(c *Client) {
 }
 
 // jsonResponse writes a JSON response with the given status code.
-func jsonResponse(w http.ResponseWriter, status int, v interface{}) {
+func jsonResponse(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	json.NewEncoder(w).Encode(v)

--- a/types.go
+++ b/types.go
@@ -2,6 +2,7 @@ package vergeos
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 )
 
@@ -33,9 +34,7 @@ func (f *FlexInt) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	// Default to 0
-	*f = 0
-	return nil
+	return fmt.Errorf("vergeos: cannot unmarshal %s into FlexInt", string(data))
 }
 
 // MarshalJSON implements json.Marshaler for FlexInt.
@@ -97,8 +96,7 @@ func (f *FlexFK) UnmarshalJSON(data []byte) error {
 		}
 	}
 
-	*f = 0
-	return nil
+	return fmt.Errorf("vergeos: cannot unmarshal %s into FlexFK", string(data))
 }
 
 // MarshalJSON implements json.Marshaler for FlexFK.

--- a/types_cloud_snapshot.go
+++ b/types_cloud_snapshot.go
@@ -47,7 +47,7 @@ type CloudSnapshotUpdateRequest struct {
 type cloudSnapshotAction struct {
 	CloudSnapshot int                    `json:"cloud_snapshot"`
 	Action        string                 `json:"action"`
-	Params        map[string]interface{} `json:"params,omitempty"`
+	Params        map[string]any `json:"params,omitempty"`
 }
 
 // CloudSnapshotCloneOptions specifies options for cloning a cloud snapshot.

--- a/types_machine_status.go
+++ b/types_machine_status.go
@@ -1,6 +1,7 @@
 package vergeos
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -73,6 +74,13 @@ type GuestInfo struct {
 // UnmarshalJSON handles the VergeOS API inconsistency where network and fsinfo
 // can be either a JSON array or a JSON object (map keyed by string).
 func (g *GuestInfo) UnmarshalJSON(data []byte) error {
+	// The API sends [] (empty array) instead of an object or null when no
+	// guest agent is running. Detect that case and return a zero-value.
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || trimmed[0] == '[' {
+		return nil
+	}
+
 	// Use an alias to avoid infinite recursion.
 	type guestInfoRaw struct {
 		OSInfo      *GuestOSInfo    `json:"osinfo,omitempty"`

--- a/types_network.go
+++ b/types_network.go
@@ -426,7 +426,7 @@ type NetworkUpdateRequest struct {
 type vnetAction struct {
 	VNet   int         `json:"vnet"`
 	Action string      `json:"action"`
-	Params interface{} `json:"params"`
+	Params any `json:"params"`
 }
 
 // networkListFields are the fields to request when listing networks.
@@ -470,7 +470,7 @@ type NetworkQuery struct {
 	// whatsmyip, arp, arp-scan, frr, trace, dhcp_release_renew, wireguard, firewall, nmap, tcp_connect
 	Query string `json:"query,omitempty"`
 	// Params contains query-specific parameters (JSON object).
-	Params map[string]interface{} `json:"params,omitempty"`
+	Params map[string]any `json:"params,omitempty"`
 	// Status is the query status (running, error, complete).
 	Status string `json:"status,omitempty"`
 	// Result is the query output.
@@ -494,7 +494,7 @@ type NetworkQueryRequest struct {
 	// whatsmyip, arp, arp-scan, frr, trace, dhcp_release_renew, wireguard, firewall, nmap, tcp_connect
 	Query string `json:"query"`
 	// Params contains query-specific parameters.
-	Params map[string]interface{} `json:"params,omitempty"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 // NetworkMonitorStats represents network monitoring statistics.

--- a/types_site.go
+++ b/types_site.go
@@ -102,7 +102,7 @@ type SiteUpdateRequest struct {
 type siteAction struct {
 	Site   int                    `json:"site"`
 	Action string                 `json:"action"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 // Site configuration options for sync direction
@@ -194,7 +194,7 @@ type SiteSyncIncomingUpdateRequest struct {
 type siteSyncIncomingAction struct {
 	SiteSyncIncoming int                    `json:"site_syncs_incoming"`
 	Action           string                 `json:"action"`
-	Params           map[string]interface{} `json:"params,omitempty"`
+	Params           map[string]any `json:"params,omitempty"`
 }
 
 // Incoming sync status values
@@ -291,7 +291,7 @@ type SiteSyncOutgoingUpdateRequest struct {
 type siteSyncOutgoingAction struct {
 	SiteSyncOutgoing int                    `json:"site_syncs_outgoing"`
 	Action           string                 `json:"action"`
-	Params           map[string]interface{} `json:"params,omitempty"`
+	Params           map[string]any `json:"params,omitempty"`
 }
 
 // Outgoing sync status values

--- a/types_task.go
+++ b/types_task.go
@@ -77,7 +77,7 @@ type TaskUpdateRequest struct {
 // TaskExecuteOptions are options for executing a task.
 type TaskExecuteOptions struct {
 	// Params are optional parameters to pass to the task action.
-	Params map[string]interface{} `json:"params,omitempty"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 // taskListFields are the fields to request when listing tasks.

--- a/user.go
+++ b/user.go
@@ -62,7 +62,7 @@ func (s *UserService) Get(ctx context.Context, id int) (*User, error) {
 
 // GetByName returns a user by username.
 func (s *UserService) GetByName(ctx context.Context, name string) (*User, error) {
-	users, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	users, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/user.go
+++ b/user.go
@@ -127,7 +127,7 @@ func (s *UserService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/users/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "User", ID: id}
 		}
 		return err
 	}

--- a/user.go
+++ b/user.go
@@ -16,7 +16,7 @@ const (
 type userAction struct {
 	User   int         `json:"user"`
 	Action string      `json:"action"`
-	Params interface{} `json:"params"`
+	Params any `json:"params"`
 }
 
 // UserService handles user operations.

--- a/user_test.go
+++ b/user_test.go
@@ -250,10 +250,13 @@ func TestUserService_Delete_NotFound(t *testing.T) {
 		},
 	}))
 
-	// Delete of already-deleted resource returns nil
+	// Delete of non-existent resource returns NotFoundError
 	err := client.Users.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("expected nil for already-deleted user, got %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted user")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }
 

--- a/version.go
+++ b/version.go
@@ -35,17 +35,21 @@ type versionResponse struct {
 
 // parseVersion extracts major version from version string.
 // Handles formats: "26.0.0", "v26.0.0", "26.0.0-beta1"
-func parseVersion(v string) (major int) {
+func parseVersion(v string) (int, error) {
 	v = strings.TrimPrefix(v, "v")
 	// Handle dash-suffixed versions like "26.0.0-beta1"
 	if idx := strings.Index(v, "-"); idx != -1 {
 		v = v[:idx]
 	}
 	parts := strings.Split(v, ".")
-	if len(parts) >= 1 {
-		major, _ = strconv.Atoi(parts[0])
+	if len(parts) == 0 || parts[0] == "" {
+		return 0, fmt.Errorf("empty version string")
 	}
-	return
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, fmt.Errorf("invalid major version %q: %w", parts[0], err)
+	}
+	return major, nil
 }
 
 // checkServerVersion fetches /version.json and validates the server is v26.
@@ -56,7 +60,10 @@ func (c *Client) checkServerVersion(ctx context.Context) error {
 		return fmt.Errorf("failed to check server version: %w", err)
 	}
 
-	major := parseVersion(resp.Version)
+	major, err := parseVersion(resp.Version)
+	if err != nil {
+		return fmt.Errorf("failed to parse server version %q: %w", resp.Version, err)
+	}
 	if major != RequiredMajorVersion {
 		return &UnsupportedVersionError{
 			ServerVersion: resp.Version,

--- a/version_test.go
+++ b/version_test.go
@@ -7,23 +7,33 @@ import (
 
 func TestParseVersion(t *testing.T) {
 	tests := []struct {
-		input string
-		major int
+		input   string
+		major   int
+		wantErr bool
 	}{
-		{"26.0.0", 26},
-		{"v26.1.2", 26},
-		{"26.0.0-beta1", 26},
-		{"4.2.0", 4},
-		{"4", 4},
-		{"", 0},
-		{"v4.2.0", 4},
-		{"26.1.3-rc1", 26},
-		{"v", 0},
-		{"abc", 0},
+		{"26.0.0", 26, false},
+		{"v26.1.2", 26, false},
+		{"26.0.0-beta1", 26, false},
+		{"4.2.0", 4, false},
+		{"4", 4, false},
+		{"v4.2.0", 4, false},
+		{"26.1.3-rc1", 26, false},
+		{"", 0, true},
+		{"v", 0, true},
+		{"abc", 0, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			major := parseVersion(tt.input)
+			major, err := parseVersion(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseVersion(%q) expected error, got %d", tt.input, major)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseVersion(%q) unexpected error: %v", tt.input, err)
+			}
 			if major != tt.major {
 				t.Errorf("parseVersion(%q) = %d, want %d", tt.input, major, tt.major)
 			}

--- a/vm.go
+++ b/vm.go
@@ -193,12 +193,6 @@ func (s *VMService) waitForPowerState(ctx context.Context, id int, desiredState 
 	}
 
 	for i := 0; i < powerStateMaxRetries; i++ {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(powerStatePollInterval):
-		}
-
 		vm, err := s.Get(ctx, id)
 		if err != nil {
 			return err
@@ -206,6 +200,12 @@ func (s *VMService) waitForPowerState(ctx context.Context, id int, desiredState 
 
 		if vm.PowerState == desiredState {
 			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(powerStatePollInterval):
 		}
 	}
 

--- a/vm.go
+++ b/vm.go
@@ -264,7 +264,7 @@ type VMCloneOptions struct {
 
 // Clone creates a copy of a VM.
 func (s *VMService) Clone(ctx context.Context, id int, opts *VMCloneOptions) error {
-	params := map[string]interface{}{}
+	params := map[string]any{}
 	if opts != nil {
 		if opts.Name != "" {
 			params["name"] = opts.Name
@@ -275,7 +275,7 @@ func (s *VMService) Clone(ctx context.Context, id int, opts *VMCloneOptions) err
 	action := struct {
 		VM     int                    `json:"vm"`
 		Action string                 `json:"action"`
-		Params map[string]interface{} `json:"params"`
+		Params map[string]any `json:"params"`
 	}{
 		VM:     id,
 		Action: vmActionClone,
@@ -298,7 +298,7 @@ type VMSnapshotOptions struct {
 
 // Snapshot takes a snapshot of a VM.
 func (s *VMService) Snapshot(ctx context.Context, id int, opts *VMSnapshotOptions) error {
-	params := map[string]interface{}{}
+	params := map[string]any{}
 	if opts != nil {
 		if opts.Retention > 0 {
 			params["retention"] = opts.Retention
@@ -309,7 +309,7 @@ func (s *VMService) Snapshot(ctx context.Context, id int, opts *VMSnapshotOption
 	action := struct {
 		VM     int                    `json:"vm"`
 		Action string                 `json:"action"`
-		Params map[string]interface{} `json:"params"`
+		Params map[string]any `json:"params"`
 	}{
 		VM:     id,
 		Action: vmActionSnapshot,
@@ -340,7 +340,7 @@ func (s *VMService) Migrate(ctx context.Context, id int, opts *VMMigrateOptions)
 		return &ValidationError{Field: "target_node", Message: "target_node is required"}
 	}
 
-	params := map[string]interface{}{
+	params := map[string]any{
 		"node": opts.TargetNode,
 	}
 
@@ -354,7 +354,7 @@ func (s *VMService) Migrate(ctx context.Context, id int, opts *VMMigrateOptions)
 	action := struct {
 		VM     int                    `json:"vm"`
 		Action string                 `json:"action"`
-		Params map[string]interface{} `json:"params"`
+		Params map[string]any `json:"params"`
 	}{
 		VM:     id,
 		Action: "migrate",

--- a/vm.go
+++ b/vm.go
@@ -209,7 +209,7 @@ func (s *VMService) waitForPowerState(ctx context.Context, id int, desiredState 
 		}
 	}
 
-	return fmt.Errorf("vergeos: timeout waiting for VM %d to become %s", id, stateStr)
+	return &TimeoutError{Resource: "VM", ID: id, Action: "become " + stateStr}
 }
 
 // Reset sends a reset signal to a running VM (equivalent to pressing the reset button).

--- a/vm_device.go
+++ b/vm_device.go
@@ -24,8 +24,9 @@ func (s *VMDeviceService) List(ctx context.Context, vmID int) ([]VMDevice, error
 
 	// Load settings for each device
 	for i := range devices {
-		// Non-fatal: continue without settings if load fails
-		_ = s.loadSettings(ctx, &devices[i])
+		if err := s.loadSettings(ctx, &devices[i]); err != nil {
+			return nil, err
+		}
 	}
 
 	return devices, nil
@@ -45,8 +46,10 @@ func (s *VMDeviceService) Get(ctx context.Context, deviceID int) (*VMDevice, err
 		return nil, err
 	}
 
-	// Load settings based on device type (non-fatal: return device without settings if load fails)
-	_ = s.loadSettings(ctx, &device)
+	// Load settings based on device type
+	if err := s.loadSettings(ctx, &device); err != nil {
+		return nil, err
+	}
 
 	return &device, nil
 }
@@ -171,8 +174,10 @@ func (s *VMDeviceService) Create(ctx context.Context, vmID int, req *VMDeviceCre
 		return nil, err
 	}
 
-	// Update device settings if provided (non-fatal: device was created but settings update may fail)
-	_ = s.updateSettings(ctx, device, req.USBSettings, req.TPMSettings, req.VGPUSettings)
+	// Update device settings if provided
+	if err := s.updateSettings(ctx, device, req.USBSettings, req.TPMSettings, req.VGPUSettings); err != nil {
+		return nil, err
+	}
 
 	// Read back with settings
 	return s.Get(ctx, id)
@@ -198,8 +203,10 @@ func (s *VMDeviceService) Update(ctx context.Context, deviceID int, req *VMDevic
 		return nil, err
 	}
 
-	// Update device settings if provided (non-fatal: device was updated but settings update may fail)
-	_ = s.updateSettings(ctx, device, req.USBSettings, req.TPMSettings, req.VGPUSettings)
+	// Update device settings if provided
+	if err := s.updateSettings(ctx, device, req.USBSettings, req.TPMSettings, req.VGPUSettings); err != nil {
+		return nil, err
+	}
 
 	// Read back with settings
 	return s.Get(ctx, deviceID)

--- a/vm_device.go
+++ b/vm_device.go
@@ -264,7 +264,7 @@ func (s *VMDeviceService) Delete(ctx context.Context, deviceID int) error {
 	endpoint := fmt.Sprintf("/machine_devices/%d", deviceID)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "VMDevice", ID: deviceID}
 		}
 		return err
 	}

--- a/vm_device.go
+++ b/vm_device.go
@@ -12,10 +12,10 @@ type VMDeviceService struct {
 }
 
 // List returns all devices for a VM.
-func (s *VMDeviceService) List(ctx context.Context, vmID int) ([]VMDevice, error) {
+func (s *VMDeviceService) List(ctx context.Context, machineID int) ([]VMDevice, error) {
 	params := url.Values{}
 	params.Set("fields", deviceListFields)
-	params.Set("filter", fmt.Sprintf("machine eq %d", vmID))
+	params.Set("filter", fmt.Sprintf("machine eq %d", machineID))
 
 	var devices []VMDevice
 	if err := s.client.get(ctx, "/machine_devices", params, &devices); err != nil {

--- a/vm_device_test.go
+++ b/vm_device_test.go
@@ -313,7 +313,10 @@ func TestVMDeviceService_Delete_NotFound(t *testing.T) {
 
 	// Delete of already-gone device should succeed (idempotent)
 	err := client.VMDevices.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("Delete of missing device should be nil, got: %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted device")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }

--- a/vm_drive.go
+++ b/vm_drive.go
@@ -118,8 +118,12 @@ func (s *VMDriveService) Create(ctx context.Context, vmID int, req *VMDriveCreat
 
 // waitForImport waits for a drive import to complete and handles resizing if needed.
 func (s *VMDriveService) waitForImport(ctx context.Context, driveID int, targetSizeGB int64) (*VMDrive, error) {
-	// Initial wait
-	time.Sleep(5 * time.Second)
+	// Initial wait before first poll
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(5 * time.Second):
+	}
 
 	for i := 0; i < importMaxRetries; i++ {
 		drive, err := s.Get(ctx, driveID)

--- a/vm_drive.go
+++ b/vm_drive.go
@@ -44,6 +44,27 @@ func (s *VMDriveService) List(ctx context.Context, vmID int) ([]VMDrive, error) 
 	return drives, nil
 }
 
+// ListAll returns all machine drives across all VMs.
+func (s *VMDriveService) ListAll(ctx context.Context, opts ...ListOption) ([]VMDrive, error) {
+	options := applyListOptions(opts)
+	if options.Fields == "most" {
+		options.Fields = driveListFields
+	}
+	params := options.toQueryParams()
+
+	var drives []VMDrive
+	if err := s.client.get(ctx, "/machine_drives", params, &drives); err != nil {
+		return nil, err
+	}
+
+	// Convert bytes to GB
+	for i := range drives {
+		drives[i].SizeGB = drives[i].SizeBytes / bytesPerGB
+	}
+
+	return drives, nil
+}
+
 // Get returns a single drive by ID.
 func (s *VMDriveService) Get(ctx context.Context, driveID int) (*VMDrive, error) {
 	params := url.Values{}

--- a/vm_drive.go
+++ b/vm_drive.go
@@ -206,7 +206,7 @@ func (s *VMDriveService) Delete(ctx context.Context, driveID int) error {
 	drive, err := s.Get(ctx, driveID)
 	if err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "VMDrive", ID: driveID}
 		}
 		return err
 	}
@@ -221,7 +221,7 @@ func (s *VMDriveService) Delete(ctx context.Context, driveID int) error {
 	endpoint := fmt.Sprintf("/machine_drives/%d", driveID)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "VMDrive", ID: driveID}
 		}
 		return err
 	}

--- a/vm_drive.go
+++ b/vm_drive.go
@@ -25,11 +25,11 @@ type VMDriveService struct {
 	client *Client
 }
 
-// List returns all drives for a VM.
-func (s *VMDriveService) List(ctx context.Context, vmID int) ([]VMDrive, error) {
+// List returns all drives for a machine.
+func (s *VMDriveService) List(ctx context.Context, machineID int) ([]VMDrive, error) {
 	params := url.Values{}
 	params.Set("fields", driveListFields)
-	params.Set("filter", fmt.Sprintf("machine eq %d", vmID))
+	params.Set("filter", fmt.Sprintf("machine eq %d", machineID))
 
 	var drives []VMDrive
 	if err := s.client.get(ctx, "/machine_drives", params, &drives); err != nil {

--- a/vm_drive.go
+++ b/vm_drive.go
@@ -172,7 +172,7 @@ func (s *VMDriveService) waitForImport(ctx context.Context, driveID int, targetS
 		}
 	}
 
-	return nil, fmt.Errorf("vergeos: timeout waiting for drive %d import to complete", driveID)
+	return nil, &TimeoutError{Resource: "VMDrive", ID: driveID, Action: "complete import"}
 }
 
 // Update updates a drive and returns the updated drive.
@@ -263,7 +263,7 @@ func (s *VMDriveService) HotplugDrive(ctx context.Context, vmID, driveID int) er
 		}
 	}
 
-	return fmt.Errorf("vergeos: timeout waiting for drive %d to hotplug", driveID)
+	return &TimeoutError{Resource: "VMDrive", ID: driveID, Action: "hotplug"}
 }
 
 // HotUnplugDrive hot-unplugs a drive from a running VM.
@@ -303,7 +303,7 @@ func (s *VMDriveService) HotUnplugDrive(ctx context.Context, vmID, driveID int) 
 		}
 	}
 
-	return fmt.Errorf("vergeos: timeout waiting for drive %d to unplug", driveID)
+	return &TimeoutError{Resource: "VMDrive", ID: driveID, Action: "unplug"}
 }
 
 // hotUnplug is the internal wrapper used by Delete.

--- a/vm_drive_test.go
+++ b/vm_drive_test.go
@@ -296,7 +296,7 @@ func TestVMDriveService_Delete_HotUnplug(t *testing.T) {
 			jsonResponse(w, 200, VMDrive{ID: FlexInt(1), Machine: 10, PowerState: state})
 		},
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "hotplugdrive" {
 				t.Errorf("expected action 'hotplugdrive', got %v", body["action"])
@@ -318,12 +318,12 @@ func TestVMDriveService_HotplugDrive(t *testing.T) {
 	getCalls := 0
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "hotplugdrive" {
 				t.Errorf("expected action 'hotplugdrive', got %v", body["action"])
 			}
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if params["device"] != "5" {
 				t.Errorf("expected device '5', got %v", params["device"])
 			}
@@ -349,12 +349,12 @@ func TestVMDriveService_HotUnplugDrive(t *testing.T) {
 	getCalls := 0
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "hotplugdrive" {
 				t.Errorf("expected action 'hotplugdrive', got %v", body["action"])
 			}
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if params["unplug"] != true {
 				t.Error("expected unplug to be true for hot-unplug")
 			}

--- a/vm_drive_test.go
+++ b/vm_drive_test.go
@@ -36,6 +36,53 @@ func TestVMDriveService_List(t *testing.T) {
 	}
 }
 
+func TestVMDriveService_ListAll(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drives": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "" {
+				t.Errorf("expected no filter for ListAll, got %q", filter)
+			}
+			jsonResponse(w, 200, []VMDrive{
+				{ID: FlexInt(1), Machine: 42, Name: "disk0", SizeBytes: 10 * bytesPerGB},
+				{ID: FlexInt(2), Machine: 99, Name: "disk1", SizeBytes: 20 * bytesPerGB},
+			})
+		},
+	}))
+
+	drives, err := client.VMDrives.ListAll(context.Background())
+	if err != nil {
+		t.Fatalf("ListAll failed: %v", err)
+	}
+	if len(drives) != 2 {
+		t.Fatalf("expected 2 drives, got %d", len(drives))
+	}
+	// Verify drives span multiple VMs
+	if drives[0].Machine == drives[1].Machine {
+		t.Error("expected drives from different VMs")
+	}
+	if drives[0].SizeGB != 10 {
+		t.Errorf("expected SizeGB 10, got %d", drives[0].SizeGB)
+	}
+}
+
+func TestVMDriveService_ListAll_WithFilter(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drives": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "status eq 'online'" {
+				t.Errorf("expected status filter, got %q", filter)
+			}
+			jsonResponse(w, 200, []VMDrive{})
+		},
+	}))
+
+	_, err := client.VMDrives.ListAll(context.Background(), WithFilter("status eq 'online'"))
+	if err != nil {
+		t.Fatalf("ListAll with filter failed: %v", err)
+	}
+}
+
 func TestVMDriveService_Get(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"GET /api/v4/machine_drives/1": func(w http.ResponseWriter, r *http.Request) {

--- a/vm_drive_test.go
+++ b/vm_drive_test.go
@@ -274,10 +274,13 @@ func TestVMDriveService_Delete_NotFound(t *testing.T) {
 		},
 	}))
 
-	// Delete of already-gone drive should succeed (idempotent)
+	// Delete of already-gone drive returns NotFoundError
 	err := client.VMDrives.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("Delete of missing drive should be nil, got: %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted drive")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }
 

--- a/vm_nic.go
+++ b/vm_nic.go
@@ -129,7 +129,7 @@ func (s *VMNICService) Delete(ctx context.Context, nicID int) error {
 	nic, err := s.Get(ctx, nicID)
 	if err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "VMNIC", ID: nicID}
 		}
 		return err
 	}
@@ -144,7 +144,7 @@ func (s *VMNICService) Delete(ctx context.Context, nicID int) error {
 	endpoint := fmt.Sprintf("/machine_nics/%d", nicID)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "VMNIC", ID: nicID}
 		}
 		return err
 	}

--- a/vm_nic.go
+++ b/vm_nic.go
@@ -89,14 +89,16 @@ func (s *VMNICService) Create(ctx context.Context, vmID int, req *VMNICCreateReq
 		return nil, err
 	}
 
-	// Assign IP address if requested (non-fatal: NIC was created but IP assignment may fail)
+	// Assign IP address if requested
 	if req.AssignIPAddress && req.VNET > 0 && nic.MAC != "" {
 		addrReq := vnetAddressRequest{
 			VNET: req.VNET,
 			MAC:  nic.MAC,
 			Type: "static",
 		}
-		_ = s.client.post(ctx, "/vnet_addresses", addrReq, nil)
+		if err := s.client.post(ctx, "/vnet_addresses", addrReq, nil); err != nil {
+			return nil, fmt.Errorf("vergeos: NIC created (ID %d) but IP assignment failed: %w", id, err)
+		}
 	}
 
 	return nic, nil

--- a/vm_nic.go
+++ b/vm_nic.go
@@ -188,5 +188,5 @@ func (s *VMNICService) hotUnplug(ctx context.Context, vmID, nicID int) error {
 		}
 	}
 
-	return fmt.Errorf("vergeos: timeout waiting for NIC %d to unplug", nicID)
+	return &TimeoutError{Resource: "VMNIC", ID: nicID, Action: "unplug"}
 }

--- a/vm_nic_test.go
+++ b/vm_nic_test.go
@@ -231,7 +231,7 @@ func TestVMNICService_Delete_HotUnplug(t *testing.T) {
 			jsonResponse(w, 200, VMNIC{ID: FlexInt(1), Machine: 10, PowerState: state})
 		},
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "hotplugnic" {
 				t.Errorf("expected action 'hotplugnic', got %v", body["action"])

--- a/vm_nic_test.go
+++ b/vm_nic_test.go
@@ -208,10 +208,13 @@ func TestVMNICService_Delete_NotFound(t *testing.T) {
 		},
 	}))
 
-	// Delete of already-gone NIC should succeed (idempotent)
+	// Delete of already-gone NIC returns NotFoundError
 	err := client.VMNICs.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("Delete of missing NIC should be nil, got: %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted NIC")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }
 

--- a/vm_snapshot.go
+++ b/vm_snapshot.go
@@ -182,7 +182,7 @@ func (s *VMSnapshotService) Restore(ctx context.Context, id int, opts *VMSnapsho
 		return err
 	}
 
-	params := map[string]interface{}{}
+	params := map[string]any{}
 	if opts != nil {
 		params["poweron"] = opts.PowerOn
 	}
@@ -190,7 +190,7 @@ func (s *VMSnapshotService) Restore(ctx context.Context, id int, opts *VMSnapsho
 	action := struct {
 		VM     int                    `json:"vm"`
 		Action string                 `json:"action"`
-		Params map[string]interface{} `json:"params"`
+		Params map[string]any `json:"params"`
 	}{
 		VM:     int(snapshot.Machine),
 		Action: "restore",

--- a/vm_snapshot.go
+++ b/vm_snapshot.go
@@ -99,7 +99,7 @@ func (s *VMSnapshotService) Get(ctx context.Context, id int) (*VMSnapshot, error
 
 // GetByName returns a VM snapshot by name within a specific VM.
 func (s *VMSnapshotService) GetByName(ctx context.Context, vmID int, name string) (*VMSnapshot, error) {
-	snapshots, err := s.ListByVM(ctx, vmID, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	snapshots, err := s.ListByVM(ctx, vmID, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/vm_snapshot_test.go
+++ b/vm_snapshot_test.go
@@ -340,7 +340,7 @@ func TestVMSnapshotService_Restore(t *testing.T) {
 			jsonResponse(w, 200, VMSnapshot{Key: FlexInt(1), Machine: FlexInt(42), Name: "snap1"})
 		},
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "restore" {
 				t.Errorf("expected action 'restore', got %v", body["action"])
@@ -348,7 +348,7 @@ func TestVMSnapshotService_Restore(t *testing.T) {
 			if int(body["vm"].(float64)) != 42 {
 				t.Errorf("expected vm 42, got %v", body["vm"])
 			}
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if int(params["snapshot"].(float64)) != 1 {
 				t.Errorf("expected snapshot param 1, got %v", params["snapshot"])
 			}
@@ -368,9 +368,9 @@ func TestVMSnapshotService_Restore_WithPowerOn(t *testing.T) {
 			jsonResponse(w, 200, VMSnapshot{Key: FlexInt(1), Machine: FlexInt(42)})
 		},
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if params["poweron"] != true {
 				t.Errorf("expected poweron true, got %v", params["poweron"])
 			}

--- a/vm_test.go
+++ b/vm_test.go
@@ -362,7 +362,7 @@ func TestVMService_PowerOn(t *testing.T) {
 			jsonResponse(w, 200, VM{ID: 1, Name: "vm", PowerState: running})
 		},
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "poweron" {
 				t.Errorf("expected action 'poweron', got %v", body["action"])
@@ -423,7 +423,7 @@ func TestVMService_PowerOff(t *testing.T) {
 			jsonResponse(w, 200, VM{ID: 1, Name: "vm", PowerState: running})
 		},
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "kill" {
 				t.Errorf("expected action 'kill', got %v", body["action"])
@@ -445,7 +445,7 @@ func TestVMService_PowerOff(t *testing.T) {
 func TestVMService_Reset(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "reset" {
 				t.Errorf("expected action 'reset', got %v", body["action"])
@@ -483,7 +483,7 @@ func TestVMService_Reset_ServerError(t *testing.T) {
 func TestVMService_GuestReboot(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "guestreboot" {
 				t.Errorf("expected action 'guestreboot', got %v", body["action"])
@@ -521,7 +521,7 @@ func TestVMService_GuestReboot_ServerError(t *testing.T) {
 func TestVMService_GuestShutdown(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "poweroff" {
 				t.Errorf("expected action 'poweroff', got %v", body["action"])
@@ -559,7 +559,7 @@ func TestVMService_GuestShutdown_ServerError(t *testing.T) {
 func TestVMService_Clone(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "clone" {
 				t.Errorf("expected action 'clone', got %v", body["action"])
@@ -567,7 +567,7 @@ func TestVMService_Clone(t *testing.T) {
 			if int(body["vm"].(float64)) != 1 {
 				t.Errorf("expected vm 1, got %v", body["vm"])
 			}
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if params["name"] != "cloned-vm" {
 				t.Errorf("expected clone name 'cloned-vm', got %v", params["name"])
 			}
@@ -584,7 +584,7 @@ func TestVMService_Clone(t *testing.T) {
 func TestVMService_Clone_NilOpts(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "clone" {
 				t.Errorf("expected action 'clone', got %v", body["action"])
@@ -602,9 +602,9 @@ func TestVMService_Clone_NilOpts(t *testing.T) {
 func TestVMService_Clone_PreserveMACs(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if params["preserve_macs"] != true {
 				t.Errorf("expected preserve_macs true, got %v", params["preserve_macs"])
 			}
@@ -638,7 +638,7 @@ func TestVMService_Clone_ServerError(t *testing.T) {
 func TestVMService_Snapshot(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "quiesce_snapshot" {
 				t.Errorf("expected action 'quiesce_snapshot', got %v", body["action"])
@@ -646,7 +646,7 @@ func TestVMService_Snapshot(t *testing.T) {
 			if int(body["vm"].(float64)) != 2 {
 				t.Errorf("expected vm 2, got %v", body["vm"])
 			}
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if int(params["retention"].(float64)) != 3600 {
 				t.Errorf("expected retention 3600, got %v", params["retention"])
 			}
@@ -663,7 +663,7 @@ func TestVMService_Snapshot(t *testing.T) {
 func TestVMService_Snapshot_NilOpts(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "quiesce_snapshot" {
 				t.Errorf("expected action 'quiesce_snapshot', got %v", body["action"])
@@ -681,9 +681,9 @@ func TestVMService_Snapshot_NilOpts(t *testing.T) {
 func TestVMService_Snapshot_WithQuiesce(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if params["quiesce"] != true {
 				t.Errorf("expected quiesce true, got %v", params["quiesce"])
 			}
@@ -717,7 +717,7 @@ func TestVMService_Snapshot_ServerError(t *testing.T) {
 func TestVMService_Migrate(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "migrate" {
 				t.Errorf("expected action 'migrate', got %v", body["action"])
@@ -725,7 +725,7 @@ func TestVMService_Migrate(t *testing.T) {
 			if int(body["vm"].(float64)) != 1 {
 				t.Errorf("expected vm 1, got %v", body["vm"])
 			}
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if int(params["node"].(float64)) != 3 {
 				t.Errorf("expected node 3, got %v", params["node"])
 			}
@@ -745,9 +745,9 @@ func TestVMService_Migrate(t *testing.T) {
 func TestVMService_Migrate_NonLive(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if params["method"] != "auto" {
 				t.Errorf("expected method 'auto', got %v", params["method"])
 			}

--- a/vnet_address.go
+++ b/vnet_address.go
@@ -38,7 +38,7 @@ func (s *VNetAddressService) ListByNetwork(ctx context.Context, vnetID int, opts
 
 // ListByType returns all addresses of a specific type within a network.
 func (s *VNetAddressService) ListByType(ctx context.Context, vnetID int, addrType string, opts ...ListOption) ([]VNetAddress, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("vnet eq %d and type eq '%s'", vnetID, addrType))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("vnet eq %d and type eq '%s'", vnetID, escapeFilterValue(addrType)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }
@@ -62,7 +62,7 @@ func (s *VNetAddressService) Get(ctx context.Context, id int) (*VNetAddress, err
 
 // GetByIP returns an address by IP within a specific network.
 func (s *VNetAddressService) GetByIP(ctx context.Context, vnetID int, ip string) (*VNetAddress, error) {
-	addresses, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and ip eq '%s'", vnetID, ip)))
+	addresses, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and ip eq '%s'", vnetID, escapeFilterValue(ip))))
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (s *VNetAddressService) GetByIP(ctx context.Context, vnetID int, ip string)
 
 // GetByMAC returns an address by MAC address within a specific network.
 func (s *VNetAddressService) GetByMAC(ctx context.Context, vnetID int, mac string) (*VNetAddress, error) {
-	addresses, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and mac eq '%s'", vnetID, mac)))
+	addresses, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and mac eq '%s'", vnetID, escapeFilterValue(mac))))
 	if err != nil {
 		return nil, err
 	}

--- a/vnet_address.go
+++ b/vnet_address.go
@@ -52,7 +52,7 @@ func (s *VNetAddressService) Get(ctx context.Context, id int) (*VNetAddress, err
 	endpoint := fmt.Sprintf("/vnet_addresses/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &address); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetAddress", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetAddress", ID: id}
 		}
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (s *VNetAddressService) Update(ctx context.Context, id int, req *VNetAddres
 	endpoint := fmt.Sprintf("/vnet_addresses/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetAddress", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetAddress", ID: id}
 		}
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (s *VNetAddressService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_addresses/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetAddress", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetAddress", ID: id}
 		}
 		return err
 	}

--- a/vnet_address_test.go
+++ b/vnet_address_test.go
@@ -185,7 +185,7 @@ func TestVNetAddressService_Create(t *testing.T) {
 			if req.Type != "static" {
 				t.Errorf("expected type 'static', got %q", req.Type)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 5, "status": "ok"})
+			jsonResponse(w, 200, map[string]any{"$key": 5, "status": "ok"})
 		},
 		"GET /api/v4/vnet_addresses/5": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetAddress{Key: 5, VNet: 10, IP: "192.168.1.200", Type: "static"})

--- a/vnet_dns.go
+++ b/vnet_dns.go
@@ -55,7 +55,7 @@ func (s *VNetDNSViewService) Get(ctx context.Context, id int) (*VNetDNSView, err
 
 // GetByName returns a DNS view by name within a specific network.
 func (s *VNetDNSViewService) GetByName(ctx context.Context, vnetID int, name string) (*VNetDNSView, error) {
-	views, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and name eq '%s'", vnetID, name)))
+	views, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and name eq '%s'", vnetID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +168,7 @@ func (s *VNetDNSZoneService) Get(ctx context.Context, id int) (*VNetDNSZone, err
 
 // GetByDomain returns a DNS zone by domain name within a specific view.
 func (s *VNetDNSZoneService) GetByDomain(ctx context.Context, viewID int, domain string) (*VNetDNSZone, error) {
-	zones, err := s.List(ctx, WithFilter(fmt.Sprintf("view eq %d and domain eq '%s'", viewID, domain)))
+	zones, err := s.List(ctx, WithFilter(fmt.Sprintf("view eq %d and domain eq '%s'", viewID, escapeFilterValue(domain))))
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +264,7 @@ func (s *VNetDNSRecordService) ListByZone(ctx context.Context, zoneID int, opts 
 
 // ListByType returns all DNS records of a specific type within a zone.
 func (s *VNetDNSRecordService) ListByType(ctx context.Context, zoneID int, recordType string, opts ...ListOption) ([]VNetDNSRecord, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("zone eq %d and type eq '%s'", zoneID, recordType))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("zone eq %d and type eq '%s'", zoneID, escapeFilterValue(recordType)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }
@@ -288,7 +288,7 @@ func (s *VNetDNSRecordService) Get(ctx context.Context, id int) (*VNetDNSRecord,
 
 // GetByHostAndType returns a DNS record by host and type within a zone.
 func (s *VNetDNSRecordService) GetByHostAndType(ctx context.Context, zoneID int, host, recordType string) (*VNetDNSRecord, error) {
-	records, err := s.List(ctx, WithFilter(fmt.Sprintf("zone eq %d and host eq '%s' and type eq '%s'", zoneID, host, recordType)))
+	records, err := s.List(ctx, WithFilter(fmt.Sprintf("zone eq %d and host eq '%s' and type eq '%s'", zoneID, escapeFilterValue(host), escapeFilterValue(recordType))))
 	if err != nil {
 		return nil, err
 	}

--- a/vnet_dns.go
+++ b/vnet_dns.go
@@ -45,7 +45,7 @@ func (s *VNetDNSViewService) Get(ctx context.Context, id int) (*VNetDNSView, err
 	endpoint := fmt.Sprintf("/vnet_dns_views/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &view); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetDNSView", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetDNSView", ID: id}
 		}
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (s *VNetDNSViewService) Update(ctx context.Context, id int, req *VNetDNSVie
 	endpoint := fmt.Sprintf("/vnet_dns_views/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetDNSView", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetDNSView", ID: id}
 		}
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (s *VNetDNSViewService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_dns_views/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetDNSView", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetDNSView", ID: id}
 		}
 		return err
 	}
@@ -158,7 +158,7 @@ func (s *VNetDNSZoneService) Get(ctx context.Context, id int) (*VNetDNSZone, err
 	endpoint := fmt.Sprintf("/vnet_dns_zones/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &zone); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetDNSZone", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetDNSZone", ID: id}
 		}
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func (s *VNetDNSZoneService) Update(ctx context.Context, id int, req *VNetDNSZon
 	endpoint := fmt.Sprintf("/vnet_dns_zones/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetDNSZone", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetDNSZone", ID: id}
 		}
 		return nil, err
 	}
@@ -225,7 +225,7 @@ func (s *VNetDNSZoneService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_dns_zones/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetDNSZone", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetDNSZone", ID: id}
 		}
 		return err
 	}
@@ -278,7 +278,7 @@ func (s *VNetDNSRecordService) Get(ctx context.Context, id int) (*VNetDNSRecord,
 	endpoint := fmt.Sprintf("/vnet_dns_zone_records/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &record); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetDNSRecord", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetDNSRecord", ID: id}
 		}
 		return nil, err
 	}
@@ -335,7 +335,7 @@ func (s *VNetDNSRecordService) Update(ctx context.Context, id int, req *VNetDNSR
 	endpoint := fmt.Sprintf("/vnet_dns_zone_records/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetDNSRecord", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetDNSRecord", ID: id}
 		}
 		return nil, err
 	}
@@ -348,7 +348,7 @@ func (s *VNetDNSRecordService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_dns_zone_records/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetDNSRecord", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetDNSRecord", ID: id}
 		}
 		return err
 	}

--- a/vnet_dns_test.go
+++ b/vnet_dns_test.go
@@ -132,7 +132,7 @@ func TestVNetDNSViewService_Create(t *testing.T) {
 			if req.VNet != 10 {
 				t.Errorf("expected vnet 10, got %d", req.VNet)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 3, "status": "ok"})
+			jsonResponse(w, 200, map[string]any{"$key": 3, "status": "ok"})
 		},
 		"GET /api/v4/vnet_dns_views/3": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetDNSView{Key: 3, VNet: 10, Name: "internal"})
@@ -378,7 +378,7 @@ func TestVNetDNSZoneService_Create(t *testing.T) {
 			if req.View != 1 {
 				t.Errorf("expected view 1, got %d", req.View)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 5, "status": "ok"})
+			jsonResponse(w, 200, map[string]any{"$key": 5, "status": "ok"})
 		},
 		"GET /api/v4/vnet_dns_zones/5": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetDNSZone{Key: 5, View: 1, Domain: "test.local", Type: "master"})
@@ -647,7 +647,7 @@ func TestVNetDNSRecordService_Create(t *testing.T) {
 			if req.Value != "192.168.1.30" {
 				t.Errorf("expected value '192.168.1.30', got %q", req.Value)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 5, "status": "ok"})
+			jsonResponse(w, 200, map[string]any{"$key": 5, "status": "ok"})
 		},
 		"GET /api/v4/vnet_dns_zone_records/5": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetDNSRecord{Key: 5, Zone: 1, Host: "api", Type: "A", Value: "192.168.1.30"})

--- a/vnet_host.go
+++ b/vnet_host.go
@@ -46,7 +46,7 @@ func (s *VNetHostService) Get(ctx context.Context, id int) (*VNetHost, error) {
 	endpoint := fmt.Sprintf("/vnet_hosts/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &host); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetHost", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetHost", ID: id}
 		}
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (s *VNetHostService) Update(ctx context.Context, id int, req *VNetHostUpdat
 	endpoint := fmt.Sprintf("/vnet_hosts/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetHost", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetHost", ID: id}
 		}
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (s *VNetHostService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_hosts/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetHost", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetHost", ID: id}
 		}
 		return err
 	}

--- a/vnet_host.go
+++ b/vnet_host.go
@@ -56,7 +56,7 @@ func (s *VNetHostService) Get(ctx context.Context, id int) (*VNetHost, error) {
 
 // GetByHost returns a host override by hostname within a specific network.
 func (s *VNetHostService) GetByHost(ctx context.Context, vnetID int, hostname string) (*VNetHost, error) {
-	hosts, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and host eq '%s'", vnetID, hostname)))
+	hosts, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and host eq '%s'", vnetID, escapeFilterValue(hostname))))
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (s *VNetHostService) GetByHost(ctx context.Context, vnetID int, hostname st
 
 // GetByIP returns a host override by IP address within a specific network.
 func (s *VNetHostService) GetByIP(ctx context.Context, vnetID int, ip string) (*VNetHost, error) {
-	hosts, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and ip eq '%s'", vnetID, ip)))
+	hosts, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and ip eq '%s'", vnetID, escapeFilterValue(ip))))
 	if err != nil {
 		return nil, err
 	}

--- a/vnet_host_test.go
+++ b/vnet_host_test.go
@@ -168,7 +168,7 @@ func TestVNetHostService_Create(t *testing.T) {
 			if req.IP != "192.168.1.50" {
 				t.Errorf("expected IP '192.168.1.50', got %q", req.IP)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 5, "status": "ok"})
+			jsonResponse(w, 200, map[string]any{"$key": 5, "status": "ok"})
 		},
 		"GET /api/v4/vnet_hosts/5": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetHost{Key: 5, VNet: 10, Host: "db-server", IP: "192.168.1.50", Type: "host"})

--- a/vnet_ipsec.go
+++ b/vnet_ipsec.go
@@ -158,7 +158,7 @@ func (s *VNetIPSecPhase1Service) Get(ctx context.Context, id int) (*VNetIPSecPha
 
 // GetByName returns a Phase 1 configuration by name within an IPSec configuration.
 func (s *VNetIPSecPhase1Service) GetByName(ctx context.Context, ipsecID int, name string) (*VNetIPSecPhase1, error) {
-	phase1s, err := s.List(ctx, WithFilter(fmt.Sprintf("ipsec eq %d and name eq '%s'", ipsecID, name)))
+	phase1s, err := s.List(ctx, WithFilter(fmt.Sprintf("ipsec eq %d and name eq '%s'", ipsecID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +274,7 @@ func (s *VNetIPSecPhase2Service) Get(ctx context.Context, id int) (*VNetIPSecPha
 
 // GetByName returns a Phase 2 configuration by name within a Phase 1.
 func (s *VNetIPSecPhase2Service) GetByName(ctx context.Context, phase1ID int, name string) (*VNetIPSecPhase2, error) {
-	phase2s, err := s.List(ctx, WithFilter(fmt.Sprintf("phase1 eq %d and name eq '%s'", phase1ID, name)))
+	phase2s, err := s.List(ctx, WithFilter(fmt.Sprintf("phase1 eq %d and name eq '%s'", phase1ID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/vnet_ipsec.go
+++ b/vnet_ipsec.go
@@ -38,7 +38,7 @@ func (s *VNetIPSecService) Get(ctx context.Context, id int) (*VNetIPSec, error) 
 	endpoint := fmt.Sprintf("/vnet_ipsecs/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &ipsec); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetIPSec", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetIPSec", ID: id}
 		}
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (s *VNetIPSecService) Update(ctx context.Context, id int, req *VNetIPSecUpd
 	endpoint := fmt.Sprintf("/vnet_ipsecs/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetIPSec", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetIPSec", ID: id}
 		}
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (s *VNetIPSecService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_ipsecs/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetIPSec", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetIPSec", ID: id}
 		}
 		return err
 	}
@@ -148,7 +148,7 @@ func (s *VNetIPSecPhase1Service) Get(ctx context.Context, id int) (*VNetIPSecPha
 	endpoint := fmt.Sprintf("/vnet_ipsec_phase1s/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &phase1); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetIPSecPhase1", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetIPSecPhase1", ID: id}
 		}
 		return nil, err
 	}
@@ -205,7 +205,7 @@ func (s *VNetIPSecPhase1Service) Update(ctx context.Context, id int, req *VNetIP
 	endpoint := fmt.Sprintf("/vnet_ipsec_phase1s/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetIPSecPhase1", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetIPSecPhase1", ID: id}
 		}
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func (s *VNetIPSecPhase1Service) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_ipsec_phase1s/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetIPSecPhase1", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetIPSecPhase1", ID: id}
 		}
 		return err
 	}
@@ -264,7 +264,7 @@ func (s *VNetIPSecPhase2Service) Get(ctx context.Context, id int) (*VNetIPSecPha
 	endpoint := fmt.Sprintf("/vnet_ipsec_phase2s/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &phase2); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetIPSecPhase2", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetIPSecPhase2", ID: id}
 		}
 		return nil, err
 	}
@@ -321,7 +321,7 @@ func (s *VNetIPSecPhase2Service) Update(ctx context.Context, id int, req *VNetIP
 	endpoint := fmt.Sprintf("/vnet_ipsec_phase2s/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetIPSecPhase2", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetIPSecPhase2", ID: id}
 		}
 		return nil, err
 	}
@@ -334,7 +334,7 @@ func (s *VNetIPSecPhase2Service) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_ipsec_phase2s/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetIPSecPhase2", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetIPSecPhase2", ID: id}
 		}
 		return err
 	}
@@ -387,7 +387,7 @@ func (s *VNetIPSecConnectionService) Get(ctx context.Context, id int) (*VNetIPSe
 	endpoint := fmt.Sprintf("/vnet_ipsec_connections/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &conn); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetIPSecConnection", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetIPSecConnection", ID: id}
 		}
 		return nil, err
 	}

--- a/vnet_ipsec_test.go
+++ b/vnet_ipsec_test.go
@@ -112,7 +112,7 @@ func TestVNetIPSecService_Create(t *testing.T) {
 			if req.VNet != 10 {
 				t.Errorf("expected vnet 10, got %d", req.VNet)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/vnet_ipsecs/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetIPSec{Key: 1, VNet: 10, Enabled: true, Mode: "normal"})
@@ -331,7 +331,7 @@ func TestVNetIPSecPhase1Service_Create(t *testing.T) {
 			if req.Name != "phase1-a" {
 				t.Errorf("expected name 'phase1-a', got %q", req.Name)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/vnet_ipsec_phase1s/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetIPSecPhase1{Key: 1, IPSec: 5, Name: "phase1-a", RemoteGateway: "1.2.3.4"})
@@ -587,7 +587,7 @@ func TestVNetIPSecPhase2Service_Create(t *testing.T) {
 			if req.Name != "phase2-a" {
 				t.Errorf("expected name 'phase2-a', got %q", req.Name)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/vnet_ipsec_phase2s/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetIPSecPhase2{Key: 1, Phase1: 3, Name: "phase2-a", Local: "10.0.0.0/24"})

--- a/vnet_rule.go
+++ b/vnet_rule.go
@@ -57,7 +57,7 @@ func (s *VNetRuleService) Get(ctx context.Context, id int) (*VNetRule, error) {
 
 // GetByName returns a firewall rule by name within a specific network.
 func (s *VNetRuleService) GetByName(ctx context.Context, vnetID int, name string) (*VNetRule, error) {
-	rules, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and name eq '%s'", vnetID, name)))
+	rules, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and name eq '%s'", vnetID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func (s *VNetRuleAliasService) Get(ctx context.Context, id int) (*VNetRuleAlias,
 
 // GetByName returns a rule alias by name.
 func (s *VNetRuleAliasService) GetByName(ctx context.Context, name string) (*VNetRuleAlias, error) {
-	aliases, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	aliases, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/vnet_rule.go
+++ b/vnet_rule.go
@@ -47,7 +47,7 @@ func (s *VNetRuleService) Get(ctx context.Context, id int) (*VNetRule, error) {
 	endpoint := fmt.Sprintf("/vnet_rules/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &rule); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetRule", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetRule", ID: id}
 		}
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (s *VNetRuleService) Update(ctx context.Context, id int, req *VNetRuleUpdat
 	endpoint := fmt.Sprintf("/vnet_rules/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetRule", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetRule", ID: id}
 		}
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (s *VNetRuleService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_rules/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetRule", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetRule", ID: id}
 		}
 		return err
 	}
@@ -208,7 +208,7 @@ func (s *VNetRuleAliasService) Get(ctx context.Context, id int) (*VNetRuleAlias,
 	endpoint := fmt.Sprintf("/vnet_rule_aliases/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &alias); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetRuleAlias", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetRuleAlias", ID: id}
 		}
 		return nil, err
 	}
@@ -265,7 +265,7 @@ func (s *VNetRuleAliasService) Update(ctx context.Context, id int, req *VNetRule
 	endpoint := fmt.Sprintf("/vnet_rule_aliases/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetRuleAlias", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetRuleAlias", ID: id}
 		}
 		return nil, err
 	}
@@ -279,7 +279,7 @@ func (s *VNetRuleAliasService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_rule_aliases/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetRuleAlias", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetRuleAlias", ID: id}
 		}
 		return err
 	}

--- a/vnet_rule_test.go
+++ b/vnet_rule_test.go
@@ -132,7 +132,7 @@ func TestVNetRuleService_Create(t *testing.T) {
 			if req.VNet != 10 {
 				t.Errorf("expected vnet 10, got %d", req.VNet)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 5, "status": "ok"})
+			jsonResponse(w, 200, map[string]any{"$key": 5, "status": "ok"})
 		},
 		"GET /api/v4/vnet_rules/5": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetRule{Key: 5, VNet: 10, Name: "allow-http", Action: "accept", Enabled: true})
@@ -418,7 +418,7 @@ func TestVNetRuleAliasService_Create(t *testing.T) {
 			if req.Name != "web-servers" {
 				t.Errorf("expected name 'web-servers', got %q", req.Name)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 3, "status": "ok"})
+			jsonResponse(w, 200, map[string]any{"$key": 3, "status": "ok"})
 		},
 		"GET /api/v4/vnet_rule_aliases/3": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetRuleAlias{Key: 3, Name: "web-servers", Value: "192.168.1.10,192.168.1.11"})

--- a/vnet_wireguard.go
+++ b/vnet_wireguard.go
@@ -55,7 +55,7 @@ func (s *VNetWireGuardService) Get(ctx context.Context, id int) (*VNetWireGuard,
 
 // GetByName returns a WireGuard interface by name within a specific network.
 func (s *VNetWireGuardService) GetByName(ctx context.Context, vnetID int, name string) (*VNetWireGuard, error) {
-	wgs, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and name eq '%s'", vnetID, name)))
+	wgs, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and name eq '%s'", vnetID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +171,7 @@ func (s *VNetWireGuardPeerService) Get(ctx context.Context, id int) (*VNetWireGu
 
 // GetByName returns a WireGuard peer by name within a specific WireGuard interface.
 func (s *VNetWireGuardPeerService) GetByName(ctx context.Context, wireguardID int, name string) (*VNetWireGuardPeer, error) {
-	peers, err := s.List(ctx, WithFilter(fmt.Sprintf("wireguard eq %d and name eq '%s'", wireguardID, name)))
+	peers, err := s.List(ctx, WithFilter(fmt.Sprintf("wireguard eq %d and name eq '%s'", wireguardID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/vnet_wireguard.go
+++ b/vnet_wireguard.go
@@ -45,7 +45,7 @@ func (s *VNetWireGuardService) Get(ctx context.Context, id int) (*VNetWireGuard,
 	endpoint := fmt.Sprintf("/vnet_wireguards/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &wg); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetWireGuard", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetWireGuard", ID: id}
 		}
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (s *VNetWireGuardService) Update(ctx context.Context, id int, req *VNetWire
 	endpoint := fmt.Sprintf("/vnet_wireguards/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetWireGuard", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetWireGuard", ID: id}
 		}
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (s *VNetWireGuardService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_wireguards/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetWireGuard", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetWireGuard", ID: id}
 		}
 		return err
 	}
@@ -161,7 +161,7 @@ func (s *VNetWireGuardPeerService) Get(ctx context.Context, id int) (*VNetWireGu
 	endpoint := fmt.Sprintf("/vnet_wireguard_peers/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &peer); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetWireGuardPeer", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetWireGuardPeer", ID: id}
 		}
 		return nil, err
 	}
@@ -224,7 +224,7 @@ func (s *VNetWireGuardPeerService) Update(ctx context.Context, id int, req *VNet
 	endpoint := fmt.Sprintf("/vnet_wireguard_peers/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetWireGuardPeer", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetWireGuardPeer", ID: id}
 		}
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (s *VNetWireGuardPeerService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_wireguard_peers/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetWireGuardPeer", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetWireGuardPeer", ID: id}
 		}
 		return err
 	}
@@ -256,7 +256,7 @@ func (s *VNetWireGuardPeerService) GetConfig(ctx context.Context, id int) (strin
 	endpoint := fmt.Sprintf("/vnet_wireguard_peers/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &result); err != nil {
 		if IsNotFoundError(err) {
-			return "", &NotFoundError{Resource: "VNetWireGuardPeer", ID: fmt.Sprintf("%d", id)}
+			return "", &NotFoundError{Resource: "VNetWireGuardPeer", ID: id}
 		}
 		return "", err
 	}
@@ -296,7 +296,7 @@ func (s *VNetWireGuardPeerStatusService) Get(ctx context.Context, id int) (*VNet
 	endpoint := fmt.Sprintf("/vnet_wireguard_peer_status/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &status); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetWireGuardPeerStatus", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetWireGuardPeerStatus", ID: id}
 		}
 		return nil, err
 	}

--- a/vnet_wireguard_test.go
+++ b/vnet_wireguard_test.go
@@ -134,7 +134,7 @@ func TestVNetWireGuardService_Create(t *testing.T) {
 			if req.VNet != 10 {
 				t.Errorf("expected vnet 10, got %d", req.VNet)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/vnet_wireguards/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetWireGuard{Key: 1, VNet: 10, Name: "wg0", IP: "10.0.0.1/24"})
@@ -395,7 +395,7 @@ func TestVNetWireGuardPeerService_Create(t *testing.T) {
 			if req.Name != "peer-a" {
 				t.Errorf("expected name 'peer-a', got %q", req.Name)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/vnet_wireguard_peers/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetWireGuardPeer{Key: 1, WireGuard: 5, Name: "peer-a", PeerIP: "10.0.0.2", PublicKey: "abc123", AllowedIPs: "10.0.0.0/24"})

--- a/volume.go
+++ b/volume.go
@@ -55,7 +55,7 @@ func (s *VolumeService) Get(ctx context.Context, id string) (*Volume, error) {
 
 // GetByName returns a single volume by name within a service.
 func (s *VolumeService) GetByName(ctx context.Context, serviceID int, name string) (*Volume, error) {
-	volumes, err := s.List(ctx, WithFilter(fmt.Sprintf("service eq %d and name eq '%s'", serviceID, name)))
+	volumes, err := s.List(ctx, WithFilter(fmt.Sprintf("service eq %d and name eq '%s'", serviceID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/volume.go
+++ b/volume.go
@@ -134,7 +134,7 @@ func (s *VolumeService) Enable(ctx context.Context, id string) error {
 	action := volumeAction{
 		Volume: id,
 		Action: "enable",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	if err := s.client.post(ctx, "/volume_actions", action, nil); err != nil {
@@ -148,7 +148,7 @@ func (s *VolumeService) Disable(ctx context.Context, id string) error {
 	action := volumeAction{
 		Volume: id,
 		Action: "disable",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	if err := s.client.post(ctx, "/volume_actions", action, nil); err != nil {
@@ -162,7 +162,7 @@ func (s *VolumeService) Reset(ctx context.Context, id string) error {
 	action := volumeAction{
 		Volume: id,
 		Action: "reset",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	if err := s.client.post(ctx, "/volume_actions", action, nil); err != nil {
@@ -175,7 +175,7 @@ func (s *VolumeService) Reset(ctx context.Context, id string) error {
 type volumeAction struct {
 	Volume string                 `json:"volume"`
 	Action string                 `json:"action"`
-	Params map[string]interface{} `json:"params"`
+	Params map[string]any `json:"params"`
 }
 
 // getStringKey extracts a string key from an API response.

--- a/volume_browser.go
+++ b/volume_browser.go
@@ -183,5 +183,5 @@ func (s *VolumeBrowserService) List(ctx context.Context, opts ...ListOption) ([]
 
 // ListByVolume returns all browse jobs for a specific volume.
 func (s *VolumeBrowserService) ListByVolume(ctx context.Context, volumeID string, opts ...ListOption) ([]VolumeBrowserJob, error) {
-	return s.List(ctx, append(opts, WithFilter(fmt.Sprintf("volume eq '%s'", volumeID)))...)
+	return s.List(ctx, append(opts, WithFilter(fmt.Sprintf("volume eq '%s'", escapeFilterValue(volumeID))))...)
 }

--- a/volume_browser_test.go
+++ b/volume_browser_test.go
@@ -19,7 +19,7 @@ func TestVolumeBrowserService_CreateJob(t *testing.T) {
 				t.Errorf("expected query 'get-dir', got %q", req.Query)
 			}
 			// Return the job ID as a string key
-			jsonResponse(w, 200, map[string]interface{}{
+			jsonResponse(w, 200, map[string]any{
 				"$key": "abc123sha1hash",
 			})
 		},

--- a/volume_share.go
+++ b/volume_share.go
@@ -32,7 +32,7 @@ func (s *VolumeCIFSShareService) List(ctx context.Context, opts ...ListOption) (
 
 // ListByVolume returns all CIFS shares belonging to a specific volume.
 func (s *VolumeCIFSShareService) ListByVolume(ctx context.Context, volumeID string, opts ...ListOption) ([]VolumeCIFSShare, error) {
-	return s.List(ctx, append(opts, WithFilter(fmt.Sprintf("volume eq '%s'", volumeID)))...)
+	return s.List(ctx, append(opts, WithFilter(fmt.Sprintf("volume eq '%s'", escapeFilterValue(volumeID))))...)
 }
 
 // Get returns a single CIFS share by its SHA1 ID.
@@ -54,7 +54,7 @@ func (s *VolumeCIFSShareService) Get(ctx context.Context, id string) (*VolumeCIF
 
 // GetByName returns a single CIFS share by name within a volume.
 func (s *VolumeCIFSShareService) GetByName(ctx context.Context, volumeID, name string) (*VolumeCIFSShare, error) {
-	shares, err := s.List(ctx, WithFilter(fmt.Sprintf("volume eq '%s' and name eq '%s'", volumeID, name)))
+	shares, err := s.List(ctx, WithFilter(fmt.Sprintf("volume eq '%s' and name eq '%s'", escapeFilterValue(volumeID), escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func (s *VolumeNFSShareService) List(ctx context.Context, opts ...ListOption) ([
 
 // ListByVolume returns all NFS shares belonging to a specific volume.
 func (s *VolumeNFSShareService) ListByVolume(ctx context.Context, volumeID string, opts ...ListOption) ([]VolumeNFSShare, error) {
-	return s.List(ctx, append(opts, WithFilter(fmt.Sprintf("volume eq '%s'", volumeID)))...)
+	return s.List(ctx, append(opts, WithFilter(fmt.Sprintf("volume eq '%s'", escapeFilterValue(volumeID))))...)
 }
 
 // Get returns a single NFS share by its SHA1 ID.
@@ -176,7 +176,7 @@ func (s *VolumeNFSShareService) Get(ctx context.Context, id string) (*VolumeNFSS
 
 // GetByName returns a single NFS share by name within a volume.
 func (s *VolumeNFSShareService) GetByName(ctx context.Context, volumeID, name string) (*VolumeNFSShare, error) {
-	shares, err := s.List(ctx, WithFilter(fmt.Sprintf("volume eq '%s' and name eq '%s'", volumeID, name)))
+	shares, err := s.List(ctx, WithFilter(fmt.Sprintf("volume eq '%s' and name eq '%s'", escapeFilterValue(volumeID), escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/volume_snapshot.go
+++ b/volume_snapshot.go
@@ -70,7 +70,7 @@ func (s *VolumeSnapshotService) Get(ctx context.Context, id int) (*VolumeSnapsho
 
 // GetByName returns a volume snapshot by name within a specific volume.
 func (s *VolumeSnapshotService) GetByName(ctx context.Context, volumeID int, name string) (*VolumeSnapshot, error) {
-	snapshots, err := s.List(ctx, WithFilter(fmt.Sprintf("volume eq %d and name eq '%s'", volumeID, name)))
+	snapshots, err := s.List(ctx, WithFilter(fmt.Sprintf("volume eq %d and name eq '%s'", volumeID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/volume_sync.go
+++ b/volume_sync.go
@@ -156,7 +156,7 @@ func (s *VolumeSyncService) Disable(ctx context.Context, id string) error {
 type volumeSyncAction struct {
 	Sync   string                 `json:"sync"`
 	Action string                 `json:"action"`
-	Params map[string]interface{} `json:"params"`
+	Params map[string]any `json:"params"`
 }
 
 // Start starts a volume sync job immediately.
@@ -164,7 +164,7 @@ func (s *VolumeSyncService) Start(ctx context.Context, id string) error {
 	action := volumeSyncAction{
 		Sync:   id,
 		Action: "start",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	if err := s.client.post(ctx, "/volume_sync_actions", action, nil); err != nil {
@@ -178,7 +178,7 @@ func (s *VolumeSyncService) Stop(ctx context.Context, id string) error {
 	action := volumeSyncAction{
 		Sync:   id,
 		Action: "stop",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	if err := s.client.post(ctx, "/volume_sync_actions", action, nil); err != nil {

--- a/volume_sync.go
+++ b/volume_sync.go
@@ -60,7 +60,7 @@ func (s *VolumeSyncService) Get(ctx context.Context, id string) (*VolumeSync, er
 
 // GetByName returns a volume sync by name within a specific service.
 func (s *VolumeSyncService) GetByName(ctx context.Context, serviceID int, name string) (*VolumeSync, error) {
-	syncs, err := s.List(ctx, WithFilter(fmt.Sprintf("service eq %d and name eq '%s'", serviceID, name)))
+	syncs, err := s.List(ctx, WithFilter(fmt.Sprintf("service eq %d and name eq '%s'", serviceID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/webhook.go
+++ b/webhook.go
@@ -38,7 +38,7 @@ func (s *WebhookURLService) Get(ctx context.Context, id int) (*WebhookURL, error
 	endpoint := fmt.Sprintf("/webhook_urls/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &webhook); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "WebhookURL", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "WebhookURL", ID: id}
 		}
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (s *WebhookURLService) Update(ctx context.Context, id int, req *WebhookURLU
 	endpoint := fmt.Sprintf("/webhook_urls/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "WebhookURL", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "WebhookURL", ID: id}
 		}
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (s *WebhookURLService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/webhook_urls/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "WebhookURL", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "WebhookURL", ID: id}
 		}
 		return err
 	}
@@ -192,7 +192,7 @@ func (s *WebhookService) Get(ctx context.Context, id int) (*Webhook, error) {
 	endpoint := fmt.Sprintf("/webhooks/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &webhook); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Webhook", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Webhook", ID: id}
 		}
 		return nil, err
 	}
@@ -205,7 +205,7 @@ func (s *WebhookService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/webhooks/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "Webhook", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "Webhook", ID: id}
 		}
 		return err
 	}

--- a/webhook.go
+++ b/webhook.go
@@ -48,7 +48,7 @@ func (s *WebhookURLService) Get(ctx context.Context, id int) (*WebhookURL, error
 
 // GetByName returns a webhook URL by name.
 func (s *WebhookURLService) GetByName(ctx context.Context, name string) (*WebhookURL, error) {
-	webhooks, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	webhooks, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func (s *WebhookService) ListByWebhookURL(ctx context.Context, webhookURLID int,
 
 // ListByStatus returns all webhook messages with a specific status.
 func (s *WebhookService) ListByStatus(ctx context.Context, status string, opts ...ListOption) ([]Webhook, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("status eq '%s'", status))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("status eq '%s'", escapeFilterValue(status)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -177,7 +177,7 @@ func TestWebhookURLService_Delete(t *testing.T) {
 func TestWebhookURLService_Send(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/webhook_url_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "send" {
 				t.Errorf("expected action 'send', got %v", body["action"])


### PR DESCRIPTION
## Summary

Resolves all confirmed issues from the full codebase audit (REVIEW.md), across 5 phases and 24 atomic commits.

### Blocking Fixes
- **B-01**: Handle empty array `[]` in `GuestInfo.UnmarshalJSON` — was breaking `MachineStatus.Get()` for machines without a guest agent
- **B-02**: Add `VMDriveService.ListAll()` for batch drive-to-VM mapping without N+1 queries

### Critical Fixes
- **C-01**: Make `WithFilter` additive (AND-combine) instead of last-one-wins — fixes security bug in `api_key.GetByName` dropping the user filter
- **C-02**: Replace `time.Sleep` with context-aware select in `waitForImport`
- **C-03**: Propagate errors in `vm_nic.Create` (IP assignment) and `vm_device` (settings load/update)
- **C-04**: Respect context in `SystemService.GetInfo`

### High Priority
- **H-01**: Reject HTTP 3xx responses as errors (was silently decoding redirect bodies)
- **H-02**: Clone existing transport in `WithInsecureTLS`/`WithEnvConfig` instead of replacing it
- **H-03**: Bound response body reads to 100 MB via `io.LimitReader`
- **H-04**: Return error for unexpected JSON types in `FlexInt`/`FlexFK` instead of silent 0
- **H-06**: Add nil request check to `GroupService.Create`
- **H-07**: Add missing compile-time interface checks for `TenantStatusService` and `TenantStatsHistoryShortService`

### Medium Priority
- **M-01**: Escape filter values across 68 call sites in 37 files to prevent filter injection
- **M-02**: Standardize all Delete methods to return `NotFoundError` (11 services normalized)
- **M-03**: Check state before first sleep in VM/Network polling loops
- **M-04**: Normalize `TenantLayer2Network.Enable/Disable` to return `error` (was `(*T, error)`)
- **M-05**: Implement expiry filter in `Certificate.ListExpiring` (was ignoring `days` param)
- **M-08**: Rename `vmID` → `machineID` in `VMDrive`/`VMDevice.List` to match API semantics

### Low Priority Cleanup
- **L-01**: Replace `interface{}` with `any` across 46 files
- **L-06**: Standardize `NotFoundError.ID` to raw int (remove `fmt.Sprintf("%d", id)`)
- **L-07**: Replace custom `bytesReader` with `bytes.NewReader`
- **L-09**: Return error from `parseVersion` on invalid input
- **L-10**: Add typed `TimeoutError` for polling timeouts with `IsTimeoutError()` helper

### Deferred
- **H-05**: Machine vs `$key` in hot-unplug — needs API verification before changing

### Breaking Changes
| Change | Type |
|--------|------|
| `WithFilter` now AND-combines | Behavioral |
| `VMDriveServiceInterface` gains `ListAll` | Interface |
| `TenantLayer2Network.Enable/Disable` returns `error` | Signature |
| Delete methods return `NotFoundError` instead of nil | Behavioral |

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1 -race` — all pass
- [x] Integration tests against live VergeOS 26.1.3 — all pass (except pre-existing `TestRulesCRUD` leftover network)
- [x] Each commit verified independently