### PR TITLE
v0.2.0

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,35 @@
+# Contributor License Agreement
+
+Thank you for your interest in contributing to the Verge CLI project ("Project"), owned and maintained by Verge.io ("Company"). This Contributor License Agreement ("Agreement") documents the rights granted by contributors to the Company.
+
+By submitting a Contribution to this Project, you accept and agree to the following terms and conditions.
+
+## 1. Definitions
+
+**"Contribution"** means any original work of authorship, including any modifications or additions to an existing work, that you intentionally submit to the Project for inclusion. "Submit" means any form of communication sent to the Project (e.g., pull requests, issues, comments), but excluding communications marked "Not a Contribution."
+
+**"You" (or "Your")** means the individual or legal entity making the Contribution.
+
+## 2. Grant of Copyright License
+
+You hereby grant to the Company and recipients of software distributed by the Company a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+## 3. Grant of Patent License
+
+You hereby grant to the Company and recipients of software distributed by the Company a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Contribution, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution alone or by combination of Your Contribution with the Project.
+
+## 4. Representations
+
+You represent that:
+
+- Each Contribution is Your original creation, or You have sufficient rights to grant the licenses in this Agreement.
+- Your Contribution does not violate any third party's intellectual property or other rights.
+- If Your employer has rights to intellectual property that You create, You have received permission to make Contributions on behalf of that employer, or Your employer has waived such rights.
+
+## 5. No Support Obligation
+
+You are not expected to provide support for Your Contributions, except to the extent You desire to do so.
+
+## 6. Agreement
+
+By submitting a pull request or other Contribution to this Project, you signify your agreement to these terms. If you are making a Contribution on behalf of your employer, you represent that you have the authority to agree to these terms on their behalf.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,331 +1,76 @@
-# goVergeOS
+# CLAUDE.md
 
-A Go client library for the VergeOS API (v4), serving as the foundation for the VergeOS Terraform Provider and Prometheus Exporter.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Tech Stack
+## Project Overview
 
-- **Language**: Go 1.21+
-- **Module**: `github.com/verge-io/goVergeOS`
-- **Dependencies**: Standard library only (no external deps)
-- **Authentication**: HTTP Basic Auth
-- **Testing**: `go test` with integration tests (build tag: `integration`)
+goVergeOS is a Go client library (SDK) for the VergeOS infrastructure platform. Pre-release, zero external dependencies (stdlib only), Go 1.21+, requires VergeOS 26.0+. Module path: `github.com/verge-io/govergeos`.
 
-## Project Structure
+Foundation for the Terraform Provider, Prometheus Exporter, and other VergeOS tooling.
 
-```
-goVergeOS/
-├── client.go             # Client struct, HTTP methods, service init
-├── options.go            # ListOptions and functional options
-├── errors.go             # Error types (APIError, NotFoundError, etc.)
-├── types.go              # FlexInt custom type for ID handling
-├── doc.go                # Package documentation
-│
-├── vm.go                 # VM service and operations
-├── vm_nic.go             # VM NIC service
-├── vm_drive.go           # VM Drive service
-├── vm_device.go          # VM Device service
-├── network.go            # Network service
-├── user.go               # User service
-├── member.go             # Member service
-├── cloudinit.go          # CloudInit service
-├── cluster.go            # Cluster service
-├── node.go               # Node service
-├── group.go              # Group service
-├── file.go               # File service
-├── resourcegroup.go      # ResourceGroup service
-├── settings.go           # Settings service
-├── system.go             # System service
-├── schema.go             # Schema service
-│
-├── types_vm.go           # VM type definitions
-├── types_vm_nic.go       # VM NIC types
-├── types_vm_drive.go     # VM Drive types
-├── types_vm_device.go    # VM Device types
-├── types_network.go      # Network types
-├── types_user.go         # User types
-├── types_member.go       # Member types
-├── types_cloudinit.go    # CloudInit types
-├── types_readonly.go     # Read-only resource types
-│
-├── examples/
-│   ├── basic/            # Basic usage
-│   ├── network-management/
-│   └── vm-lifecycle/
-│
-├── DECISIONS.md          # Architecture Decision Records
-├── README.md             # User-facing documentation
-└── .claude/
-    ├── PRD.md            # Product requirements
-    └── reference/        # Best practices docs and API refrence schemas
-```
-
-## Commands
+## Build & Test Commands
 
 ```bash
-# Build
-go build ./...
+go build ./...                # Build
+go test ./...                 # Unit tests
+go test -v ./...              # Verbose
+go test -run TestName ./...   # Single test
+go vet ./...                  # Static analysis
+go fmt ./...                  # Format
 
-# Run tests
-go test ./...
-go test -run TestFunctionName ./...    # Single test
-go test -v ./...                        # Verbose
-
-# Format and lint
-go fmt ./...
-go vet ./...
-
-# Run examples (requires env vars)
-VERGEOS_HOST=https://your-host \
-VERGEOS_USERNAME=user \
-VERGEOS_PASSWORD=pass \
-VERGEOS_VERIFY_SSL=false \
-go run ./examples/basic/
+# Integration tests (require live VergeOS server + env vars)
+go test -tags=integration -v ./test/integration/
+go test -tags=integration -v ./test/integration/ -run "TestVM"
 ```
 
-## Environment Variables
-
-The SDK supports configuration via environment variables with explicit opt-in:
-
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `VERGEOS_HOST` | Yes | - | API base URL |
-| `VERGEOS_USERNAME` | No* | - | Basic auth username |
-| `VERGEOS_PASSWORD` | No* | - | Basic auth password |
-| `VERGEOS_API_KEY` | No* | - | Bearer token auth |
-| `VERGEOS_VERIFY_SSL` | No | `true` | TLS verification |
-| `VERGEOS_TIMEOUT` | No | `30` | Request timeout (seconds) |
-
-*One of (USERNAME+PASSWORD) or API_KEY required.
-
-Use `vergeos.NewClient(vergeos.WithEnvConfig())` to opt-in to environment configuration.
-Environment variables are never automatically picked up - this is intentional (see ADR-017).
-
-## Reference Documentation
-
-| Document | When to Read |
-|----------|--------------|
-| `.claude/PRD.md` | Understanding requirements, API coverage, feature scope |
-| `.claude/reference/API_SCHEMA_GUIDE.md` | Adding/updating services, type mapping, field coverage |
-| `.claude/reference/api-schmea/schema/v4/` | Raw API schema files for each resource |
-| `DECISIONS.md` | Architecture decisions, design rationale |
-| `README.md` | User-facing examples, quick start guide |
-| `examples/` | Working code examples for common use cases |
+Integration tests use `//go:build integration` build constraint and require `VERGEOS_HOST`, `VERGEOS_USERNAME`/`VERGEOS_PASSWORD` (or `VERGEOS_API_KEY`) environment variables.
 
 ## Architecture
 
-### Flat Package Structure
-All code lives in the root `vergeos` package. This provides simple imports (`vergeos.NewClient()`) and follows patterns of aws-sdk-go and google-cloud-go.
+**Single flat package** (`vergeos`) — all code lives at the repository root. No nested packages.
 
-### Service-Oriented Design
-The `Client` struct holds 16 service instances, each handling operations for one resource type:
+### Core Pattern: Service-Oriented Design (77 services)
 
-```go
-client.VMs.List(ctx)
-client.VMs.Create(ctx, req)
-client.Networks.Get(ctx, id)
-client.Networks.Update(ctx, id, req)
-```
+Each VergeOS resource has three pieces:
 
-**Services**: VMs, VMNICs, VMDrives, VMDevices, Networks, Users, Members, CloudInitFiles, Clusters, Nodes, Groups, Files, ResourceGroups, Settings, System, Schema
+1. **Type definitions** in `types_{resource}.go` — request/response structs
+2. **Service implementation** in `{resource}.go` — methods calling the API
+3. **Interface** in `interfaces.go` — enables mocking for consumers
 
-### Key Files
-- `client.go` - Client struct, HTTP methods (`get`, `post`, `put`, `delete`), service initialization
-- `options.go` - ListOptions and functional options (`WithFilter`, `WithFields`, `WithSort`)
-- `errors.go` - Error types (`APIError`, `NotFoundError`, `AuthError`, `ValidationError`)
-- `types.go` - FlexInt custom type for handling API ID inconsistencies
+Services are initialized in `NewClient()` (in `client.go`) and exposed as interface-typed fields on the `Client` struct.
 
-## Code Conventions
+### Key Design Decisions
 
-### Functional Options Pattern
-Client configuration uses builder-style options:
+Detailed rationale in `DECISIONS.md` (ADR-001 through ADR-018). The critical ones:
 
-```go
-client, err := vergeos.NewClient(
-    vergeos.WithBaseURL("https://host"),
-    vergeos.WithCredentials("user", "pass"),
-    vergeos.WithInsecureTLS(true),
-)
-```
+- **FlexInt** (`types.go`): Custom type handling VergeOS API returning IDs as int or string. Exception: Volume service uses `string` keys (SHA1 hashes).
+- **Pointer fields** in Update requests: `*int`, `*bool` etc. distinguish "not provided" (nil) from "set to zero value".
+- **Functional options**: `WithBaseURL()`, `WithCredentials()`, `WithAPIKey()`, `WithEnvConfig()`, etc.
+- **Context-first**: All API methods take `context.Context` as first parameter.
+- **Actions return error only**: Clone, snapshot, power operations don't return the new resource.
+- **Mandatory version check**: `NewClient()` validates server version during initialization.
+- **WithEnvConfig() is opt-in**: Environment variables are not auto-read.
 
-### Pointer Types for Updates
-Update request structs use pointers (`*string`, `*int`) to distinguish "don't update" (nil) from "set to zero value" (non-nil):
+### Adding a New Service
 
-```go
-type VMUpdateRequest struct {
-    Name        *string `json:"name,omitempty"`
-    Description *string `json:"description,omitempty"`
-    RAM         *int    `json:"ram,omitempty"`
-}
-```
+1. Create `types_{resource}.go` with request/response structs
+2. Create `{resource}.go` with service struct and methods
+3. Add interface to `interfaces.go`
+4. Initialize service in `NewClient()` in `client.go`
+5. Add integration tests in `test/integration/` with `//go:build integration`
 
-### FlexInt Type
-The VergeOS API sometimes returns IDs as strings, sometimes as integers. The `FlexInt` type in `types.go` handles this transparently.
+### Error Types
 
-### API Method Patterns
-- All methods take `context.Context` as first parameter
-- List methods accept variadic `ListOption` arguments
-- Create returns the created resource (reads back after POST)
-- Update returns the updated resource (reads back after PUT)
-- Delete returns only error
-- Action methods (PowerOn, Clone, etc.) return only error
+Defined in `errors.go`: `APIError`, `NotFoundError`, `AuthError`, `ValidationError`, `UnsupportedVersionError`. Check with `IsNotFoundError(err)`, `IsAuthError(err)`, etc.
 
-### Error Handling
-Use typed error checking:
+### Query Options
 
-```go
-if vergeos.IsNotFoundError(err) { ... }
-if vergeos.IsAuthError(err) { ... }
-if vergeos.IsValidationError(err) { ... }
-```
+List operations use composable options from `options.go`: `WithFilter()`, `WithSort()`, `WithFields()`, `WithLimit()`, `WithOffset()`.
 
-### Naming Conventions
-- `camelCase` for variables and functions
-- `PascalCase` for exported types and methods
-- Service files: `resourcename.go` (e.g., `vm.go`, `network.go`)
-- Type files: `types_resourcename.go` (e.g., `types_vm.go`)
+### Field Selection
 
-## Adding a New Service
+Services define default field sets for List vs Get operations to optimize API payloads. Users can override with `WithFields("all")`.
 
-### Step 0: Review the API Schema
+### Power State Polling
 
-Before writing code, check the schema for complete field coverage:
-
-```bash
-# Find the schema file
-ls .claude/reference/api-schmea/schema/v4/ | grep resourcename
-
-# Read the schema
-cat .claude/reference/api-schmea/schema/v4/resourcename/table.json
-```
-
-See `.claude/reference/API_SCHEMA_GUIDE.md` for detailed type mapping and patterns.
-
-### Step 1: Create Types
-
-Create `types_newresource.go` with resource and request types based on schema fields:
-
-```go
-type NewResource struct {
-    Key  FlexInt `json:"$key"`           // Row key (use FlexInt for IDs)
-    Name string  `json:"name"`            // Required fields as values
-    Status string `json:"status,omitempty"` // Optional fields with omitempty
-}
-
-type NewResourceCreateRequest struct {
-    Name string `json:"name"`             // Required - value type
-    Description string `json:"description,omitempty"` // Optional
-}
-
-type NewResourceUpdateRequest struct {
-    Name *string `json:"name,omitempty"`  // Pointer for optional update
-    Description *string `json:"description,omitempty"`
-}
-
-// Field list constant - include all fields from schema
-const newResourceListFields = "$key,name,status,description,created,..."
-```
-
-### Step 2: Create Service
-
-Create `newresource.go` with service struct and methods:
-
-```go
-type NewResourceService struct {
-    client *Client
-}
-
-func (s *NewResourceService) List(ctx context.Context, opts ...ListOption) ([]NewResource, error) {
-    // Implementation
-}
-```
-
-### Step 3: Register Service
-
-Add service to Client in `client.go`:
-
-```go
-// In Client struct
-NewResources *NewResourceService
-
-// In NewClient()
-c.NewResources = &NewResourceService{client: c}
-```
-
-### Step 4: Verify Coverage
-
-Compare your types against the schema to ensure complete coverage:
-- All schema fields mapped to struct fields
-- Correct Go types (see API_SCHEMA_GUIDE.md for mapping)
-- JSON tags match schema field names exactly
-- Field list constant includes all relevant fields
-
-## Testing Strategy
-
-Tests follow Go conventions with integration tests against a live VergeOS API.
-
-### Test Organization
-
-Integration tests are organized by service category in `test/integration/`:
-
-```
-test/integration/
-├── helpers_test.go          # Shared utilities (setupTestClient, prettyPrint, ptr)
-├── api_keys_test.go         # User API Keys
-├── certificates_test.go     # SSL/TLS Certificates
-├── clusters_test.go         # Clusters, Network Diagnostics
-├── dr_test.go               # Sites, Site Syncs, Cloud Snapshots
-├── files_test.go            # File upload/download
-├── groups_test.go           # Groups
-├── logs_test.go             # System Logs
-├── monitoring_test.go       # Alarms, Alarm Types, Tasks
-├── nas_test.go              # NAS Services, Users, Syncs, Snapshots, CIFS/NFS Shares
-├── networking_test.go       # VNet Addresses, DNS, Hosts
-├── permissions_test.go      # Permissions
-├── rules_test.go            # VNet Rules, Rule Aliases
-├── snapshot_profiles_test.go # Snapshot Profiles, Periods
-├── tags_test.go             # Tags, Tag Categories
-├── tenants_test.go          # Tenants, Tenant Nodes/Storage/Snapshots/Layer2
-├── version_test.go          # Version check
-├── vm_snapshots_test.go     # VM Snapshots, VM Migration
-├── volumes_test.go          # Volumes
-├── vpn_test.go              # WireGuard, IPSec
-├── vsan_test.go             # Storage Tiers, Cluster Tiers, Drive Phys, Stats
-└── webhooks_test.go         # Webhook URLs, Webhooks
-```
-
-### Running Integration Tests
-
-```bash
-# Set credentials
-export VERGEOS_HOST=https://your-vergeos-host
-export VERGEOS_USERNAME=admin
-export VERGEOS_PASSWORD=your-password
-
-# Run all integration tests
-go test -tags=integration -v ./test/integration/
-
-# Run by category
-go test -tags=integration -v ./test/integration/ -run "TestVMSnapshots"
-go test -tags=integration -v ./test/integration/ -run "TestNAS"
-go test -tags=integration -v ./test/integration/ -run "TestClusters"
-go test -tags=integration -v ./test/integration/ -run "TestVSAN"
-go test -tags=integration -v ./test/integration/ -run "TestDR"
-go test -tags=integration -v ./test/integration/ -run "TestVPN"
-
-# Run CRUD lifecycle tests only
-go test -tags=integration -v ./test/integration/ -run "CRUD"
-
-# Run multiple categories
-go test -tags=integration -v ./test/integration/ -run "TestNAS|TestVolume"
-```
-
-### Test Conventions
-
-- All tests require `//go:build integration` build tag
-- Tests use `setupTestClient(t)` from helpers_test.go
-- Context timeout: 2 minutes per test function
-- CRUD tests clean up created resources in defer blocks
-- Destructive tests (Create/Delete) often require opt-in via environment variables
-
-## Reserved Networks
-IMPORTANT: Never use "Core" or "DMZ" networks for workloads, services, VMs, or NAS. These networks are reserved for the VergeOS operating system. Always create a new network (e.g., "Internal") for test workloads and examples.
+VM/Network power operations poll with 5-second intervals, max 30 retries.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,200 @@
-MIT License
 
-Copyright (c) 2026 Verge.io
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please also get an
+      information on the current year.
+
+      Copyright 2024 Verge.io
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.

--- a/alarm.go
+++ b/alarm.go
@@ -69,7 +69,7 @@ func (s *AlarmService) Get(ctx context.Context, id int) (*Alarm, error) {
 	endpoint := fmt.Sprintf("/alarms/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &alarm); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Alarm", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Alarm", ID: id}
 		}
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (s *AlarmService) Update(ctx context.Context, id int, req *AlarmUpdateReque
 	endpoint := fmt.Sprintf("/alarms/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Alarm", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Alarm", ID: id}
 		}
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (s *AlarmService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/alarms/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "Alarm", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "Alarm", ID: id}
 		}
 		return err
 	}

--- a/alarm.go
+++ b/alarm.go
@@ -41,21 +41,21 @@ func (s *AlarmService) ListActive(ctx context.Context, opts ...ListOption) ([]Al
 // ListByOwner returns all alarms for a specific owner resource.
 // owner should be a resource path like "vms/123" or "nodes/1".
 func (s *AlarmService) ListByOwner(ctx context.Context, owner string, opts ...ListOption) ([]Alarm, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("owner eq '%s'", owner))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("owner eq '%s'", escapeFilterValue(owner)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }
 
 // ListByLevel returns all alarms with a specific severity level.
 func (s *AlarmService) ListByLevel(ctx context.Context, level string, opts ...ListOption) ([]Alarm, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("level eq '%s'", level))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("level eq '%s'", escapeFilterValue(level)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }
 
 // ListByAlarmType returns all alarms of a specific alarm type.
 func (s *AlarmService) ListByAlarmType(ctx context.Context, alarmTypeKey string, opts ...ListOption) ([]Alarm, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("alarm_type eq '%s'", alarmTypeKey))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("alarm_type eq '%s'", escapeFilterValue(alarmTypeKey)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }
@@ -175,7 +175,7 @@ func (s *AlarmTypeService) Get(ctx context.Context, key string) (*AlarmType, err
 
 // ListByLevel returns all alarm types with a specific default severity level.
 func (s *AlarmTypeService) ListByLevel(ctx context.Context, level string, opts ...ListOption) ([]AlarmType, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("level eq '%s'", level))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("level eq '%s'", escapeFilterValue(level)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }

--- a/alarm.go
+++ b/alarm.go
@@ -111,7 +111,7 @@ func (s *AlarmService) Unsnooze(ctx context.Context, id int) error {
 // Resolve resolves an alarm if it is resolvable.
 func (s *AlarmService) Resolve(ctx context.Context, id int) error {
 	endpoint := "/alarm_actions"
-	body := map[string]interface{}{
+	body := map[string]any{
 		"alarm":  id,
 		"action": "resolve",
 	}

--- a/alarm_test.go
+++ b/alarm_test.go
@@ -205,7 +205,7 @@ func TestAlarmService_Unsnooze(t *testing.T) {
 func TestAlarmService_Resolve(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/alarm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "resolve" {
 				t.Errorf("expected action 'resolve', got %v", body["action"])

--- a/alarm_test.go
+++ b/alarm_test.go
@@ -1,0 +1,303 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestAlarmService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/alarms": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Alarm{
+				{Key: 1, Level: "warning", Status: "disk usage high"},
+				{Key: 2, Level: "error", Status: "node offline"},
+			})
+		},
+	}))
+
+	alarms, err := client.Alarms.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(alarms) != 2 {
+		t.Fatalf("expected 2 alarms, got %d", len(alarms))
+	}
+	if alarms[0].Level != "warning" {
+		t.Errorf("expected level 'warning', got %q", alarms[0].Level)
+	}
+}
+
+func TestAlarmService_ListActive(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/alarms": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter for active alarms")
+			}
+			jsonResponse(w, 200, []Alarm{{Key: 1, Level: "error"}})
+		},
+	}))
+
+	alarms, err := client.Alarms.ListActive(context.Background())
+	if err != nil {
+		t.Fatalf("ListActive failed: %v", err)
+	}
+	if len(alarms) != 1 {
+		t.Fatalf("expected 1 alarm, got %d", len(alarms))
+	}
+}
+
+func TestAlarmService_ListByOwner(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/alarms": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "owner eq 'vms/123'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Alarm{{Key: 1, Owner: "vms/123"}})
+		},
+	}))
+
+	alarms, err := client.Alarms.ListByOwner(context.Background(), "vms/123")
+	if err != nil {
+		t.Fatalf("ListByOwner failed: %v", err)
+	}
+	if len(alarms) != 1 {
+		t.Fatalf("expected 1 alarm, got %d", len(alarms))
+	}
+}
+
+func TestAlarmService_ListByLevel(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/alarms": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Alarm{{Key: 1, Level: "critical"}})
+		},
+	}))
+
+	alarms, err := client.Alarms.ListByLevel(context.Background(), "critical")
+	if err != nil {
+		t.Fatalf("ListByLevel failed: %v", err)
+	}
+	if len(alarms) != 1 {
+		t.Fatalf("expected 1 alarm, got %d", len(alarms))
+	}
+}
+
+func TestAlarmService_ListByAlarmType(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/alarms": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Alarm{{Key: 1, AlarmType: "vm_cpu_high"}})
+		},
+	}))
+
+	alarms, err := client.Alarms.ListByAlarmType(context.Background(), "vm_cpu_high")
+	if err != nil {
+		t.Fatalf("ListByAlarmType failed: %v", err)
+	}
+	if len(alarms) != 1 {
+		t.Fatalf("expected 1 alarm, got %d", len(alarms))
+	}
+}
+
+func TestAlarmService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/alarms/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Alarm{Key: 1, Level: "error", Status: "node offline"})
+		},
+	}))
+
+	alarm, err := client.Alarms.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if alarm.Status != "node offline" {
+		t.Errorf("expected status 'node offline', got %q", alarm.Status)
+	}
+}
+
+func TestAlarmService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/alarms/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Alarms.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestAlarmService_Update(t *testing.T) {
+	snooze := int64(9999999)
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/alarms/1": func(w http.ResponseWriter, r *http.Request) {
+			var req AlarmUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Snooze == nil || *req.Snooze != snooze {
+				t.Errorf("expected snooze %d, got %v", snooze, req.Snooze)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/alarms/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Alarm{Key: 1, Snooze: snooze})
+		},
+	}))
+
+	alarm, err := client.Alarms.Update(context.Background(), 1, &AlarmUpdateRequest{Snooze: &snooze})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if alarm.Snooze != snooze {
+		t.Errorf("expected snooze %d, got %d", snooze, alarm.Snooze)
+	}
+}
+
+func TestAlarmService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Alarms.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestAlarmService_Snooze(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/alarms/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/alarms/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Alarm{Key: 1, Snooze: 9999})
+		},
+	}))
+
+	err := client.Alarms.Snooze(context.Background(), 1, 9999)
+	if err != nil {
+		t.Fatalf("Snooze failed: %v", err)
+	}
+}
+
+func TestAlarmService_Unsnooze(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/alarms/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/alarms/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Alarm{Key: 1, Snooze: 0})
+		},
+	}))
+
+	err := client.Alarms.Unsnooze(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Unsnooze failed: %v", err)
+	}
+}
+
+func TestAlarmService_Resolve(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/alarm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "resolve" {
+				t.Errorf("expected action 'resolve', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Alarms.Resolve(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+}
+
+func TestAlarmService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/alarms/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Alarms.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestAlarmService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/alarms/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.Alarms.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// AlarmType tests
+
+func TestAlarmTypeService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/alarm_types": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []AlarmType{
+				{Key: "vm_cpu_high", Name: "VM CPU High", Level: "warning"},
+				{Key: "node_offline", Name: "Node Offline", Level: "critical"},
+			})
+		},
+	}))
+
+	types, err := client.AlarmTypes.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(types) != 2 {
+		t.Fatalf("expected 2 alarm types, got %d", len(types))
+	}
+}
+
+func TestAlarmTypeService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/alarm_types/vm_cpu_high": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, AlarmType{Key: "vm_cpu_high", Name: "VM CPU High"})
+		},
+	}))
+
+	at, err := client.AlarmTypes.Get(context.Background(), "vm_cpu_high")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if at.Name != "VM CPU High" {
+		t.Errorf("expected name 'VM CPU High', got %q", at.Name)
+	}
+}
+
+func TestAlarmTypeService_ListByLevel(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/alarm_types": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []AlarmType{{Key: "node_offline", Level: "critical"}})
+		},
+	}))
+
+	types, err := client.AlarmTypes.ListByLevel(context.Background(), "critical")
+	if err != nil {
+		t.Fatalf("ListByLevel failed: %v", err)
+	}
+	if len(types) != 1 {
+		t.Fatalf("expected 1 alarm type, got %d", len(types))
+	}
+}

--- a/api_key.go
+++ b/api_key.go
@@ -92,7 +92,7 @@ func (s *UserAPIKeyService) Create(ctx context.Context, req *UserAPIKeyCreateReq
 
 	// Extract token from response if available
 	var token string
-	if respMap, ok := resp.Response.(map[string]interface{}); ok {
+	if respMap, ok := resp.Response.(map[string]any); ok {
 		if t, ok := respMap["token"].(string); ok {
 			token = t
 		}

--- a/api_key.go
+++ b/api_key.go
@@ -45,7 +45,7 @@ func (s *UserAPIKeyService) Get(ctx context.Context, id int) (*UserAPIKey, error
 	endpoint := fmt.Sprintf("/user_api_keys/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &key); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "UserAPIKey", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "UserAPIKey", ID: id}
 		}
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (s *UserAPIKeyService) Update(ctx context.Context, id int, req *UserAPIKeyU
 	endpoint := fmt.Sprintf("/user_api_keys/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "UserAPIKey", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "UserAPIKey", ID: id}
 		}
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (s *UserAPIKeyService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/user_api_keys/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "UserAPIKey", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "UserAPIKey", ID: id}
 		}
 		return err
 	}

--- a/api_key.go
+++ b/api_key.go
@@ -56,8 +56,7 @@ func (s *UserAPIKeyService) Get(ctx context.Context, id int) (*UserAPIKey, error
 // GetByName returns an API key by name within a user's keys.
 func (s *UserAPIKeyService) GetByName(ctx context.Context, userID int, name string) (*UserAPIKey, error) {
 	keys, err := s.List(ctx,
-		WithFilter(fmt.Sprintf("user eq %d", userID)),
-		WithFilter(fmt.Sprintf("name eq '%s'", name)),
+		WithFilter(fmt.Sprintf("user eq %d and name eq '%s'", userID, name)),
 	)
 	if err != nil {
 		return nil, err

--- a/api_key.go
+++ b/api_key.go
@@ -56,7 +56,7 @@ func (s *UserAPIKeyService) Get(ctx context.Context, id int) (*UserAPIKey, error
 // GetByName returns an API key by name within a user's keys.
 func (s *UserAPIKeyService) GetByName(ctx context.Context, userID int, name string) (*UserAPIKey, error) {
 	keys, err := s.List(ctx,
-		WithFilter(fmt.Sprintf("user eq %d and name eq '%s'", userID, name)),
+		WithFilter(fmt.Sprintf("user eq %d and name eq '%s'", userID, escapeFilterValue(name))),
 	)
 	if err != nil {
 		return nil, err

--- a/api_key_test.go
+++ b/api_key_test.go
@@ -134,7 +134,7 @@ func TestUserAPIKeyService_Create(t *testing.T) {
 			}
 			jsonResponse(w, 200, apiResponse{
 				Key:      float64(5),
-				Response: map[string]interface{}{"token": "secret-token-123"},
+				Response: map[string]any{"token": "secret-token-123"},
 			})
 		},
 		"GET /api/v4/user_api_keys/5": func(w http.ResponseWriter, r *http.Request) {

--- a/api_key_test.go
+++ b/api_key_test.go
@@ -1,0 +1,284 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// UserAPIKey tests
+
+func TestUserAPIKeyService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/user_api_keys": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []UserAPIKey{
+				{Key: 1, Name: "key1", User: 10},
+				{Key: 2, Name: "key2", User: 20},
+			})
+		},
+	}))
+
+	keys, err := client.UserAPIKeys.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(keys))
+	}
+	if keys[0].Name != "key1" {
+		t.Errorf("expected name 'key1', got %q", keys[0].Name)
+	}
+}
+
+func TestUserAPIKeyService_ListByUser(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/user_api_keys": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "user eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []UserAPIKey{{Key: 1, Name: "key1", User: 10}})
+		},
+	}))
+
+	keys, err := client.UserAPIKeys.ListByUser(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListByUser failed: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys))
+	}
+}
+
+func TestUserAPIKeyService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/user_api_keys/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, UserAPIKey{Key: 1, Name: "my-key", User: 10, Description: "test key"})
+		},
+	}))
+
+	key, err := client.UserAPIKeys.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if key.Name != "my-key" {
+		t.Errorf("expected name 'my-key', got %q", key.Name)
+	}
+	if key.Description != "test key" {
+		t.Errorf("expected description 'test key', got %q", key.Description)
+	}
+}
+
+func TestUserAPIKeyService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/user_api_keys/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.UserAPIKeys.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestUserAPIKeyService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/user_api_keys": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []UserAPIKey{{Key: 1, Name: "my-key", User: 10}})
+		},
+		"GET /api/v4/user_api_keys/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, UserAPIKey{Key: 1, Name: "my-key", User: 10})
+		},
+	}))
+
+	key, err := client.UserAPIKeys.GetByName(context.Background(), 10, "my-key")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if key.Name != "my-key" {
+		t.Errorf("expected name 'my-key', got %q", key.Name)
+	}
+}
+
+func TestUserAPIKeyService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/user_api_keys": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []UserAPIKey{})
+		},
+	}))
+
+	_, err := client.UserAPIKeys.GetByName(context.Background(), 10, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestUserAPIKeyService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/user_api_keys": func(w http.ResponseWriter, r *http.Request) {
+			var req UserAPIKeyCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.User != 10 {
+				t.Errorf("expected user 10, got %d", req.User)
+			}
+			if req.Name != "new-key" {
+				t.Errorf("expected name 'new-key', got %q", req.Name)
+			}
+			jsonResponse(w, 200, apiResponse{
+				Key:      float64(5),
+				Response: map[string]interface{}{"token": "secret-token-123"},
+			})
+		},
+		"GET /api/v4/user_api_keys/5": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, UserAPIKey{Key: 5, Name: "new-key", User: 10})
+		},
+	}))
+
+	key, token, err := client.UserAPIKeys.Create(context.Background(), &UserAPIKeyCreateRequest{
+		User: 10,
+		Name: "new-key",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if key.Name != "new-key" {
+		t.Errorf("expected name 'new-key', got %q", key.Name)
+	}
+	if token != "secret-token-123" {
+		t.Errorf("expected token 'secret-token-123', got %q", token)
+	}
+}
+
+func TestUserAPIKeyService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, _, err := client.UserAPIKeys.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestUserAPIKeyService_Create_MissingUser(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, _, err := client.UserAPIKeys.Create(context.Background(), &UserAPIKeyCreateRequest{
+		Name: "key",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing user")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestUserAPIKeyService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, _, err := client.UserAPIKeys.Create(context.Background(), &UserAPIKeyCreateRequest{
+		User: 10,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestUserAPIKeyService_Update(t *testing.T) {
+	newName := "updated-key"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/user_api_keys/1": func(w http.ResponseWriter, r *http.Request) {
+			var req UserAPIKeyUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/user_api_keys/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, UserAPIKey{Key: 1, Name: newName, User: 10})
+		},
+	}))
+
+	key, err := client.UserAPIKeys.Update(context.Background(), 1, &UserAPIKeyUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if key.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, key.Name)
+	}
+}
+
+func TestUserAPIKeyService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.UserAPIKeys.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestUserAPIKeyService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/user_api_keys/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.UserAPIKeys.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestUserAPIKeyService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/user_api_keys/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.UserAPIKeys.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestUserAPIKeyService_ListExpired(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/user_api_keys": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "expires gt 0" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []UserAPIKey{{Key: 1, Expires: 1700000000}})
+		},
+	}))
+
+	keys, err := client.UserAPIKeys.ListExpired(context.Background())
+	if err != nil {
+		t.Fatalf("ListExpired failed: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 key, got %d", len(keys))
+	}
+}

--- a/certificate.go
+++ b/certificate.go
@@ -39,7 +39,7 @@ func (s *CertificateService) Get(ctx context.Context, id int) (*Certificate, err
 	endpoint := fmt.Sprintf("/certificates/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &cert); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Certificate", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Certificate", ID: id}
 		}
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (s *CertificateService) GetWithKeys(ctx context.Context, id int) (*Certific
 	endpoint := fmt.Sprintf("/certificates/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &cert); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Certificate", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Certificate", ID: id}
 		}
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (s *CertificateService) Update(ctx context.Context, id int, req *Certificat
 	endpoint := fmt.Sprintf("/certificates/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Certificate", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Certificate", ID: id}
 		}
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (s *CertificateService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/certificates/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "Certificate", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "Certificate", ID: id}
 		}
 		return err
 	}

--- a/certificate.go
+++ b/certificate.go
@@ -48,7 +48,7 @@ func (s *CertificateService) Get(ctx context.Context, id int) (*Certificate, err
 
 // GetByDomain returns a certificate by its primary domain.
 func (s *CertificateService) GetByDomain(ctx context.Context, domain string) (*Certificate, error) {
-	certs, err := s.List(ctx, WithFilter(fmt.Sprintf("domain eq '%s'", domain)))
+	certs, err := s.List(ctx, WithFilter(fmt.Sprintf("domain eq '%s'", escapeFilterValue(domain))))
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func (s *CertificateService) ListValid(ctx context.Context, opts ...ListOption) 
 
 // ListByType returns certificates of a specific type (manual, letsencrypt, self_signed).
 func (s *CertificateService) ListByType(ctx context.Context, certType string, opts ...ListOption) ([]Certificate, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("type eq '%s'", certType))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("type eq '%s'", escapeFilterValue(certType)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }

--- a/certificate.go
+++ b/certificate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"time"
 )
 
 // CertificateService handles SSL/TLS certificate operations.
@@ -132,9 +133,8 @@ func (s *CertificateService) Renew(ctx context.Context, id int) (*Certificate, e
 
 // ListExpiring returns certificates that will expire within the specified number of days.
 func (s *CertificateService) ListExpiring(ctx context.Context, days int, opts ...ListOption) ([]Certificate, error) {
-	// Calculate Unix timestamp for 'days' from now
-	// This is a simple filter approach - exact implementation depends on API support
-	filterOpts := []ListOption{WithFilter("valid eq true")}
+	expiresBy := time.Now().Add(time.Duration(days) * 24 * time.Hour).Unix()
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("valid eq true and expires le %d", expiresBy))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }

--- a/certificate_test.go
+++ b/certificate_test.go
@@ -1,0 +1,360 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestCertificateService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/certificates": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Certificate{
+				{Key: 1, Domain: "example.com", Type: "letsencrypt", Valid: true},
+				{Key: 2, Domain: "test.com", Type: "manual", Valid: true},
+			})
+		},
+	}))
+
+	certs, err := client.Certificates.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(certs) != 2 {
+		t.Fatalf("expected 2 certificates, got %d", len(certs))
+	}
+	if certs[0].Domain != "example.com" {
+		t.Errorf("expected domain 'example.com', got %q", certs[0].Domain)
+	}
+}
+
+func TestCertificateService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/certificates/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Certificate{Key: 1, Domain: "example.com", Type: "letsencrypt", Valid: true})
+		},
+	}))
+
+	cert, err := client.Certificates.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if cert.Domain != "example.com" {
+		t.Errorf("expected domain 'example.com', got %q", cert.Domain)
+	}
+	if cert.Type != "letsencrypt" {
+		t.Errorf("expected type 'letsencrypt', got %q", cert.Type)
+	}
+}
+
+func TestCertificateService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/certificates/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Certificates.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestCertificateService_GetByDomain(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/certificates": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "domain eq 'example.com'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Certificate{{Key: 1, Domain: "example.com"}})
+		},
+		"GET /api/v4/certificates/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Certificate{Key: 1, Domain: "example.com", Type: "letsencrypt"})
+		},
+	}))
+
+	cert, err := client.Certificates.GetByDomain(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("GetByDomain failed: %v", err)
+	}
+	if cert.Domain != "example.com" {
+		t.Errorf("expected domain 'example.com', got %q", cert.Domain)
+	}
+}
+
+func TestCertificateService_GetByDomain_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/certificates": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Certificate{})
+		},
+	}))
+
+	_, err := client.Certificates.GetByDomain(context.Background(), "nonexistent.com")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestCertificateService_GetWithKeys(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/certificates/1": func(w http.ResponseWriter, r *http.Request) {
+			fields := r.URL.Query().Get("fields")
+			if fields == "" {
+				t.Error("expected fields parameter")
+			}
+			jsonResponse(w, 200, Certificate{
+				Key:     1,
+				Domain:  "example.com",
+				Public:  "-----BEGIN CERTIFICATE-----\nMIIB...",
+				Private: "-----BEGIN PRIVATE KEY-----\nMIIE...",
+				Chain:   "-----BEGIN CERTIFICATE-----\nMIIC...",
+			})
+		},
+	}))
+
+	cert, err := client.Certificates.GetWithKeys(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetWithKeys failed: %v", err)
+	}
+	if cert.Public == "" {
+		t.Error("expected non-empty public key")
+	}
+	if cert.Private == "" {
+		t.Error("expected non-empty private key")
+	}
+}
+
+func TestCertificateService_GetWithKeys_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/certificates/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Certificates.GetWithKeys(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestCertificateService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/certificates": func(w http.ResponseWriter, r *http.Request) {
+			var req CertificateCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.DomainName != "example.com" {
+				t.Errorf("expected domain 'example.com', got %q", req.DomainName)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+		},
+		"GET /api/v4/certificates/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Certificate{Key: 1, Domain: "example.com", Type: "self_signed"})
+		},
+	}))
+
+	cert, err := client.Certificates.Create(context.Background(), &CertificateCreateRequest{
+		DomainName: "example.com",
+		Type:       "self_signed",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if cert.Domain != "example.com" {
+		t.Errorf("expected domain 'example.com', got %q", cert.Domain)
+	}
+}
+
+func TestCertificateService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Certificates.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCertificateService_Update(t *testing.T) {
+	newDesc := "updated cert"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/certificates/1": func(w http.ResponseWriter, r *http.Request) {
+			var req CertificateUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Description == nil || *req.Description != newDesc {
+				t.Errorf("expected description %q, got %v", newDesc, req.Description)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/certificates/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Certificate{Key: 1, Domain: "example.com", Description: newDesc})
+		},
+	}))
+
+	cert, err := client.Certificates.Update(context.Background(), 1, &CertificateUpdateRequest{Description: &newDesc})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if cert.Description != newDesc {
+		t.Errorf("expected description %q, got %q", newDesc, cert.Description)
+	}
+}
+
+func TestCertificateService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Certificates.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCertificateService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/certificates/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newDesc := "updated"
+	_, err := client.Certificates.Update(context.Background(), 999, &CertificateUpdateRequest{Description: &newDesc})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestCertificateService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/certificates/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Certificates.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestCertificateService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/certificates/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.Certificates.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestCertificateService_Renew(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/certificates/1": func(w http.ResponseWriter, r *http.Request) {
+			var req CertificateUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Renew == nil || !*req.Renew {
+				t.Error("expected renew=true")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/certificates/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Certificate{Key: 1, Domain: "example.com", Type: "letsencrypt", Valid: true})
+		},
+	}))
+
+	cert, err := client.Certificates.Renew(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Renew failed: %v", err)
+	}
+	if !cert.Valid {
+		t.Error("expected cert to be valid after renewal")
+	}
+}
+
+func TestCertificateService_ListExpiring(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/certificates": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter for expiring certs")
+			}
+			jsonResponse(w, 200, []Certificate{{Key: 1, Domain: "example.com", Valid: true}})
+		},
+	}))
+
+	certs, err := client.Certificates.ListExpiring(context.Background(), 30)
+	if err != nil {
+		t.Fatalf("ListExpiring failed: %v", err)
+	}
+	if len(certs) != 1 {
+		t.Fatalf("expected 1 certificate, got %d", len(certs))
+	}
+}
+
+func TestCertificateService_ListValid(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/certificates": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "valid eq true" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Certificate{
+				{Key: 1, Domain: "example.com", Valid: true},
+			})
+		},
+	}))
+
+	certs, err := client.Certificates.ListValid(context.Background())
+	if err != nil {
+		t.Fatalf("ListValid failed: %v", err)
+	}
+	if len(certs) != 1 {
+		t.Fatalf("expected 1 certificate, got %d", len(certs))
+	}
+}
+
+func TestCertificateService_ListByType(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/certificates": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "type eq 'letsencrypt'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Certificate{{Key: 1, Domain: "example.com", Type: "letsencrypt"}})
+		},
+	}))
+
+	certs, err := client.Certificates.ListByType(context.Background(), "letsencrypt")
+	if err != nil {
+		t.Fatalf("ListByType failed: %v", err)
+	}
+	if len(certs) != 1 {
+		t.Fatalf("expected 1 certificate, got %d", len(certs))
+	}
+	if certs[0].Type != "letsencrypt" {
+		t.Errorf("expected type 'letsencrypt', got %q", certs[0].Type)
+	}
+}

--- a/certificate_test.go
+++ b/certificate_test.go
@@ -156,7 +156,7 @@ func TestCertificateService_Create(t *testing.T) {
 			if req.DomainName != "example.com" {
 				t.Errorf("expected domain 'example.com', got %q", req.DomainName)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/certificates/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, Certificate{Key: 1, Domain: "example.com", Type: "self_signed"})

--- a/client.go
+++ b/client.go
@@ -402,13 +402,13 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 
 // apiResponse represents the standard VergeOS API response structure.
 type apiResponse struct {
-	Key      interface{} `json:"$key,omitempty"`
-	Response interface{} `json:"response,omitempty"`
+	Key      any `json:"$key,omitempty"`
+	Response any `json:"response,omitempty"`
 	Err      string      `json:"err,omitempty"`
 }
 
 // request performs an HTTP request to the VergeOS API.
-func (c *Client) request(ctx context.Context, method, endpoint string, body interface{}, params url.Values) (*http.Response, error) {
+func (c *Client) request(ctx context.Context, method, endpoint string, body any, params url.Values) (*http.Response, error) {
 	// Build URL
 	u := fmt.Sprintf("%s%s%s", c.baseURL, apiBasePath, endpoint)
 	if len(params) > 0 {
@@ -452,7 +452,7 @@ func (c *Client) request(ctx context.Context, method, endpoint string, body inte
 }
 
 // do performs an HTTP request and decodes the response.
-func (c *Client) do(ctx context.Context, method, endpoint string, body interface{}, params url.Values, result interface{}) error {
+func (c *Client) do(ctx context.Context, method, endpoint string, body any, params url.Values, result any) error {
 	resp, err := c.request(ctx, method, endpoint, body, params)
 	if err != nil {
 		return err
@@ -503,17 +503,17 @@ func (c *Client) do(ctx context.Context, method, endpoint string, body interface
 }
 
 // get performs a GET request.
-func (c *Client) get(ctx context.Context, endpoint string, params url.Values, result interface{}) error {
+func (c *Client) get(ctx context.Context, endpoint string, params url.Values, result any) error {
 	return c.do(ctx, http.MethodGet, endpoint, nil, params, result)
 }
 
 // post performs a POST request and returns the created resource's key.
-func (c *Client) post(ctx context.Context, endpoint string, body interface{}, result interface{}) error {
+func (c *Client) post(ctx context.Context, endpoint string, body any, result any) error {
 	return c.do(ctx, http.MethodPost, endpoint, body, nil, result)
 }
 
 // put performs a PUT request.
-func (c *Client) put(ctx context.Context, endpoint string, body interface{}, result interface{}) error {
+func (c *Client) put(ctx context.Context, endpoint string, body any, result any) error {
 	return c.do(ctx, http.MethodPut, endpoint, body, nil, result)
 }
 
@@ -524,7 +524,7 @@ func (c *Client) delete(ctx context.Context, endpoint string) error {
 
 // getAbsolute performs a GET request to an absolute path (not under /api/v4/).
 // This is used for endpoints like /version.json that are outside the API path.
-func (c *Client) getAbsolute(ctx context.Context, path string, params url.Values, result interface{}) error {
+func (c *Client) getAbsolute(ctx context.Context, path string, params url.Values, result any) error {
 	// Build URL with absolute path
 	u := c.baseURL + path
 	if len(params) > 0 {

--- a/client.go
+++ b/client.go
@@ -67,6 +67,8 @@ type Client struct {
 	Tenants                 TenantServiceInterface
 	TenantNodes             TenantNodeServiceInterface
 	TenantStorage           TenantStorageServiceInterface
+	TenantStatus            TenantStatusServiceInterface
+	TenantStatsHistoryShort TenantStatsHistoryShortServiceInterface
 	TenantSnapshots         TenantSnapshotServiceInterface
 	TenantLayer2Networks    TenantLayer2NetworkServiceInterface
 	SnapshotProfiles        SnapshotProfileServiceInterface
@@ -330,6 +332,8 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c.Tenants = &TenantService{client: c}
 	c.TenantNodes = &TenantNodeService{client: c}
 	c.TenantStorage = &TenantStorageService{client: c}
+	c.TenantStatus = &TenantStatusService{client: c}
+	c.TenantStatsHistoryShort = &TenantStatsHistoryShortService{client: c}
 	c.TenantSnapshots = &TenantSnapshotService{client: c}
 	c.TenantLayer2Networks = &TenantLayer2NetworkService{client: c}
 	c.SnapshotProfiles = &SnapshotProfileService{client: c}

--- a/client.go
+++ b/client.go
@@ -22,6 +22,8 @@ const (
 	apiBasePath = "/api/v4"
 	// defaultUserAgent is the default User-Agent header.
 	defaultUserAgent = "govergeos/1.0"
+	// maxResponseSize is the maximum response body size (100 MB).
+	maxResponseSize = 100 << 20
 )
 
 // Client is the VergeOS API client.
@@ -457,8 +459,8 @@ func (c *Client) do(ctx context.Context, method, endpoint string, body interface
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	// Read response body
-	respBody, err := io.ReadAll(resp.Body)
+	// Read response body (bounded to prevent OOM from misbehaving servers)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
 	if err != nil {
 		return fmt.Errorf("vergeos: failed to read response body: %w", err)
 	}
@@ -553,7 +555,7 @@ func (c *Client) getAbsolute(ctx context.Context, path string, params url.Values
 
 	// Check for HTTP errors
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
 		if resp.StatusCode == 401 || resp.StatusCode == 403 {
 			return &AuthError{Message: string(body)}
 		}

--- a/client.go
+++ b/client.go
@@ -152,18 +152,27 @@ func WithAPIKey(apiKey string) ClientOption {
 	}
 }
 
+// cloneOrNewTransport returns a clone of the existing transport if it is an
+// *http.Transport, or a fresh transport with sensible defaults otherwise.
+func cloneOrNewTransport(rt http.RoundTripper) *http.Transport {
+	if t, ok := rt.(*http.Transport); ok {
+		return t.Clone()
+	}
+	return &http.Transport{
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 20,
+		IdleConnTimeout:     90 * time.Second,
+	}
+}
+
 // WithInsecureTLS configures whether to skip TLS certificate verification.
 // This is useful for self-signed certificates.
 func WithInsecureTLS(insecure bool) ClientOption {
 	return func(c *Client) error {
 		if insecure {
-			transport := &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
-				MaxIdleConns:        100,
-				MaxIdleConnsPerHost: 20,
-				IdleConnTimeout:     90 * time.Second,
+			transport := cloneOrNewTransport(c.httpClient.Transport)
+			transport.TLSClientConfig = &tls.Config{
+				InsecureSkipVerify: true,
 			}
 			c.httpClient.Transport = transport
 		}
@@ -249,13 +258,9 @@ func WithEnvConfig() ClientOption {
 		// Only apply if VERGEOS_VERIFY_SSL is explicitly set to false
 		verifySSL := os.Getenv("VERGEOS_VERIFY_SSL")
 		if strings.ToLower(verifySSL) == "false" || verifySSL == "0" {
-			transport := &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
-				MaxIdleConns:        100,
-				MaxIdleConnsPerHost: 20,
-				IdleConnTimeout:     90 * time.Second,
+			transport := cloneOrNewTransport(c.httpClient.Transport)
+			transport.TLSClientConfig = &tls.Config{
+				InsecureSkipVerify: true,
 			}
 			c.httpClient.Transport = transport
 		}

--- a/client.go
+++ b/client.go
@@ -459,7 +459,7 @@ func (c *Client) do(ctx context.Context, method, endpoint string, body interface
 	}
 
 	// Check for HTTP errors
-	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// Try to parse error message from response
 		var apiResp apiResponse
 		errMsg := string(respBody)
@@ -547,7 +547,7 @@ func (c *Client) getAbsolute(ctx context.Context, path string, params url.Values
 	defer func() { _ = resp.Body.Close() }()
 
 	// Check for HTTP errors
-	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
 		if resp.StatusCode == 401 || resp.StatusCode == 403 {
 			return &AuthError{Message: string(body)}

--- a/cloud_snapshot.go
+++ b/cloud_snapshot.go
@@ -87,7 +87,7 @@ func (s *CloudSnapshotService) Create(ctx context.Context, req *CloudSnapshotCre
 	}
 
 	// Cloud snapshots use table_actions/create endpoint
-	tableAction := map[string]interface{}{
+	tableAction := map[string]any{
 		"name": req.Name,
 	}
 	if req.Description != "" {
@@ -173,7 +173,7 @@ func (s *CloudSnapshotService) Clone(ctx context.Context, id int, opts *CloudSna
 	action := cloudSnapshotAction{
 		CloudSnapshot: id,
 		Action:        "clone",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"name": opts.Name,
 		},
 	}

--- a/cloud_snapshot.go
+++ b/cloud_snapshot.go
@@ -66,7 +66,7 @@ func (s *CloudSnapshotService) Get(ctx context.Context, id int) (*CloudSnapshot,
 
 // GetByName returns a cloud snapshot by name.
 func (s *CloudSnapshotService) GetByName(ctx context.Context, name string) (*CloudSnapshot, error) {
-	snapshots, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	snapshots, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/cloud_snapshot.go
+++ b/cloud_snapshot.go
@@ -56,7 +56,7 @@ func (s *CloudSnapshotService) Get(ctx context.Context, id int) (*CloudSnapshot,
 	endpoint := fmt.Sprintf("/cloud_snapshots/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &snapshot); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "CloudSnapshot", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "CloudSnapshot", ID: id}
 		}
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (s *CloudSnapshotService) Update(ctx context.Context, id int, req *CloudSna
 	endpoint := fmt.Sprintf("/cloud_snapshots/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "CloudSnapshot", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "CloudSnapshot", ID: id}
 		}
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (s *CloudSnapshotService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/cloud_snapshots/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "CloudSnapshot", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "CloudSnapshot", ID: id}
 		}
 		return err
 	}
@@ -261,7 +261,7 @@ func (s *CloudSnapshotVMService) Get(ctx context.Context, id int) (*CloudSnapsho
 	endpoint := fmt.Sprintf("/cloud_snapshot_vms/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &vm); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "CloudSnapshotVM", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "CloudSnapshotVM", ID: id}
 		}
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func (s *CloudSnapshotTenantService) Get(ctx context.Context, id int) (*CloudSna
 	endpoint := fmt.Sprintf("/cloud_snapshot_tenants/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &tenant); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "CloudSnapshotTenant", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "CloudSnapshotTenant", ID: id}
 		}
 		return nil, err
 	}

--- a/cloud_snapshot_test.go
+++ b/cloud_snapshot_test.go
@@ -1,0 +1,574 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// CloudSnapshotService
+// ---------------------------------------------------------------------------
+
+func TestCloudSnapshotService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloud_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []CloudSnapshot{
+				{Key: 1, Name: "snap-daily-20260101", Status: "normal"},
+				{Key: 2, Name: "snap-daily-20260102", Status: "normal"},
+			})
+		},
+	}))
+
+	snaps, err := client.CloudSnapshots.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(snaps) != 2 {
+		t.Fatalf("expected 2 snapshots, got %d", len(snaps))
+	}
+	if snaps[0].Name != "snap-daily-20260101" {
+		t.Errorf("expected name 'snap-daily-20260101', got %q", snaps[0].Name)
+	}
+}
+
+func TestCloudSnapshotService_ListExpiring(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloud_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter for expiring snapshots")
+			}
+			jsonResponse(w, 200, []CloudSnapshot{{Key: 1, Expires: 1735776000}})
+		},
+	}))
+
+	snaps, err := client.CloudSnapshots.ListExpiring(context.Background())
+	if err != nil {
+		t.Fatalf("ListExpiring failed: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(snaps))
+	}
+}
+
+func TestCloudSnapshotService_ListLocal(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloud_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter for local snapshots")
+			}
+			jsonResponse(w, 200, []CloudSnapshot{{Key: 1, Provider: false}})
+		},
+	}))
+
+	snaps, err := client.CloudSnapshots.ListLocal(context.Background())
+	if err != nil {
+		t.Fatalf("ListLocal failed: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(snaps))
+	}
+}
+
+func TestCloudSnapshotService_ListByProfile(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloud_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter for profile")
+			}
+			jsonResponse(w, 200, []CloudSnapshot{{Key: 1, SnapshotProfile: 5}})
+		},
+	}))
+
+	snaps, err := client.CloudSnapshots.ListByProfile(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("ListByProfile failed: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(snaps))
+	}
+}
+
+func TestCloudSnapshotService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloud_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, CloudSnapshot{Key: 1, Name: "snap-daily-20260101", Status: "normal"})
+		},
+	}))
+
+	snap, err := client.CloudSnapshots.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if snap.Name != "snap-daily-20260101" {
+		t.Errorf("expected name 'snap-daily-20260101', got %q", snap.Name)
+	}
+}
+
+func TestCloudSnapshotService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloud_snapshots/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.CloudSnapshots.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestCloudSnapshotService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloud_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []CloudSnapshot{{Key: 1, Name: "snap-daily-20260101"}})
+		},
+		"GET /api/v4/cloud_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, CloudSnapshot{Key: 1, Name: "snap-daily-20260101", Status: "normal"})
+		},
+	}))
+
+	snap, err := client.CloudSnapshots.GetByName(context.Background(), "snap-daily-20260101")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if snap.Name != "snap-daily-20260101" {
+		t.Errorf("expected name 'snap-daily-20260101', got %q", snap.Name)
+	}
+}
+
+func TestCloudSnapshotService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloud_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []CloudSnapshot{})
+		},
+	}))
+
+	_, err := client.CloudSnapshots.GetByName(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestCloudSnapshotService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/cloud_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["name"] != "manual-snap" {
+				t.Errorf("expected name 'manual-snap', got %v", body["name"])
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+		},
+		"GET /api/v4/cloud_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, CloudSnapshot{Key: 1, Name: "manual-snap", Status: "normal"})
+		},
+	}))
+
+	snap, err := client.CloudSnapshots.Create(context.Background(), &CloudSnapshotCreateRequest{
+		Name: "manual-snap",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if snap.Name != "manual-snap" {
+		t.Errorf("expected name 'manual-snap', got %q", snap.Name)
+	}
+}
+
+func TestCloudSnapshotService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.CloudSnapshots.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCloudSnapshotService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.CloudSnapshots.Create(context.Background(), &CloudSnapshotCreateRequest{})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCloudSnapshotService_Update(t *testing.T) {
+	newDesc := "updated description"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/cloud_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			var req CloudSnapshotUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Description == nil || *req.Description != newDesc {
+				t.Errorf("expected description %q, got %v", newDesc, req.Description)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/cloud_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, CloudSnapshot{Key: 1, Name: "snap", Description: newDesc})
+		},
+	}))
+
+	snap, err := client.CloudSnapshots.Update(context.Background(), 1, &CloudSnapshotUpdateRequest{Description: &newDesc})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if snap.Description != newDesc {
+		t.Errorf("expected description %q, got %q", newDesc, snap.Description)
+	}
+}
+
+func TestCloudSnapshotService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.CloudSnapshots.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCloudSnapshotService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/cloud_snapshots/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newDesc := "test"
+	_, err := client.CloudSnapshots.Update(context.Background(), 999, &CloudSnapshotUpdateRequest{Description: &newDesc})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestCloudSnapshotService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/cloud_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.CloudSnapshots.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestCloudSnapshotService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/cloud_snapshots/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.CloudSnapshots.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestCloudSnapshotService_Refresh(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/cloud_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "refresh" {
+				t.Errorf("expected action 'refresh', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.CloudSnapshots.Refresh(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Refresh failed: %v", err)
+	}
+}
+
+func TestCloudSnapshotService_Clone(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/cloud_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "clone" {
+				t.Errorf("expected action 'clone', got %v", body["action"])
+			}
+			params, ok := body["params"].(map[string]interface{})
+			if !ok {
+				t.Fatal("expected params in body")
+			}
+			if params["name"] != "cloned-snap" {
+				t.Errorf("expected name 'cloned-snap', got %v", params["name"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.CloudSnapshots.Clone(context.Background(), 1, &CloudSnapshotCloneOptions{Name: "cloned-snap"})
+	if err != nil {
+		t.Fatalf("Clone failed: %v", err)
+	}
+}
+
+func TestCloudSnapshotService_Clone_NilOptions(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	err := client.CloudSnapshots.Clone(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil options")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCloudSnapshotService_Clone_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	err := client.CloudSnapshots.Clone(context.Background(), 1, &CloudSnapshotCloneOptions{})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCloudSnapshotService_RequestFromProvider(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/cloud_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "request" {
+				t.Errorf("expected action 'request', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.CloudSnapshots.RequestFromProvider(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("RequestFromProvider failed: %v", err)
+	}
+}
+
+func TestCloudSnapshotService_FindTenants(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/cloud_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "find_tenants" {
+				t.Errorf("expected action 'find_tenants', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.CloudSnapshots.FindTenants(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("FindTenants failed: %v", err)
+	}
+}
+
+func TestCloudSnapshotService_FindVMs(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/cloud_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "find_vms" {
+				t.Errorf("expected action 'find_vms', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.CloudSnapshots.FindVMs(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("FindVMs failed: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CloudSnapshotVMService
+// ---------------------------------------------------------------------------
+
+func TestCloudSnapshotVMService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloud_snapshot_vms": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []CloudSnapshotVM{
+				{Key: 1, Name: "vm-web-01", CloudSnapshot: 10, CPUCores: 4, RAM: 8192},
+				{Key: 2, Name: "vm-db-01", CloudSnapshot: 10, CPUCores: 8, RAM: 16384},
+			})
+		},
+	}))
+
+	vms, err := client.CloudSnapshotVMs.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(vms) != 2 {
+		t.Fatalf("expected 2 VMs, got %d", len(vms))
+	}
+	if vms[0].Name != "vm-web-01" {
+		t.Errorf("expected name 'vm-web-01', got %q", vms[0].Name)
+	}
+}
+
+func TestCloudSnapshotVMService_ListBySnapshot(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloud_snapshot_vms": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter for snapshot")
+			}
+			jsonResponse(w, 200, []CloudSnapshotVM{{Key: 1, CloudSnapshot: 10, Name: "vm-web-01"}})
+		},
+	}))
+
+	vms, err := client.CloudSnapshotVMs.ListBySnapshot(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListBySnapshot failed: %v", err)
+	}
+	if len(vms) != 1 {
+		t.Fatalf("expected 1 VM, got %d", len(vms))
+	}
+}
+
+func TestCloudSnapshotVMService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloud_snapshot_vms/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, CloudSnapshotVM{Key: 1, Name: "vm-web-01", CPUCores: 4, RAM: 8192})
+		},
+	}))
+
+	vm, err := client.CloudSnapshotVMs.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if vm.Name != "vm-web-01" {
+		t.Errorf("expected name 'vm-web-01', got %q", vm.Name)
+	}
+	if vm.CPUCores != 4 {
+		t.Errorf("expected 4 cpu cores, got %d", vm.CPUCores)
+	}
+}
+
+func TestCloudSnapshotVMService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloud_snapshot_vms/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.CloudSnapshotVMs.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CloudSnapshotTenantService
+// ---------------------------------------------------------------------------
+
+func TestCloudSnapshotTenantService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloud_snapshot_tenants": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []CloudSnapshotTenant{
+				{Key: 1, Name: "tenant-prod", CloudSnapshot: 10},
+				{Key: 2, Name: "tenant-dev", CloudSnapshot: 10},
+			})
+		},
+	}))
+
+	tenants, err := client.CloudSnapshotTenants.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(tenants) != 2 {
+		t.Fatalf("expected 2 tenants, got %d", len(tenants))
+	}
+	if tenants[0].Name != "tenant-prod" {
+		t.Errorf("expected name 'tenant-prod', got %q", tenants[0].Name)
+	}
+}
+
+func TestCloudSnapshotTenantService_ListBySnapshot(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloud_snapshot_tenants": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter for snapshot")
+			}
+			jsonResponse(w, 200, []CloudSnapshotTenant{{Key: 1, CloudSnapshot: 10, Name: "tenant-prod"}})
+		},
+	}))
+
+	tenants, err := client.CloudSnapshotTenants.ListBySnapshot(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListBySnapshot failed: %v", err)
+	}
+	if len(tenants) != 1 {
+		t.Fatalf("expected 1 tenant, got %d", len(tenants))
+	}
+}
+
+func TestCloudSnapshotTenantService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloud_snapshot_tenants/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, CloudSnapshotTenant{Key: 1, Name: "tenant-prod", CloudSnapshot: 10})
+		},
+	}))
+
+	tenant, err := client.CloudSnapshotTenants.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if tenant.Name != "tenant-prod" {
+		t.Errorf("expected name 'tenant-prod', got %q", tenant.Name)
+	}
+}
+
+func TestCloudSnapshotTenantService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloud_snapshot_tenants/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.CloudSnapshotTenants.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/cloud_snapshot_test.go
+++ b/cloud_snapshot_test.go
@@ -163,12 +163,12 @@ func TestCloudSnapshotService_GetByName_NotFound(t *testing.T) {
 func TestCloudSnapshotService_Create(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/cloud_snapshots": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["name"] != "manual-snap" {
 				t.Errorf("expected name 'manual-snap', got %v", body["name"])
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/cloud_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, CloudSnapshot{Key: 1, Name: "manual-snap", Status: "normal"})
@@ -296,7 +296,7 @@ func TestCloudSnapshotService_Delete_NotFound(t *testing.T) {
 func TestCloudSnapshotService_Refresh(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/cloud_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "refresh" {
 				t.Errorf("expected action 'refresh', got %v", body["action"])
@@ -314,12 +314,12 @@ func TestCloudSnapshotService_Refresh(t *testing.T) {
 func TestCloudSnapshotService_Clone(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/cloud_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "clone" {
 				t.Errorf("expected action 'clone', got %v", body["action"])
 			}
-			params, ok := body["params"].(map[string]interface{})
+			params, ok := body["params"].(map[string]any)
 			if !ok {
 				t.Fatal("expected params in body")
 			}
@@ -363,7 +363,7 @@ func TestCloudSnapshotService_Clone_MissingName(t *testing.T) {
 func TestCloudSnapshotService_RequestFromProvider(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/cloud_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "request" {
 				t.Errorf("expected action 'request', got %v", body["action"])
@@ -381,7 +381,7 @@ func TestCloudSnapshotService_RequestFromProvider(t *testing.T) {
 func TestCloudSnapshotService_FindTenants(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/cloud_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "find_tenants" {
 				t.Errorf("expected action 'find_tenants', got %v", body["action"])
@@ -399,7 +399,7 @@ func TestCloudSnapshotService_FindTenants(t *testing.T) {
 func TestCloudSnapshotService_FindVMs(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/cloud_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "find_vms" {
 				t.Errorf("expected action 'find_vms', got %v", body["action"])

--- a/cloudinit.go
+++ b/cloudinit.go
@@ -108,7 +108,7 @@ func (s *CloudInitService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/cloudinit_files/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "CloudInit", ID: id}
 		}
 		return err
 	}

--- a/cloudinit.go
+++ b/cloudinit.go
@@ -49,7 +49,7 @@ func (s *CloudInitService) Get(ctx context.Context, id int) (*CloudInitFile, err
 
 // GetByName returns a cloud-init file by name.
 func (s *CloudInitService) GetByName(ctx context.Context, name string) (*CloudInitFile, error) {
-	files, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	files, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/cloudinit_test.go
+++ b/cloudinit_test.go
@@ -243,7 +243,10 @@ func TestCloudInitService_Delete_NotFound(t *testing.T) {
 
 	// Delete returns nil for not found (already deleted)
 	err := client.CloudInitFiles.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("Delete should not error for not found, got: %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted cloud-init")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }

--- a/cloudinit_test.go
+++ b/cloudinit_test.go
@@ -124,7 +124,7 @@ func TestCloudInitService_Create(t *testing.T) {
 			if req.Name != "user-data" {
 				t.Errorf("expected name 'user-data', got %q", req.Name)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/cloudinit_files/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, CloudInitFile{ID: 1, Name: "user-data", Contents: "#cloud-config"})

--- a/cloudinit_test.go
+++ b/cloudinit_test.go
@@ -1,0 +1,249 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestCloudInitService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloudinit_files": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []CloudInitFile{
+				{ID: 1, Name: "user-data", Contents: "#cloud-config"},
+				{ID: 2, Name: "meta-data", Contents: "instance-id: test"},
+			})
+		},
+	}))
+
+	files, err := client.CloudInitFiles.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(files))
+	}
+	if files[0].Name != "user-data" {
+		t.Errorf("expected name 'user-data', got %q", files[0].Name)
+	}
+}
+
+func TestCloudInitService_List_WithFilter(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloudinit_files": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter parameter")
+			}
+			jsonResponse(w, 200, []CloudInitFile{{ID: 1, Name: "user-data"}})
+		},
+	}))
+
+	files, err := client.CloudInitFiles.List(context.Background(), WithFilter("name eq 'user-data'"))
+	if err != nil {
+		t.Fatalf("List with filter failed: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+}
+
+func TestCloudInitService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloudinit_files/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, CloudInitFile{ID: 1, Name: "user-data", Contents: "#cloud-config"})
+		},
+	}))
+
+	file, err := client.CloudInitFiles.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if file.Name != "user-data" {
+		t.Errorf("expected name 'user-data', got %q", file.Name)
+	}
+	if file.Contents != "#cloud-config" {
+		t.Errorf("expected contents '#cloud-config', got %q", file.Contents)
+	}
+}
+
+func TestCloudInitService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloudinit_files/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.CloudInitFiles.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestCloudInitService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloudinit_files": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []CloudInitFile{{ID: 1, Name: "user-data"}})
+		},
+	}))
+
+	file, err := client.CloudInitFiles.GetByName(context.Background(), "user-data")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if file.Name != "user-data" {
+		t.Errorf("expected name 'user-data', got %q", file.Name)
+	}
+}
+
+func TestCloudInitService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cloudinit_files": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []CloudInitFile{})
+		},
+	}))
+
+	_, err := client.CloudInitFiles.GetByName(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestCloudInitService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/cloudinit_files": func(w http.ResponseWriter, r *http.Request) {
+			var req CloudInitFileCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "user-data" {
+				t.Errorf("expected name 'user-data', got %q", req.Name)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+		},
+		"GET /api/v4/cloudinit_files/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, CloudInitFile{ID: 1, Name: "user-data", Contents: "#cloud-config"})
+		},
+	}))
+
+	file, err := client.CloudInitFiles.Create(context.Background(), &CloudInitFileCreateRequest{
+		Name:     "user-data",
+		Contents: "#cloud-config",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if file.Name != "user-data" {
+		t.Errorf("expected name 'user-data', got %q", file.Name)
+	}
+}
+
+func TestCloudInitService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.CloudInitFiles.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCloudInitService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.CloudInitFiles.Create(context.Background(), &CloudInitFileCreateRequest{})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCloudInitService_Update(t *testing.T) {
+	newName := "meta-data"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/cloudinit_files/1": func(w http.ResponseWriter, r *http.Request) {
+			var req CloudInitFileUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/cloudinit_files/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, CloudInitFile{ID: 1, Name: newName})
+		},
+	}))
+
+	file, err := client.CloudInitFiles.Update(context.Background(), 1, &CloudInitFileUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if file.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, file.Name)
+	}
+}
+
+func TestCloudInitService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.CloudInitFiles.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestCloudInitService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/cloudinit_files/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newName := "updated"
+	_, err := client.CloudInitFiles.Update(context.Background(), 999, &CloudInitFileUpdateRequest{Name: &newName})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestCloudInitService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/cloudinit_files/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.CloudInitFiles.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestCloudInitService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/cloudinit_files/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	// Delete returns nil for not found (already deleted)
+	err := client.CloudInitFiles.Delete(context.Background(), 999)
+	if err != nil {
+		t.Fatalf("Delete should not error for not found, got: %v", err)
+	}
+}

--- a/cluster.go
+++ b/cluster.go
@@ -133,7 +133,7 @@ func (s *ClusterService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/clusters/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "Cluster", ID: id}
 		}
 		return err
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -48,7 +48,7 @@ func (s *ClusterService) Get(ctx context.Context, id int) (*Cluster, error) {
 
 // GetByName returns a cluster by name.
 func (s *ClusterService) GetByName(ctx context.Context, name string) (*Cluster, error) {
-	clusters, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	clusters, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -271,7 +271,10 @@ func TestClusterService_Delete_NotFound(t *testing.T) {
 
 	// Cluster.Delete returns nil for 404 (already deleted)
 	err := client.Clusters.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("expected nil for not-found delete, got: %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted cluster")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1,0 +1,277 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestClusterService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/clusters": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Cluster{
+				{Key: 1, Name: "cluster-a", Enabled: true},
+				{Key: 2, Name: "cluster-b", Enabled: false},
+			})
+		},
+	}))
+
+	clusters, err := client.Clusters.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(clusters) != 2 {
+		t.Fatalf("expected 2 clusters, got %d", len(clusters))
+	}
+	if clusters[0].Name != "cluster-a" {
+		t.Errorf("expected name 'cluster-a', got %q", clusters[0].Name)
+	}
+}
+
+func TestClusterService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/clusters/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Cluster{Key: 1, Name: "cluster-a", Enabled: true, Description: "primary"})
+		},
+	}))
+
+	cluster, err := client.Clusters.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if cluster.Name != "cluster-a" {
+		t.Errorf("expected name 'cluster-a', got %q", cluster.Name)
+	}
+	if cluster.Description != "primary" {
+		t.Errorf("expected description 'primary', got %q", cluster.Description)
+	}
+}
+
+func TestClusterService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/clusters/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Clusters.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestClusterService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/clusters": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Cluster{{Key: 1, Name: "cluster-a"}})
+		},
+	}))
+
+	cluster, err := client.Clusters.GetByName(context.Background(), "cluster-a")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if cluster.Name != "cluster-a" {
+		t.Errorf("expected name 'cluster-a', got %q", cluster.Name)
+	}
+}
+
+func TestClusterService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/clusters": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Cluster{})
+		},
+	}))
+
+	_, err := client.Clusters.GetByName(context.Background(), "nope")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestClusterService_GetStatus(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/clusters/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, struct {
+				Status ClusterStatus `json:"status"`
+			}{
+				Status: ClusterStatus{
+					Cluster:    1,
+					Status:     "online",
+					TotalNodes: 3,
+					OnlineNodes: 3,
+				},
+			})
+		},
+	}))
+
+	status, err := client.Clusters.GetStatus(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetStatus failed: %v", err)
+	}
+	if status.Status != "online" {
+		t.Errorf("expected status 'online', got %q", status.Status)
+	}
+	if status.TotalNodes != 3 {
+		t.Errorf("expected 3 total nodes, got %d", status.TotalNodes)
+	}
+}
+
+func TestClusterService_GetStatus_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/clusters/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Clusters.GetStatus(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestClusterService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/clusters": func(w http.ResponseWriter, r *http.Request) {
+			var req ClusterCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "new-cluster" {
+				t.Errorf("expected name 'new-cluster', got %q", req.Name)
+			}
+			if req.Enabled == nil || !*req.Enabled {
+				t.Error("expected enabled to default to true")
+			}
+			jsonResponse(w, 200, apiResponse{Key: 10})
+		},
+		"GET /api/v4/clusters/10": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Cluster{Key: 10, Name: "new-cluster", Enabled: true})
+		},
+	}))
+
+	cluster, err := client.Clusters.Create(context.Background(), &ClusterCreateRequest{
+		Name: "new-cluster",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if cluster.Name != "new-cluster" {
+		t.Errorf("expected name 'new-cluster', got %q", cluster.Name)
+	}
+}
+
+func TestClusterService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Clusters.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestClusterService_Create_EmptyName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Clusters.Create(context.Background(), &ClusterCreateRequest{})
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestClusterService_Update(t *testing.T) {
+	newName := "renamed"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/clusters/1": func(w http.ResponseWriter, r *http.Request) {
+			var req ClusterUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/clusters/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Cluster{Key: 1, Name: newName})
+		},
+	}))
+
+	cluster, err := client.Clusters.Update(context.Background(), 1, &ClusterUpdateRequest{
+		Name: &newName,
+	})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if cluster.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, cluster.Name)
+	}
+}
+
+func TestClusterService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Clusters.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestClusterService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/clusters/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newName := "nope"
+	_, err := client.Clusters.Update(context.Background(), 999, &ClusterUpdateRequest{Name: &newName})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestClusterService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/clusters/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Clusters.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestClusterService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/clusters/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	// Cluster.Delete returns nil for 404 (already deleted)
+	err := client.Clusters.Delete(context.Background(), 999)
+	if err != nil {
+		t.Fatalf("expected nil for not-found delete, got: %v", err)
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -58,6 +58,27 @@ func (e *ValidationError) Error() string {
 	return fmt.Sprintf("vergeos: validation error: %s", e.Message)
 }
 
+// TimeoutError is returned when a polling operation exceeds its retry limit.
+type TimeoutError struct {
+	Resource string
+	ID       int
+	Action   string
+}
+
+// Error implements the error interface.
+func (e *TimeoutError) Error() string {
+	return fmt.Sprintf("vergeos: timeout waiting for %s %d to %s", e.Resource, e.ID, e.Action)
+}
+
+// IsTimeoutError returns true if the error is a TimeoutError.
+func IsTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var timeoutErr *TimeoutError
+	return errors.As(err, &timeoutErr)
+}
+
 // IsNotFoundError returns true if the error is a NotFoundError or a 404 API error.
 func IsNotFoundError(err error) bool {
 	if err == nil {

--- a/errors.go
+++ b/errors.go
@@ -23,7 +23,7 @@ func (e *APIError) Error() string {
 // NotFoundError is returned when a resource is not found.
 type NotFoundError struct {
 	Resource string
-	ID       interface{}
+	ID       any
 }
 
 // Error implements the error interface.

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,247 @@
+package vergeos
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// --- Error message formatting ---
+
+func TestAPIError_Error(t *testing.T) {
+	err := &APIError{StatusCode: 500, Endpoint: "/api/v4/vms", Message: "internal error"}
+	want := "vergeos: API error 500 at /api/v4/vms: internal error"
+	if err.Error() != want {
+		t.Errorf("got %q, want %q", err.Error(), want)
+	}
+}
+
+func TestNotFoundError_Error(t *testing.T) {
+	err := &NotFoundError{Resource: "VM", ID: 42}
+	want := "vergeos: VM with ID 42 not found"
+	if err.Error() != want {
+		t.Errorf("got %q, want %q", err.Error(), want)
+	}
+}
+
+func TestNotFoundError_Error_StringID(t *testing.T) {
+	err := &NotFoundError{Resource: "VolumeBrowserJob", ID: "sha1hash"}
+	want := "vergeos: VolumeBrowserJob with ID sha1hash not found"
+	if err.Error() != want {
+		t.Errorf("got %q, want %q", err.Error(), want)
+	}
+}
+
+func TestAuthError_Error(t *testing.T) {
+	err := &AuthError{Message: "invalid credentials"}
+	want := "vergeos: authentication failed: invalid credentials"
+	if err.Error() != want {
+		t.Errorf("got %q, want %q", err.Error(), want)
+	}
+}
+
+func TestAuthError_Error_Empty(t *testing.T) {
+	err := &AuthError{}
+	want := "vergeos: authentication failed"
+	if err.Error() != want {
+		t.Errorf("got %q, want %q", err.Error(), want)
+	}
+}
+
+func TestValidationError_Error_WithField(t *testing.T) {
+	err := &ValidationError{Field: "name", Message: "is required"}
+	want := "vergeos: validation error on field name: is required"
+	if err.Error() != want {
+		t.Errorf("got %q, want %q", err.Error(), want)
+	}
+}
+
+func TestValidationError_Error_WithoutField(t *testing.T) {
+	err := &ValidationError{Message: "request is required"}
+	want := "vergeos: validation error: request is required"
+	if err.Error() != want {
+		t.Errorf("got %q, want %q", err.Error(), want)
+	}
+}
+
+// --- IsNotFoundError ---
+
+func TestIsNotFoundError_Nil(t *testing.T) {
+	if IsNotFoundError(nil) {
+		t.Error("expected false for nil error")
+	}
+}
+
+func TestIsNotFoundError_Direct(t *testing.T) {
+	err := &NotFoundError{Resource: "VM", ID: 1}
+	if !IsNotFoundError(err) {
+		t.Error("expected true for NotFoundError")
+	}
+}
+
+func TestIsNotFoundError_Wrapped(t *testing.T) {
+	inner := &NotFoundError{Resource: "VM", ID: 1}
+	err := fmt.Errorf("wrapped: %w", inner)
+	if !IsNotFoundError(err) {
+		t.Error("expected true for wrapped NotFoundError")
+	}
+}
+
+func TestIsNotFoundError_APIError404(t *testing.T) {
+	err := &APIError{StatusCode: 404, Endpoint: "/vms/1", Message: "not found"}
+	if !IsNotFoundError(err) {
+		t.Error("expected true for 404 APIError")
+	}
+}
+
+func TestIsNotFoundError_APIError500(t *testing.T) {
+	err := &APIError{StatusCode: 500, Endpoint: "/vms", Message: "server error"}
+	if IsNotFoundError(err) {
+		t.Error("expected false for 500 APIError")
+	}
+}
+
+func TestIsNotFoundError_OtherError(t *testing.T) {
+	err := errors.New("some random error")
+	if IsNotFoundError(err) {
+		t.Error("expected false for generic error")
+	}
+}
+
+// --- IsAuthError ---
+
+func TestIsAuthError_Nil(t *testing.T) {
+	if IsAuthError(nil) {
+		t.Error("expected false for nil error")
+	}
+}
+
+func TestIsAuthError_Direct(t *testing.T) {
+	err := &AuthError{Message: "bad creds"}
+	if !IsAuthError(err) {
+		t.Error("expected true for AuthError")
+	}
+}
+
+func TestIsAuthError_Wrapped(t *testing.T) {
+	inner := &AuthError{Message: "expired"}
+	err := fmt.Errorf("wrapped: %w", inner)
+	if !IsAuthError(err) {
+		t.Error("expected true for wrapped AuthError")
+	}
+}
+
+func TestIsAuthError_APIError401(t *testing.T) {
+	err := &APIError{StatusCode: 401, Endpoint: "/login", Message: "unauthorized"}
+	if !IsAuthError(err) {
+		t.Error("expected true for 401 APIError")
+	}
+}
+
+func TestIsAuthError_APIError403(t *testing.T) {
+	err := &APIError{StatusCode: 403, Endpoint: "/admin", Message: "forbidden"}
+	if !IsAuthError(err) {
+		t.Error("expected true for 403 APIError")
+	}
+}
+
+func TestIsAuthError_APIError500(t *testing.T) {
+	err := &APIError{StatusCode: 500, Endpoint: "/vms", Message: "server error"}
+	if IsAuthError(err) {
+		t.Error("expected false for 500 APIError")
+	}
+}
+
+func TestIsAuthError_OtherError(t *testing.T) {
+	err := errors.New("something else")
+	if IsAuthError(err) {
+		t.Error("expected false for generic error")
+	}
+}
+
+// --- IsValidationError ---
+
+func TestIsValidationError_Nil(t *testing.T) {
+	if IsValidationError(nil) {
+		t.Error("expected false for nil error")
+	}
+}
+
+func TestIsValidationError_Direct(t *testing.T) {
+	err := &ValidationError{Field: "name", Message: "required"}
+	if !IsValidationError(err) {
+		t.Error("expected true for ValidationError")
+	}
+}
+
+func TestIsValidationError_Wrapped(t *testing.T) {
+	inner := &ValidationError{Message: "missing"}
+	err := fmt.Errorf("wrapped: %w", inner)
+	if !IsValidationError(err) {
+		t.Error("expected true for wrapped ValidationError")
+	}
+}
+
+func TestIsValidationError_APIError400(t *testing.T) {
+	err := &APIError{StatusCode: 400, Endpoint: "/vms", Message: "bad request"}
+	if !IsValidationError(err) {
+		t.Error("expected true for 400 APIError")
+	}
+}
+
+func TestIsValidationError_APIError500(t *testing.T) {
+	err := &APIError{StatusCode: 500, Endpoint: "/vms", Message: "server error"}
+	if IsValidationError(err) {
+		t.Error("expected false for 500 APIError")
+	}
+}
+
+func TestIsValidationError_OtherError(t *testing.T) {
+	err := errors.New("nope")
+	if IsValidationError(err) {
+		t.Error("expected false for generic error")
+	}
+}
+
+// --- errors.As compatibility ---
+
+func TestErrorsAs_APIError(t *testing.T) {
+	err := &APIError{StatusCode: 422, Endpoint: "/test", Message: "unprocessable"}
+	var target *APIError
+	if !errors.As(err, &target) {
+		t.Error("errors.As should match APIError")
+	}
+	if target.StatusCode != 422 {
+		t.Errorf("expected status 422, got %d", target.StatusCode)
+	}
+}
+
+func TestErrorsAs_NotFoundError(t *testing.T) {
+	err := fmt.Errorf("outer: %w", &NotFoundError{Resource: "Network", ID: 7})
+	var target *NotFoundError
+	if !errors.As(err, &target) {
+		t.Error("errors.As should match wrapped NotFoundError")
+	}
+	if target.Resource != "Network" {
+		t.Errorf("expected resource 'Network', got %q", target.Resource)
+	}
+}
+
+func TestErrorsAs_AuthError(t *testing.T) {
+	err := fmt.Errorf("outer: %w", &AuthError{Message: "token expired"})
+	var target *AuthError
+	if !errors.As(err, &target) {
+		t.Error("errors.As should match wrapped AuthError")
+	}
+}
+
+func TestErrorsAs_ValidationError(t *testing.T) {
+	err := fmt.Errorf("outer: %w", &ValidationError{Field: "ram", Message: "must be positive"})
+	var target *ValidationError
+	if !errors.As(err, &target) {
+		t.Error("errors.As should match wrapped ValidationError")
+	}
+	if target.Field != "ram" {
+		t.Errorf("expected field 'ram', got %q", target.Field)
+	}
+}

--- a/file.go
+++ b/file.go
@@ -56,7 +56,7 @@ func (s *FileService) Get(ctx context.Context, id int) (*File, error) {
 
 // GetByName returns a file by name.
 func (s *FileService) GetByName(ctx context.Context, name string) (*File, error) {
-	files, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	files, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/file.go
+++ b/file.go
@@ -1,6 +1,7 @@
 package vergeos
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -294,7 +295,7 @@ func (s *FileService) uploadChunk(ctx context.Context, id int, data []byte, offs
 	req.Close = true
 
 	// Set body
-	req.Body = io.NopCloser(newBytesReader(data))
+	req.Body = io.NopCloser(bytes.NewReader(data))
 	req.ContentLength = int64(len(data))
 
 	// Execute request
@@ -315,23 +316,4 @@ func (s *FileService) uploadChunk(ctx context.Context, id int, data []byte, offs
 	}
 
 	return nil
-}
-
-// bytesReader wraps a byte slice to implement io.Reader.
-type bytesReader struct {
-	data   []byte
-	offset int
-}
-
-func newBytesReader(data []byte) *bytesReader {
-	return &bytesReader{data: data}
-}
-
-func (r *bytesReader) Read(p []byte) (n int, err error) {
-	if r.offset >= len(r.data) {
-		return 0, io.EOF
-	}
-	n = copy(p, r.data[r.offset:])
-	r.offset += n
-	return n, nil
 }

--- a/file.go
+++ b/file.go
@@ -106,7 +106,13 @@ func (s *FileService) Update(ctx context.Context, id int, req *FileUpdateRequest
 // Files that are referenced by VM drives cannot be deleted until the reference is removed.
 func (s *FileService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/files/%d", id)
-	return s.client.delete(ctx, endpoint)
+	if err := s.client.delete(ctx, endpoint); err != nil {
+		if IsNotFoundError(err) {
+			return &NotFoundError{Resource: "File", ID: id}
+		}
+		return err
+	}
+	return nil
 }
 
 // Download downloads a file from VergeOS and returns an io.ReadCloser.

--- a/file_test.go
+++ b/file_test.go
@@ -1,0 +1,391 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestFileService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/files": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []File{
+				{ID: 1, Name: "ubuntu.iso", Type: "iso"},
+				{ID: 2, Name: "data.img", Type: "img"},
+			})
+		},
+	}))
+
+	files, err := client.Files.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(files))
+	}
+	if files[0].Name != "ubuntu.iso" {
+		t.Errorf("expected name 'ubuntu.iso', got %q", files[0].Name)
+	}
+}
+
+func TestFileService_List_WithFilter(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/files": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter parameter")
+			}
+			jsonResponse(w, 200, []File{{ID: 1, Name: "ubuntu.iso", Type: "iso"}})
+		},
+	}))
+
+	files, err := client.Files.List(context.Background(), WithFilter("type eq 'iso'"))
+	if err != nil {
+		t.Fatalf("List with filter failed: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+}
+
+func TestFileService_List_Empty(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/files": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []File{})
+		},
+	}))
+
+	files, err := client.Files.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected 0 files, got %d", len(files))
+	}
+}
+
+func TestFileService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/files/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, File{ID: 1, Name: "ubuntu.iso", Type: "iso", Filesize: 1048576})
+		},
+	}))
+
+	file, err := client.Files.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if file.Name != "ubuntu.iso" {
+		t.Errorf("expected name 'ubuntu.iso', got %q", file.Name)
+	}
+	if file.Filesize != 1048576 {
+		t.Errorf("expected filesize 1048576, got %d", file.Filesize)
+	}
+}
+
+func TestFileService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/files/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Files.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestFileService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/files": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "name eq 'ubuntu.iso'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []File{{ID: 1, Name: "ubuntu.iso", Type: "iso"}})
+		},
+	}))
+
+	file, err := client.Files.GetByName(context.Background(), "ubuntu.iso")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if file.Name != "ubuntu.iso" {
+		t.Errorf("expected name 'ubuntu.iso', got %q", file.Name)
+	}
+}
+
+func TestFileService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/files": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []File{})
+		},
+	}))
+
+	_, err := client.Files.GetByName(context.Background(), "nonexistent.iso")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestFileService_ListISOs(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/files": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if !strings.Contains(filter, "type eq 'iso'") {
+				t.Errorf("expected ISO filter, got %q", filter)
+			}
+			jsonResponse(w, 200, []File{
+				{ID: 1, Name: "ubuntu.iso", Type: "iso"},
+				{ID: 2, Name: "windows.iso", Type: "iso"},
+			})
+		},
+	}))
+
+	files, err := client.Files.ListISOs(context.Background())
+	if err != nil {
+		t.Fatalf("ListISOs failed: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 ISOs, got %d", len(files))
+	}
+}
+
+func TestFileService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/files": func(w http.ResponseWriter, r *http.Request) {
+			var req FileCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "test.iso" {
+				t.Errorf("expected name 'test.iso', got %q", req.Name)
+			}
+			jsonResponse(w, 200, apiResponse{Key: float64(10)})
+		},
+		"GET /api/v4/files/10": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, File{ID: 10, Name: "test.iso", Type: "iso"})
+		},
+	}))
+
+	file, err := client.Files.Create(context.Background(), &FileCreateRequest{
+		Name:           "test.iso",
+		AllocatedBytes: "1048576",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if file.Name != "test.iso" {
+		t.Errorf("expected name 'test.iso', got %q", file.Name)
+	}
+	if int(file.ID) != 10 {
+		t.Errorf("expected ID 10, got %d", int(file.ID))
+	}
+}
+
+func TestFileService_Create_WithURL(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/files": func(w http.ResponseWriter, r *http.Request) {
+			var req FileCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.URL != "https://example.com/file.iso" {
+				t.Errorf("expected URL, got %q", req.URL)
+			}
+			jsonResponse(w, 200, apiResponse{Key: float64(11)})
+		},
+		"GET /api/v4/files/11": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, File{ID: 11, Name: "file.iso", URL: "https://example.com/file.iso"})
+		},
+	}))
+
+	file, err := client.Files.Create(context.Background(), &FileCreateRequest{
+		Name: "file.iso",
+		URL:  "https://example.com/file.iso",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if file.URL != "https://example.com/file.iso" {
+		t.Errorf("expected URL in response, got %q", file.URL)
+	}
+}
+
+func TestFileService_Update(t *testing.T) {
+	newName := "renamed.iso"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/files/1": func(w http.ResponseWriter, r *http.Request) {
+			var req FileUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/files/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, File{ID: 1, Name: newName, Type: "iso"})
+		},
+	}))
+
+	file, err := client.Files.Update(context.Background(), 1, &FileUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if file.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, file.Name)
+	}
+}
+
+func TestFileService_Update_NotFound(t *testing.T) {
+	newName := "renamed.iso"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/files/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Files.Update(context.Background(), 999, &FileUpdateRequest{Name: &newName})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+}
+
+func TestFileService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/files/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Files.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestFileService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/files/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.Files.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestFileService_Download(t *testing.T) {
+	fileContent := "fake ISO file content here"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/files/1": func(w http.ResponseWriter, r *http.Request) {
+			// Download request has download=1 param; Get request does not
+			if r.URL.Query().Get("download") == "1" {
+				w.Header().Set("Content-Type", "application/octet-stream")
+				w.WriteHeader(200)
+				w.Write([]byte(fileContent))
+				return
+			}
+			// Regular Get for file metadata
+			jsonResponse(w, 200, File{ID: 1, Name: "test.iso", Type: "iso", Filesize: int64(len(fileContent))})
+		},
+	}))
+
+	reader, file, err := client.Files.Download(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Download failed: %v", err)
+	}
+	defer reader.Close()
+
+	if file.Name != "test.iso" {
+		t.Errorf("expected file name 'test.iso', got %q", file.Name)
+	}
+
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("failed to read download body: %v", err)
+	}
+	if string(body) != fileContent {
+		t.Errorf("expected body %q, got %q", fileContent, string(body))
+	}
+}
+
+func TestFileService_Download_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/files/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, _, err := client.Files.Download(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+}
+
+func TestFileService_Upload(t *testing.T) {
+	content := "upload test data 1234567890"
+	size := int64(len(content))
+
+	var receivedData []byte
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/files/1": func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			receivedData = append(receivedData, body...)
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/files/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, File{ID: 1, Name: "uploaded.bin", Filesize: size})
+		},
+	}))
+
+	file, err := client.Files.Upload(context.Background(), 1, strings.NewReader(content), size)
+	if err != nil {
+		t.Fatalf("Upload failed: %v", err)
+	}
+	if file.Name != "uploaded.bin" {
+		t.Errorf("expected name 'uploaded.bin', got %q", file.Name)
+	}
+	if string(receivedData) != content {
+		t.Errorf("expected uploaded data %q, got %q", content, string(receivedData))
+	}
+}
+
+func TestFileService_UploadWithChunkSize(t *testing.T) {
+	content := "abcdefghijklmnop" // 16 bytes
+	size := int64(len(content))
+	chunkSize := 8 // 8 bytes per chunk => 2 chunks
+
+	var chunkCount int
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/files/1": func(w http.ResponseWriter, r *http.Request) {
+			chunkCount++
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/files/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, File{ID: 1, Name: "chunked.bin", Filesize: size})
+		},
+	}))
+
+	file, err := client.Files.UploadWithChunkSize(context.Background(), 1, strings.NewReader(content), size, chunkSize)
+	if err != nil {
+		t.Fatalf("UploadWithChunkSize failed: %v", err)
+	}
+	if file.Name != "chunked.bin" {
+		t.Errorf("expected name 'chunked.bin', got %q", file.Name)
+	}
+	if chunkCount != 2 {
+		t.Errorf("expected 2 chunks, got %d", chunkCount)
+	}
+}

--- a/group.go
+++ b/group.go
@@ -62,6 +62,9 @@ func (s *GroupService) GetByName(ctx context.Context, name string) (*Group, erro
 
 // Create creates a new group and returns it.
 func (s *GroupService) Create(ctx context.Context, req *GroupCreateRequest) (*Group, error) {
+	if req == nil {
+		return nil, &ValidationError{Message: "create request is required"}
+	}
 	var result struct {
 		Key FlexInt `json:"$key"`
 	}

--- a/group.go
+++ b/group.go
@@ -88,5 +88,11 @@ func (s *GroupService) Update(ctx context.Context, id int, req *GroupUpdateReque
 // Delete deletes a group by ID.
 func (s *GroupService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/groups/%d", id)
-	return s.client.delete(ctx, endpoint)
+	if err := s.client.delete(ctx, endpoint); err != nil {
+		if IsNotFoundError(err) {
+			return &NotFoundError{Resource: "Group", ID: id}
+		}
+		return err
+	}
+	return nil
 }

--- a/group.go
+++ b/group.go
@@ -48,7 +48,7 @@ func (s *GroupService) Get(ctx context.Context, id int) (*Group, error) {
 
 // GetByName returns a group by name.
 func (s *GroupService) GetByName(ctx context.Context, name string) (*Group, error) {
-	groups, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	groups, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/group_test.go
+++ b/group_test.go
@@ -1,0 +1,206 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestGroupService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/groups": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Group{
+				{ID: 1, Name: "admins"},
+				{ID: 2, Name: "operators"},
+			})
+		},
+	}))
+
+	groups, err := client.Groups.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+	if groups[0].Name != "admins" {
+		t.Errorf("expected name 'admins', got %q", groups[0].Name)
+	}
+}
+
+func TestGroupService_List_WithFilter(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/groups": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter parameter")
+			}
+			jsonResponse(w, 200, []Group{{ID: 1, Name: "admins"}})
+		},
+	}))
+
+	groups, err := client.Groups.List(context.Background(), WithFilter("enabled eq true"))
+	if err != nil {
+		t.Fatalf("List with filter failed: %v", err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+}
+
+func TestGroupService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/groups/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Group{ID: 1, Name: "admins", Description: "Administrator group"})
+		},
+	}))
+
+	group, err := client.Groups.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if group.Name != "admins" {
+		t.Errorf("expected name 'admins', got %q", group.Name)
+	}
+	if group.Description != "Administrator group" {
+		t.Errorf("expected description 'Administrator group', got %q", group.Description)
+	}
+}
+
+func TestGroupService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/groups/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Groups.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestGroupService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/groups": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "name eq 'admins'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Group{{ID: 1, Name: "admins"}})
+		},
+	}))
+
+	group, err := client.Groups.GetByName(context.Background(), "admins")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if group.Name != "admins" {
+		t.Errorf("expected name 'admins', got %q", group.Name)
+	}
+}
+
+func TestGroupService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/groups": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Group{})
+		},
+	}))
+
+	_, err := client.Groups.GetByName(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestGroupService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/groups": func(w http.ResponseWriter, r *http.Request) {
+			var req GroupCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "newgroup" {
+				t.Errorf("expected name 'newgroup', got %q", req.Name)
+			}
+			jsonResponse(w, 200, struct {
+				Key FlexInt `json:"$key"`
+			}{Key: 5})
+		},
+		"GET /api/v4/groups/5": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Group{ID: 5, Name: "newgroup"})
+		},
+	}))
+
+	group, err := client.Groups.Create(context.Background(), &GroupCreateRequest{
+		Name: "newgroup",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if group.Name != "newgroup" {
+		t.Errorf("expected name 'newgroup', got %q", group.Name)
+	}
+	if int(group.ID) != 5 {
+		t.Errorf("expected ID 5, got %d", int(group.ID))
+	}
+}
+
+func TestGroupService_Update(t *testing.T) {
+	newDesc := "Updated description"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/groups/1": func(w http.ResponseWriter, r *http.Request) {
+			var req GroupUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Description == nil || *req.Description != newDesc {
+				t.Errorf("expected description %q, got %v", newDesc, req.Description)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/groups/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Group{ID: 1, Name: "admins", Description: newDesc})
+		},
+	}))
+
+	group, err := client.Groups.Update(context.Background(), 1, &GroupUpdateRequest{Description: &newDesc})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if group.Description != newDesc {
+		t.Errorf("expected description %q, got %q", newDesc, group.Description)
+	}
+}
+
+func TestGroupService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/groups/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Groups.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestGroupService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/groups/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.Groups.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -54,7 +54,7 @@ type VMNICServiceInterface interface {
 
 // VMDriveServiceInterface defines the interface for VM Drive operations.
 type VMDriveServiceInterface interface {
-	List(ctx context.Context, vmID int) ([]VMDrive, error)
+	List(ctx context.Context, machineID int) ([]VMDrive, error)
 	ListAll(ctx context.Context, opts ...ListOption) ([]VMDrive, error)
 	Get(ctx context.Context, driveID int) (*VMDrive, error)
 	Create(ctx context.Context, vmID int, req *VMDriveCreateRequest) (*VMDrive, error)
@@ -66,7 +66,7 @@ type VMDriveServiceInterface interface {
 
 // VMDeviceServiceInterface defines the interface for VM Device operations.
 type VMDeviceServiceInterface interface {
-	List(ctx context.Context, vmID int) ([]VMDevice, error)
+	List(ctx context.Context, machineID int) ([]VMDevice, error)
 	Get(ctx context.Context, deviceID int) (*VMDevice, error)
 	Create(ctx context.Context, vmID int, req *VMDeviceCreateRequest) (*VMDevice, error)
 	Update(ctx context.Context, deviceID int, req *VMDeviceUpdateRequest) (*VMDevice, error)

--- a/interfaces.go
+++ b/interfaces.go
@@ -995,4 +995,6 @@ var (
 	_ UpdateSettingsServiceInterface          = (*UpdateSettingsService)(nil)
 	_ UpdateBranchServiceInterface            = (*UpdateBranchService)(nil)
 	_ UpdateSourcePackageServiceInterface     = (*UpdateSourcePackageService)(nil)
+	_ TenantStatusServiceInterface            = (*TenantStatusService)(nil)
+	_ TenantStatsHistoryShortServiceInterface = (*TenantStatsHistoryShortService)(nil)
 )

--- a/interfaces.go
+++ b/interfaces.go
@@ -138,7 +138,6 @@ type NodeServiceInterface interface {
 	ListPhysical(ctx context.Context, opts ...ListOption) ([]Node, error)
 	Get(ctx context.Context, id int) (*Node, error)
 	GetByName(ctx context.Context, name string) (*Node, error)
-	GetDashboard(ctx context.Context, id int) (*Node, error)
 	EnableMaintenance(ctx context.Context, id int) error
 	DisableMaintenance(ctx context.Context, id int) error
 	MaintenanceReboot(ctx context.Context, id int) error

--- a/interfaces.go
+++ b/interfaces.go
@@ -822,8 +822,8 @@ type TenantLayer2NetworkServiceInterface interface {
 	Create(ctx context.Context, req *TenantLayer2NetworkCreateRequest) (*TenantLayer2Network, error)
 	Update(ctx context.Context, id int, req *TenantLayer2NetworkUpdateRequest) (*TenantLayer2Network, error)
 	Delete(ctx context.Context, id int) error
-	Enable(ctx context.Context, id int) (*TenantLayer2Network, error)
-	Disable(ctx context.Context, id int) (*TenantLayer2Network, error)
+	Enable(ctx context.Context, id int) error
+	Disable(ctx context.Context, id int) error
 	Assign(ctx context.Context, tenantID, vnetID int) (*TenantLayer2Network, error)
 	Unassign(ctx context.Context, tenantID, vnetID int) error
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -55,6 +55,7 @@ type VMNICServiceInterface interface {
 // VMDriveServiceInterface defines the interface for VM Drive operations.
 type VMDriveServiceInterface interface {
 	List(ctx context.Context, vmID int) ([]VMDrive, error)
+	ListAll(ctx context.Context, opts ...ListOption) ([]VMDrive, error)
 	Get(ctx context.Context, driveID int) (*VMDrive, error)
 	Create(ctx context.Context, vmID int, req *VMDriveCreateRequest) (*VMDrive, error)
 	Update(ctx context.Context, driveID int, req *VMDriveUpdateRequest) (*VMDrive, error)

--- a/interfaces.go
+++ b/interfaces.go
@@ -326,6 +326,22 @@ type TenantStorageServiceInterface interface {
 	Delete(ctx context.Context, id int) error
 }
 
+// TenantStatusServiceInterface defines the interface for tenant status operations (read-only).
+type TenantStatusServiceInterface interface {
+	List(ctx context.Context, opts ...ListOption) ([]TenantStatus, error)
+	Get(ctx context.Context, tenantKey int) (*TenantStatus, error)
+	GetByKey(ctx context.Context, key int) (*TenantStatus, error)
+}
+
+// TenantStatsHistoryShortServiceInterface defines the interface for tenant short-term statistics history operations (read-only).
+// This provides high-resolution historical metrics for tenant monitoring.
+type TenantStatsHistoryShortServiceInterface interface {
+	List(ctx context.Context, opts ...ListOption) ([]TenantStatsHistoryShort, error)
+	ListByTenant(ctx context.Context, tenantID int, opts ...ListOption) ([]TenantStatsHistoryShort, error)
+	GetLatest(ctx context.Context, tenantID int) (*TenantStatsHistoryShort, error)
+	Get(ctx context.Context, id int) (*TenantStatsHistoryShort, error)
+}
+
 // SnapshotProfileServiceInterface defines the interface for SnapshotProfile operations.
 type SnapshotProfileServiceInterface interface {
 	List(ctx context.Context, opts ...ListOption) ([]SnapshotProfile, error)

--- a/log.go
+++ b/log.go
@@ -84,7 +84,7 @@ func (s *LogService) Get(ctx context.Context, id int) (*Log, error) {
 	endpoint := fmt.Sprintf("/logs/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &log); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Log", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Log", ID: id}
 		}
 		return nil, err
 	}

--- a/log.go
+++ b/log.go
@@ -37,13 +37,13 @@ func (s *LogService) List(ctx context.Context, opts ...ListOption) ([]Log, error
 
 // ListByLevel returns logs filtered by level.
 func (s *LogService) ListByLevel(ctx context.Context, level string, opts ...ListOption) ([]Log, error) {
-	opts = append(opts, WithFilter(fmt.Sprintf("level eq '%s'", level)))
+	opts = append(opts, WithFilter(fmt.Sprintf("level eq '%s'", escapeFilterValue(level))))
 	return s.List(ctx, opts...)
 }
 
 // ListByObjectType returns logs filtered by object type.
 func (s *LogService) ListByObjectType(ctx context.Context, objectType string, opts ...ListOption) ([]Log, error) {
-	opts = append(opts, WithFilter(fmt.Sprintf("object_type eq '%s'", objectType)))
+	opts = append(opts, WithFilter(fmt.Sprintf("object_type eq '%s'", escapeFilterValue(objectType))))
 	return s.List(ctx, opts...)
 }
 
@@ -65,7 +65,7 @@ func (s *LogService) ListWarnings(ctx context.Context, opts ...ListOption) ([]Lo
 
 // ListByUser returns logs filtered by username.
 func (s *LogService) ListByUser(ctx context.Context, username string, opts ...ListOption) ([]Log, error) {
-	opts = append(opts, WithFilter(fmt.Sprintf("user eq '%s'", username)))
+	opts = append(opts, WithFilter(fmt.Sprintf("user eq '%s'", escapeFilterValue(username))))
 	return s.List(ctx, opts...)
 }
 

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,324 @@
+package vergeos
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestLogService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/logs": func(w http.ResponseWriter, r *http.Request) {
+			sort := r.URL.Query().Get("sort")
+			if sort != "-timestamp" {
+				t.Errorf("expected default sort '-timestamp', got %q", sort)
+			}
+			jsonResponse(w, 200, []Log{
+				{Key: 1, Level: "audit", Text: "user logged in", User: "admin", Timestamp: 1700000002},
+				{Key: 2, Level: "error", Text: "disk failure", ObjectType: "cluster", Timestamp: 1700000001},
+			})
+		},
+	}))
+
+	logs, err := client.Logs.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(logs) != 2 {
+		t.Fatalf("expected 2 logs, got %d", len(logs))
+	}
+	if logs[0].Level != "audit" {
+		t.Errorf("expected level 'audit', got %q", logs[0].Level)
+	}
+}
+
+func TestLogService_List_Empty(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/logs": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Log{})
+		},
+	}))
+
+	logs, err := client.Logs.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(logs) != 0 {
+		t.Fatalf("expected 0 logs, got %d", len(logs))
+	}
+}
+
+func TestLogService_ListByLevel(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/logs": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "level eq 'warning'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Log{
+				{Key: 1, Level: "warning", Text: "disk usage high"},
+			})
+		},
+	}))
+
+	logs, err := client.Logs.ListByLevel(context.Background(), "warning")
+	if err != nil {
+		t.Fatalf("ListByLevel failed: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(logs))
+	}
+}
+
+func TestLogService_ListByObjectType(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/logs": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "object_type eq 'vm'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Log{
+				{Key: 1, Level: "audit", ObjectType: "vm", ObjectName: "web-server-01"},
+			})
+		},
+	}))
+
+	logs, err := client.Logs.ListByObjectType(context.Background(), "vm")
+	if err != nil {
+		t.Fatalf("ListByObjectType failed: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(logs))
+	}
+	if logs[0].ObjectName != "web-server-01" {
+		t.Errorf("expected ObjectName 'web-server-01', got %q", logs[0].ObjectName)
+	}
+}
+
+func TestLogService_ListErrors(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/logs": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "(level eq 'error') or (level eq 'critical')" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Log{
+				{Key: 1, Level: "error", Text: "disk failure"},
+				{Key: 2, Level: "critical", Text: "node unreachable"},
+			})
+		},
+	}))
+
+	logs, err := client.Logs.ListErrors(context.Background())
+	if err != nil {
+		t.Fatalf("ListErrors failed: %v", err)
+	}
+	if len(logs) != 2 {
+		t.Fatalf("expected 2 logs, got %d", len(logs))
+	}
+}
+
+func TestLogService_ListAudit(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/logs": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "level eq 'audit'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Log{
+				{Key: 1, Level: "audit", Text: "user created VM"},
+			})
+		},
+	}))
+
+	logs, err := client.Logs.ListAudit(context.Background())
+	if err != nil {
+		t.Fatalf("ListAudit failed: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(logs))
+	}
+}
+
+func TestLogService_ListWarnings(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/logs": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "level eq 'warning'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Log{
+				{Key: 1, Level: "warning", Text: "high memory usage"},
+			})
+		},
+	}))
+
+	logs, err := client.Logs.ListWarnings(context.Background())
+	if err != nil {
+		t.Fatalf("ListWarnings failed: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(logs))
+	}
+}
+
+func TestLogService_ListByUser(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/logs": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "user eq 'admin'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Log{
+				{Key: 1, Level: "audit", User: "admin", Text: "changed settings"},
+			})
+		},
+	}))
+
+	logs, err := client.Logs.ListByUser(context.Background(), "admin")
+	if err != nil {
+		t.Fatalf("ListByUser failed: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(logs))
+	}
+	if logs[0].User != "admin" {
+		t.Errorf("expected user 'admin', got %q", logs[0].User)
+	}
+}
+
+func TestLogService_ListSince(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/logs": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "timestamp ge 1700000000" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Log{
+				{Key: 1, Timestamp: 1700000001, Text: "recent event"},
+			})
+		},
+	}))
+
+	logs, err := client.Logs.ListSince(context.Background(), 1700000000)
+	if err != nil {
+		t.Fatalf("ListSince failed: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(logs))
+	}
+}
+
+func TestLogService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/logs/42": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Log{
+				Key: 42, Level: "error", Text: "disk failure detected", ObjectType: "cluster", ObjectName: "storage-01",
+			})
+		},
+	}))
+
+	log, err := client.Logs.Get(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if log.Text != "disk failure detected" {
+		t.Errorf("expected text 'disk failure detected', got %q", log.Text)
+	}
+	if log.ObjectType != "cluster" {
+		t.Errorf("expected object_type 'cluster', got %q", log.ObjectType)
+	}
+}
+
+func TestLogService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/logs/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Logs.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestLogService_GetRecent(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/logs": func(w http.ResponseWriter, r *http.Request) {
+			limit := r.URL.Query().Get("limit")
+			if limit != "5" {
+				t.Errorf("expected limit '5', got %q", limit)
+			}
+			jsonResponse(w, 200, []Log{
+				{Key: 10, Text: "event 1"},
+				{Key: 9, Text: "event 2"},
+				{Key: 8, Text: "event 3"},
+				{Key: 7, Text: "event 4"},
+				{Key: 6, Text: "event 5"},
+			})
+		},
+	}))
+
+	logs, err := client.Logs.GetRecent(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("GetRecent failed: %v", err)
+	}
+	if len(logs) != 5 {
+		t.Fatalf("expected 5 logs, got %d", len(logs))
+	}
+}
+
+func TestLogService_GetRecentErrors(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/logs": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "(level eq 'error') or (level eq 'critical')" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			limit := r.URL.Query().Get("limit")
+			if limit != "3" {
+				t.Errorf("expected limit '3', got %q", limit)
+			}
+			jsonResponse(w, 200, []Log{
+				{Key: 10, Level: "error", Text: "error 1"},
+				{Key: 9, Level: "critical", Text: "critical 1"},
+				{Key: 8, Level: "error", Text: "error 2"},
+			})
+		},
+	}))
+
+	logs, err := client.Logs.GetRecentErrors(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("GetRecentErrors failed: %v", err)
+	}
+	if len(logs) != 3 {
+		t.Fatalf("expected 3 logs, got %d", len(logs))
+	}
+}
+
+func TestLogService_Search(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/logs": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "text ct 'disk failure'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Log{
+				{Key: 1, Level: "error", Text: "disk failure detected on node2"},
+				{Key: 2, Level: "warning", Text: "potential disk failure imminent"},
+			})
+		},
+	}))
+
+	logs, err := client.Logs.Search(context.Background(), "disk failure")
+	if err != nil {
+		t.Fatalf("Search failed: %v", err)
+	}
+	if len(logs) != 2 {
+		t.Fatalf("expected 2 logs, got %d", len(logs))
+	}
+}

--- a/machine_drive_stats_test.go
+++ b/machine_drive_stats_test.go
@@ -1,0 +1,145 @@
+package vergeos
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestMachineDriveStatsService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drive_stats": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []MachineDriveStats{
+				{Key: 1, ParentDrive: 100, Reads: 5000, Writes: 3000, Physical: true},
+				{Key: 2, ParentDrive: 200, Reads: 1200, Writes: 800, Physical: false},
+			})
+		},
+	}))
+
+	stats, err := client.MachineDriveStats.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("expected 2 stats, got %d", len(stats))
+	}
+	if stats[0].Reads != 5000 {
+		t.Errorf("expected Reads 5000, got %d", stats[0].Reads)
+	}
+}
+
+func TestMachineDriveStatsService_List_Empty(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drive_stats": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []MachineDriveStats{})
+		},
+	}))
+
+	stats, err := client.MachineDriveStats.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(stats) != 0 {
+		t.Fatalf("expected 0 stats, got %d", len(stats))
+	}
+}
+
+func TestMachineDriveStatsService_ListPhysical(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drive_stats": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "physical eq true" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []MachineDriveStats{
+				{Key: 1, ParentDrive: 100, Physical: true, Rops: 150, Wops: 80},
+			})
+		},
+	}))
+
+	stats, err := client.MachineDriveStats.ListPhysical(context.Background())
+	if err != nil {
+		t.Fatalf("ListPhysical failed: %v", err)
+	}
+	if len(stats) != 1 {
+		t.Fatalf("expected 1 stat, got %d", len(stats))
+	}
+	if !stats[0].Physical {
+		t.Error("expected physical drive stat")
+	}
+}
+
+func TestMachineDriveStatsService_GetByDrive(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drive_stats": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "parent_drive eq 100" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []MachineDriveStats{
+				{Key: 1, ParentDrive: 100, ReadBytes: 1048576, WriteBytes: 524288, ServiceTime: 1.5, Util: 35.2},
+			})
+		},
+	}))
+
+	stats, err := client.MachineDriveStats.GetByDrive(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("GetByDrive failed: %v", err)
+	}
+	if stats.ParentDrive != 100 {
+		t.Errorf("expected ParentDrive 100, got %d", stats.ParentDrive)
+	}
+	if stats.ServiceTime != 1.5 {
+		t.Errorf("expected ServiceTime 1.5, got %f", stats.ServiceTime)
+	}
+}
+
+func TestMachineDriveStatsService_GetByDrive_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drive_stats": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []MachineDriveStats{})
+		},
+	}))
+
+	_, err := client.MachineDriveStats.GetByDrive(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestMachineDriveStatsService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drive_stats/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, MachineDriveStats{
+				Key: 1, ParentDrive: 100, Rbps: 52428800, Wbps: 26214400,
+			})
+		},
+	}))
+
+	stats, err := client.MachineDriveStats.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if stats.Rbps != 52428800 {
+		t.Errorf("expected Rbps 52428800, got %d", stats.Rbps)
+	}
+}
+
+func TestMachineDriveStatsService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drive_stats/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.MachineDriveStats.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/machine_nic_test.go
+++ b/machine_nic_test.go
@@ -1,0 +1,121 @@
+package vergeos
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestMachineNICService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_nics": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []MachineNIC{
+				{Key: 1, Machine: 10, Name: "eno1"},
+				{Key: 2, Machine: 10, Name: "eno2"},
+			})
+		},
+	}))
+
+	nics, err := client.MachineNICs.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(nics) != 2 {
+		t.Fatalf("expected 2 NICs, got %d", len(nics))
+	}
+	if nics[0].Name != "eno1" {
+		t.Errorf("expected name 'eno1', got %q", nics[0].Name)
+	}
+}
+
+func TestMachineNICService_List_Empty(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_nics": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []MachineNIC{})
+		},
+	}))
+
+	nics, err := client.MachineNICs.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(nics) != 0 {
+		t.Fatalf("expected 0 NICs, got %d", len(nics))
+	}
+}
+
+func TestMachineNICService_ListByMachine(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_nics": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "machine eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []MachineNIC{
+				{Key: 1, Machine: 10, Name: "eno1",
+					Stats:  &MachineNICStats{TxBytes: 1048576, RxBytes: 2097152},
+					Status: &MachineNICStatus{Status: "up", Speed: 10000},
+				},
+			})
+		},
+	}))
+
+	nics, err := client.MachineNICs.ListByMachine(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListByMachine failed: %v", err)
+	}
+	if len(nics) != 1 {
+		t.Fatalf("expected 1 NIC, got %d", len(nics))
+	}
+	if nics[0].Stats == nil {
+		t.Fatal("expected Stats to be populated")
+	}
+	if nics[0].Stats.TxBytes != 1048576 {
+		t.Errorf("expected TxBytes 1048576, got %d", nics[0].Stats.TxBytes)
+	}
+	if nics[0].Status == nil {
+		t.Fatal("expected Status to be populated")
+	}
+	if nics[0].Status.Speed != 10000 {
+		t.Errorf("expected Speed 10000, got %d", nics[0].Status.Speed)
+	}
+}
+
+func TestMachineNICService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_nics/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, MachineNIC{
+				Key: 1, Machine: 10, Name: "eno1",
+				Stats:  &MachineNICStats{TxPckts: 50000, RxPckts: 80000},
+				Status: &MachineNICStatus{Status: "up", Speed: 1000},
+			})
+		},
+	}))
+
+	nic, err := client.MachineNICs.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if nic.Name != "eno1" {
+		t.Errorf("expected name 'eno1', got %q", nic.Name)
+	}
+	if nic.Stats.RxPckts != 80000 {
+		t.Errorf("expected RxPckts 80000, got %d", nic.Stats.RxPckts)
+	}
+}
+
+func TestMachineNICService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_nics/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.MachineNICs.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/machine_stats_test.go
+++ b/machine_stats_test.go
@@ -1,0 +1,120 @@
+package vergeos
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestMachineStatsService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_stats": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []MachineStats{
+				{Key: 1, Machine: 10, TotalCPU: 45, RAMUsed: 4096, RAMPct: 50},
+				{Key: 2, Machine: 20, TotalCPU: 80, RAMUsed: 7168, RAMPct: 87},
+			})
+		},
+	}))
+
+	stats, err := client.MachineStats.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("expected 2 stats, got %d", len(stats))
+	}
+	if stats[0].TotalCPU != 45 {
+		t.Errorf("expected TotalCPU 45, got %d", stats[0].TotalCPU)
+	}
+}
+
+func TestMachineStatsService_List_Empty(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_stats": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []MachineStats{})
+		},
+	}))
+
+	stats, err := client.MachineStats.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(stats) != 0 {
+		t.Fatalf("expected 0 stats, got %d", len(stats))
+	}
+}
+
+func TestMachineStatsService_GetByMachine(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_stats": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "machine eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []MachineStats{
+				{Key: 1, Machine: 10, TotalCPU: 55, UserCPU: 40, SystemCPU: 15},
+			})
+		},
+	}))
+
+	stats, err := client.MachineStats.GetByMachine(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("GetByMachine failed: %v", err)
+	}
+	if stats.TotalCPU != 55 {
+		t.Errorf("expected TotalCPU 55, got %d", stats.TotalCPU)
+	}
+}
+
+func TestMachineStatsService_GetByMachine_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_stats": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []MachineStats{})
+		},
+	}))
+
+	_, err := client.MachineStats.GetByMachine(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestMachineStatsService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_stats/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, MachineStats{
+				Key: 1, Machine: 10, TotalCPU: 30, CoreTemp: 65, CoreTempTop: 72,
+			})
+		},
+	}))
+
+	stats, err := client.MachineStats.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if stats.CoreTemp != 65 {
+		t.Errorf("expected CoreTemp 65, got %d", stats.CoreTemp)
+	}
+	if stats.CoreTempTop != 72 {
+		t.Errorf("expected CoreTempTop 72, got %d", stats.CoreTempTop)
+	}
+}
+
+func TestMachineStatsService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_stats/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.MachineStats.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/machine_status_test.go
+++ b/machine_status_test.go
@@ -1,0 +1,123 @@
+package vergeos
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestMachineStatusService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_status": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []MachineStatus{
+				{Key: 1, Machine: 10, Running: true, Status: "running", State: "online"},
+				{Key: 2, Machine: 20, Running: false, Status: "stopped", State: "offline"},
+			})
+		},
+	}))
+
+	statuses, err := client.MachineStatus.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(statuses) != 2 {
+		t.Fatalf("expected 2 statuses, got %d", len(statuses))
+	}
+	if !statuses[0].Running {
+		t.Error("expected first status to be running")
+	}
+	if statuses[1].Status != "stopped" {
+		t.Errorf("expected status 'stopped', got %q", statuses[1].Status)
+	}
+}
+
+func TestMachineStatusService_List_Empty(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_status": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []MachineStatus{})
+		},
+	}))
+
+	statuses, err := client.MachineStatus.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(statuses) != 0 {
+		t.Fatalf("expected 0 statuses, got %d", len(statuses))
+	}
+}
+
+func TestMachineStatusService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_status": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "machine eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []MachineStatus{
+				{Key: 1, Machine: 10, Running: true, Status: "running", State: "online", RunningCores: 4, RunningRAM: 8192},
+			})
+		},
+	}))
+
+	status, err := client.MachineStatus.Get(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if status.Machine != 10 {
+		t.Errorf("expected machine 10, got %d", status.Machine)
+	}
+	if status.RunningCores != 4 {
+		t.Errorf("expected 4 cores, got %d", status.RunningCores)
+	}
+}
+
+func TestMachineStatusService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_status": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []MachineStatus{})
+		},
+	}))
+
+	_, err := client.MachineStatus.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestMachineStatusService_GetByKey(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_status/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, MachineStatus{
+				Key: 1, Machine: 10, Running: true, Status: "running", NodeName: "node1",
+			})
+		},
+	}))
+
+	status, err := client.MachineStatus.GetByKey(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetByKey failed: %v", err)
+	}
+	if status.NodeName != "node1" {
+		t.Errorf("expected node_name 'node1', got %q", status.NodeName)
+	}
+}
+
+func TestMachineStatusService_GetByKey_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_status/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.MachineStatus.GetByKey(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/machine_status_test.go
+++ b/machine_status_test.go
@@ -2,6 +2,7 @@ package vergeos
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 )
@@ -103,6 +104,47 @@ func TestMachineStatusService_GetByKey(t *testing.T) {
 	}
 	if status.NodeName != "node1" {
 		t.Errorf("expected node_name 'node1', got %q", status.NodeName)
+	}
+}
+
+func TestGuestInfo_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"empty array", `[]`, false},
+		{"empty array with spaces", `[ ]`, false},
+		{"valid object", `{"hostname":"test","last_refresh":1234}`, false},
+		{"empty object", `{}`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var g GuestInfo
+			err := json.Unmarshal([]byte(tt.input), &g)
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestGuestInfo_UnmarshalJSON_InMachineStatus(t *testing.T) {
+	// Simulate the full MachineStatus response where agent_guest_info is []
+	input := `{"$key":1,"machine":10,"running":true,"agent_guest_info":[]}`
+	var ms MachineStatus
+	if err := json.Unmarshal([]byte(input), &ms); err != nil {
+		t.Fatalf("unexpected error unmarshaling MachineStatus with empty guest info: %v", err)
+	}
+	if ms.AgentGuestInfo == nil {
+		t.Fatal("expected AgentGuestInfo to be non-nil (allocated but zero-value)")
+	}
+	if ms.AgentGuestInfo.Hostname != "" {
+		t.Errorf("expected empty hostname, got %q", ms.AgentGuestInfo.Hostname)
 	}
 }
 

--- a/member.go
+++ b/member.go
@@ -102,7 +102,7 @@ func (s *MemberService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/members/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "Member", ID: id}
 		}
 		return err
 	}

--- a/member.go
+++ b/member.go
@@ -121,7 +121,7 @@ func (s *MemberService) Add(ctx context.Context, groupID int, member string) (*M
 func (s *MemberService) Remove(ctx context.Context, groupID int, member string) error {
 	// Find the membership
 	members, err := s.List(ctx,
-		WithFilter(fmt.Sprintf("parent_group eq %d and member eq '%s'", groupID, member)),
+		WithFilter(fmt.Sprintf("parent_group eq %d and member eq '%s'", groupID, escapeFilterValue(member))),
 	)
 	if err != nil {
 		return err

--- a/member_test.go
+++ b/member_test.go
@@ -1,0 +1,300 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestMemberService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/members": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Member{
+				{ID: 1, Group: 10, Member: "users/admin"},
+				{ID: 2, Group: 10, Member: "users/operator"},
+			})
+		},
+	}))
+
+	members, err := client.Members.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("expected 2 members, got %d", len(members))
+	}
+	if members[0].Member != "users/admin" {
+		t.Errorf("expected member 'users/admin', got %q", members[0].Member)
+	}
+}
+
+func TestMemberService_ListByGroup(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/members": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "parent_group eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Member{
+				{ID: 1, Group: 10, Member: "users/admin"},
+			})
+		},
+	}))
+
+	members, err := client.Members.ListByGroup(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListByGroup failed: %v", err)
+	}
+	if len(members) != 1 {
+		t.Fatalf("expected 1 member, got %d", len(members))
+	}
+}
+
+func TestMemberService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/members/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Member{ID: 1, Group: 10, Member: "users/admin"})
+		},
+	}))
+
+	member, err := client.Members.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if member.Member != "users/admin" {
+		t.Errorf("expected member 'users/admin', got %q", member.Member)
+	}
+	if int(member.Group) != 10 {
+		t.Errorf("expected group 10, got %d", int(member.Group))
+	}
+}
+
+func TestMemberService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/members/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Members.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestMemberService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/members": func(w http.ResponseWriter, r *http.Request) {
+			var req MemberCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Group != 10 {
+				t.Errorf("expected group 10, got %d", req.Group)
+			}
+			if req.Member != "users/newuser" {
+				t.Errorf("expected member 'users/newuser', got %q", req.Member)
+			}
+			jsonResponse(w, 200, apiResponse{Key: float64(3)})
+		},
+		"GET /api/v4/members/3": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Member{ID: 3, Group: 10, Member: "users/newuser"})
+		},
+	}))
+
+	member, err := client.Members.Create(context.Background(), &MemberCreateRequest{
+		Group:  10,
+		Member: "users/newuser",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if member.Member != "users/newuser" {
+		t.Errorf("expected member 'users/newuser', got %q", member.Member)
+	}
+	if int(member.ID) != 3 {
+		t.Errorf("expected ID 3, got %d", int(member.ID))
+	}
+}
+
+func TestMemberService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Members.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestMemberService_Create_MissingGroup(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Members.Create(context.Background(), &MemberCreateRequest{
+		Member: "users/admin",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing group")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestMemberService_Create_MissingMember(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Members.Create(context.Background(), &MemberCreateRequest{
+		Group: 10,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing member")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestMemberService_Update(t *testing.T) {
+	newMember := "users/updated"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/members/1": func(w http.ResponseWriter, r *http.Request) {
+			var req MemberUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Member == nil || *req.Member != newMember {
+				t.Errorf("expected member %q, got %v", newMember, req.Member)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/members/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Member{ID: 1, Group: 10, Member: newMember})
+		},
+	}))
+
+	member, err := client.Members.Update(context.Background(), 1, &MemberUpdateRequest{Member: &newMember})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if member.Member != newMember {
+		t.Errorf("expected member %q, got %q", newMember, member.Member)
+	}
+}
+
+func TestMemberService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Members.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestMemberService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/members/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newMember := "users/updated"
+	_, err := client.Members.Update(context.Background(), 999, &MemberUpdateRequest{Member: &newMember})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestMemberService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/members/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Members.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestMemberService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/members/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	// Delete of already-deleted resource returns nil
+	err := client.Members.Delete(context.Background(), 999)
+	if err != nil {
+		t.Fatalf("expected nil for already-deleted member, got %v", err)
+	}
+}
+
+func TestMemberService_Add(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/members": func(w http.ResponseWriter, r *http.Request) {
+			var req MemberCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Group != 10 {
+				t.Errorf("expected group 10, got %d", req.Group)
+			}
+			if req.Member != "users/admin" {
+				t.Errorf("expected member 'users/admin', got %q", req.Member)
+			}
+			jsonResponse(w, 200, apiResponse{Key: float64(5)})
+		},
+		"GET /api/v4/members/5": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Member{ID: 5, Group: 10, Member: "users/admin"})
+		},
+	}))
+
+	member, err := client.Members.Add(context.Background(), 10, "users/admin")
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+	if member.Member != "users/admin" {
+		t.Errorf("expected member 'users/admin', got %q", member.Member)
+	}
+}
+
+func TestMemberService_Remove(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/members": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Member{
+				{ID: 5, Group: 10, Member: "users/admin"},
+			})
+		},
+		"DELETE /api/v4/members/5": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Members.Remove(context.Background(), 10, "users/admin")
+	if err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+}
+
+func TestMemberService_Remove_AlreadyRemoved(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/members": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Member{})
+		},
+	}))
+
+	// Remove of non-existent membership returns nil
+	err := client.Members.Remove(context.Background(), 10, "users/nonexistent")
+	if err != nil {
+		t.Fatalf("expected nil for already-removed member, got %v", err)
+	}
+}

--- a/member_test.go
+++ b/member_test.go
@@ -233,10 +233,13 @@ func TestMemberService_Delete_NotFound(t *testing.T) {
 		},
 	}))
 
-	// Delete of already-deleted resource returns nil
+	// Delete of non-existent resource returns NotFoundError
 	err := client.Members.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("expected nil for already-deleted member, got %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted member")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }
 

--- a/nas_service.go
+++ b/nas_service.go
@@ -63,7 +63,7 @@ func (s *NASServiceService) GetByVM(ctx context.Context, vmID int) (*NASService,
 
 // GetByName returns a NAS service by name.
 func (s *NASServiceService) GetByName(ctx context.Context, name string) (*NASService, error) {
-	services, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	services, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (s *NASServiceUserService) Get(ctx context.Context, id string) (*NASService
 
 // GetByName returns a NAS service user by name within a specific service.
 func (s *NASServiceUserService) GetByName(ctx context.Context, serviceID int, name string) (*NASServiceUser, error) {
-	users, err := s.List(ctx, WithFilter(fmt.Sprintf("service eq %d and name eq '%s'", serviceID, name)))
+	users, err := s.List(ctx, WithFilter(fmt.Sprintf("service eq %d and name eq '%s'", serviceID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/nas_service_test.go
+++ b/nas_service_test.go
@@ -1,0 +1,561 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// NASService tests
+
+func TestNASServiceService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vm_services": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []NASService{
+				{Key: 1, Name: "nas1", VM: 100},
+				{Key: 2, Name: "nas2", VM: 200},
+			})
+		},
+	}))
+
+	services, err := client.NASServices.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(services) != 2 {
+		t.Fatalf("expected 2 services, got %d", len(services))
+	}
+	if services[0].Name != "nas1" {
+		t.Errorf("expected name 'nas1', got %q", services[0].Name)
+	}
+}
+
+func TestNASServiceService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vm_services/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NASService{Key: 1, Name: "nas1", VM: 100, Enabled: true})
+		},
+	}))
+
+	svc, err := client.NASServices.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if svc.Name != "nas1" {
+		t.Errorf("expected name 'nas1', got %q", svc.Name)
+	}
+	if !svc.Enabled {
+		t.Error("expected enabled to be true")
+	}
+}
+
+func TestNASServiceService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vm_services/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.NASServices.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestNASServiceService_GetByVM(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vm_services": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []NASService{{Key: 1, Name: "nas1", VM: 100}})
+		},
+		"GET /api/v4/vm_services/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NASService{Key: 1, Name: "nas1", VM: 100})
+		},
+	}))
+
+	svc, err := client.NASServices.GetByVM(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("GetByVM failed: %v", err)
+	}
+	if svc.Name != "nas1" {
+		t.Errorf("expected name 'nas1', got %q", svc.Name)
+	}
+}
+
+func TestNASServiceService_GetByVM_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vm_services": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []NASService{})
+		},
+	}))
+
+	_, err := client.NASServices.GetByVM(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestNASServiceService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vm_services": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []NASService{{Key: 1, Name: "nas1", VM: 100}})
+		},
+		"GET /api/v4/vm_services/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NASService{Key: 1, Name: "nas1", VM: 100})
+		},
+	}))
+
+	svc, err := client.NASServices.GetByName(context.Background(), "nas1")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if svc.Name != "nas1" {
+		t.Errorf("expected name 'nas1', got %q", svc.Name)
+	}
+}
+
+func TestNASServiceService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vm_services": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []NASService{})
+		},
+	}))
+
+	_, err := client.NASServices.GetByName(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestNASServiceService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_services": func(w http.ResponseWriter, r *http.Request) {
+			var req NASServiceCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.VM != 100 {
+				t.Errorf("expected vm 100, got %d", req.VM)
+			}
+			jsonResponse(w, 200, apiResponse{Key: float64(5)})
+		},
+		"GET /api/v4/vm_services/5": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NASService{Key: 5, Name: "nas-new", VM: 100})
+		},
+	}))
+
+	svc, err := client.NASServices.Create(context.Background(), &NASServiceCreateRequest{VM: 100})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if svc.Name != "nas-new" {
+		t.Errorf("expected name 'nas-new', got %q", svc.Name)
+	}
+}
+
+func TestNASServiceService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.NASServices.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestNASServiceService_Create_MissingVM(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.NASServices.Create(context.Background(), &NASServiceCreateRequest{})
+	if err == nil {
+		t.Fatal("expected error for missing vm")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestNASServiceService_Update(t *testing.T) {
+	maxImports := 8
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vm_services/1": func(w http.ResponseWriter, r *http.Request) {
+			var req NASServiceUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.MaxImports == nil || *req.MaxImports != maxImports {
+				t.Errorf("expected max_imports %d, got %v", maxImports, req.MaxImports)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vm_services/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NASService{Key: 1, Name: "nas1", MaxImports: maxImports})
+		},
+	}))
+
+	svc, err := client.NASServices.Update(context.Background(), 1, &NASServiceUpdateRequest{MaxImports: &maxImports})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if svc.MaxImports != maxImports {
+		t.Errorf("expected max_imports %d, got %d", maxImports, svc.MaxImports)
+	}
+}
+
+func TestNASServiceService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.NASServices.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestNASServiceService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vm_services/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.NASServices.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestNASServiceService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vm_services/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.NASServices.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// NASServiceUser tests
+
+func TestNASServiceUserService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vm_service_users": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []NASServiceUser{
+				{ID: "abc123", Name: "user1", Service: 1},
+				{ID: "def456", Name: "user2", Service: 1},
+			})
+		},
+	}))
+
+	users, err := client.NASServiceUsers.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(users))
+	}
+	if users[0].Name != "user1" {
+		t.Errorf("expected name 'user1', got %q", users[0].Name)
+	}
+}
+
+func TestNASServiceUserService_ListByService(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vm_service_users": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "service eq 1" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []NASServiceUser{{ID: "abc123", Name: "user1", Service: 1}})
+		},
+	}))
+
+	users, err := client.NASServiceUsers.ListByService(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ListByService failed: %v", err)
+	}
+	if len(users) != 1 {
+		t.Fatalf("expected 1 user, got %d", len(users))
+	}
+}
+
+func TestNASServiceUserService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vm_service_users/abc123": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NASServiceUser{ID: "abc123", Name: "user1", Enabled: true})
+		},
+	}))
+
+	user, err := client.NASServiceUsers.Get(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if user.Name != "user1" {
+		t.Errorf("expected name 'user1', got %q", user.Name)
+	}
+	if !user.Enabled {
+		t.Error("expected enabled to be true")
+	}
+}
+
+func TestNASServiceUserService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vm_service_users/nonexistent": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.NASServiceUsers.Get(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestNASServiceUserService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vm_service_users": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []NASServiceUser{{ID: "abc123", Name: "user1", Service: 1}})
+		},
+		"GET /api/v4/vm_service_users/abc123": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NASServiceUser{ID: "abc123", Name: "user1", Service: 1})
+		},
+	}))
+
+	user, err := client.NASServiceUsers.GetByName(context.Background(), 1, "user1")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if user.Name != "user1" {
+		t.Errorf("expected name 'user1', got %q", user.Name)
+	}
+}
+
+func TestNASServiceUserService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vm_service_users": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []NASServiceUser{})
+		},
+	}))
+
+	_, err := client.NASServiceUsers.GetByName(context.Background(), 1, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestNASServiceUserService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_service_users": func(w http.ResponseWriter, r *http.Request) {
+			var req NASServiceUserCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Service != 1 {
+				t.Errorf("expected service 1, got %d", req.Service)
+			}
+			if req.Name != "newuser" {
+				t.Errorf("expected name 'newuser', got %q", req.Name)
+			}
+			jsonResponse(w, 200, apiResponse{Key: "sha1hash123"})
+		},
+		"GET /api/v4/vm_service_users/sha1hash123": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NASServiceUser{ID: "sha1hash123", Name: "newuser", Service: 1, Enabled: true})
+		},
+	}))
+
+	user, err := client.NASServiceUsers.Create(context.Background(), &NASServiceUserCreateRequest{
+		Service:  1,
+		Name:     "newuser",
+		Password: "secret",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if user.Name != "newuser" {
+		t.Errorf("expected name 'newuser', got %q", user.Name)
+	}
+}
+
+func TestNASServiceUserService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.NASServiceUsers.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestNASServiceUserService_Create_MissingService(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.NASServiceUsers.Create(context.Background(), &NASServiceUserCreateRequest{
+		Name:     "user",
+		Password: "pass",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing service")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestNASServiceUserService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.NASServiceUsers.Create(context.Background(), &NASServiceUserCreateRequest{
+		Service:  1,
+		Password: "pass",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestNASServiceUserService_Create_MissingPassword(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.NASServiceUsers.Create(context.Background(), &NASServiceUserCreateRequest{
+		Service: 1,
+		Name:    "user",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing password")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestNASServiceUserService_Update(t *testing.T) {
+	newDisplay := "New Display"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vm_service_users/abc123": func(w http.ResponseWriter, r *http.Request) {
+			var req NASServiceUserUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.DisplayName == nil || *req.DisplayName != newDisplay {
+				t.Errorf("expected display name %q, got %v", newDisplay, req.DisplayName)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vm_service_users/abc123": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NASServiceUser{ID: "abc123", Name: "user1", DisplayName: newDisplay})
+		},
+	}))
+
+	user, err := client.NASServiceUsers.Update(context.Background(), "abc123", &NASServiceUserUpdateRequest{DisplayName: &newDisplay})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if user.DisplayName != newDisplay {
+		t.Errorf("expected display name %q, got %q", newDisplay, user.DisplayName)
+	}
+}
+
+func TestNASServiceUserService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.NASServiceUsers.Update(context.Background(), "abc123", nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestNASServiceUserService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vm_service_users/abc123": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.NASServiceUsers.Delete(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestNASServiceUserService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vm_service_users/nonexistent": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.NASServiceUsers.Delete(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestNASServiceUserService_Enable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vm_service_users/abc123": func(w http.ResponseWriter, r *http.Request) {
+			var req NASServiceUserUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Enabled == nil || !*req.Enabled {
+				t.Error("expected enabled to be true")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vm_service_users/abc123": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NASServiceUser{ID: "abc123", Name: "user1", Enabled: true})
+		},
+	}))
+
+	err := client.NASServiceUsers.Enable(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("Enable failed: %v", err)
+	}
+}
+
+func TestNASServiceUserService_Disable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vm_service_users/abc123": func(w http.ResponseWriter, r *http.Request) {
+			var req NASServiceUserUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Enabled == nil || *req.Enabled {
+				t.Error("expected enabled to be false")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vm_service_users/abc123": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NASServiceUser{ID: "abc123", Name: "user1", Enabled: false})
+		},
+	}))
+
+	err := client.NASServiceUsers.Disable(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("Disable failed: %v", err)
+	}
+}

--- a/network.go
+++ b/network.go
@@ -202,7 +202,7 @@ func (s *NetworkService) waitForPowerState(ctx context.Context, id int, desiredS
 		}
 	}
 
-	return fmt.Errorf("vergeos: timeout waiting for network %d to become %s", id, stateDesc)
+	return &TimeoutError{Resource: "Network", ID: id, Action: "become " + stateDesc}
 }
 
 // Kill forcefully powers off a network (hard power off).

--- a/network.go
+++ b/network.go
@@ -186,12 +186,6 @@ func (s *NetworkService) waitForPowerState(ctx context.Context, id int, desiredS
 	}
 
 	for i := 0; i < networkPowerStateMaxRetries; i++ {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(networkPowerStatePollInterval):
-		}
-
 		network, err := s.Get(ctx, id)
 		if err != nil {
 			return err
@@ -199,6 +193,12 @@ func (s *NetworkService) waitForPowerState(ctx context.Context, id int, desiredS
 
 		if network.PowerState == desiredState {
 			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(networkPowerStatePollInterval):
 		}
 	}
 

--- a/network.go
+++ b/network.go
@@ -345,7 +345,7 @@ func (s *NetworkService) Ping(ctx context.Context, networkID int, target string,
 	if count <= 0 {
 		count = 4
 	}
-	params := map[string]interface{}{
+	params := map[string]any{
 		"address": target,
 		"count":   count,
 	}
@@ -358,7 +358,7 @@ func (s *NetworkService) Ping(ctx context.Context, networkID int, target string,
 
 // Traceroute runs a traceroute diagnostic on a network.
 func (s *NetworkService) Traceroute(ctx context.Context, networkID int, target string) (*NetworkQuery, error) {
-	params := map[string]interface{}{
+	params := map[string]any{
 		"address": target,
 	}
 	return s.RunQueryWait(ctx, &NetworkQueryRequest{
@@ -370,7 +370,7 @@ func (s *NetworkService) Traceroute(ctx context.Context, networkID int, target s
 
 // DNSLookup runs a DNS lookup diagnostic on a network.
 func (s *NetworkService) DNSLookup(ctx context.Context, networkID int, hostname string) (*NetworkQuery, error) {
-	params := map[string]interface{}{
+	params := map[string]any{
 		"hostname": hostname,
 	}
 	return s.RunQueryWait(ctx, &NetworkQueryRequest{

--- a/network.go
+++ b/network.go
@@ -115,7 +115,7 @@ func (s *NetworkService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnets/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "Network", ID: id}
 		}
 		return err
 	}

--- a/network_test.go
+++ b/network_test.go
@@ -288,12 +288,12 @@ func TestNetworkService_Kill(t *testing.T) {
 func TestNetworkService_Reset(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vnet_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "reset" {
 				t.Errorf("expected action 'reset', got %v", body["action"])
 			}
-			params, ok := body["params"].(map[string]interface{})
+			params, ok := body["params"].(map[string]any)
 			if !ok {
 				t.Fatal("expected params to be a map")
 			}
@@ -313,9 +313,9 @@ func TestNetworkService_Reset(t *testing.T) {
 func TestNetworkService_Reset_NoApply(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vnet_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
-			params, _ := body["params"].(map[string]interface{})
+			params, _ := body["params"].(map[string]any)
 			if params["apply"] != false {
 				t.Errorf("expected apply=false, got %v", params["apply"])
 			}

--- a/network_test.go
+++ b/network_test.go
@@ -1,0 +1,802 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// --- List ---
+
+func TestNetworkService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnets": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Network{
+				{ID: 1, Name: "internal", Type: "internal"},
+				{ID: 2, Name: "external", Type: "external"},
+			})
+		},
+	}))
+
+	networks, err := client.Networks.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(networks) != 2 {
+		t.Fatalf("expected 2 networks, got %d", len(networks))
+	}
+	if networks[0].Name != "internal" {
+		t.Errorf("expected name 'internal', got %q", networks[0].Name)
+	}
+}
+
+func TestNetworkService_List_WithFilter(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnets": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter parameter")
+			}
+			jsonResponse(w, 200, []Network{{ID: 1, Name: "internal", Type: "internal"}})
+		},
+	}))
+
+	networks, err := client.Networks.List(context.Background(), WithFilter("type eq 'internal'"))
+	if err != nil {
+		t.Fatalf("List with filter failed: %v", err)
+	}
+	if len(networks) != 1 {
+		t.Fatalf("expected 1 network, got %d", len(networks))
+	}
+}
+
+func TestNetworkService_List_Empty(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnets": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Network{})
+		},
+	}))
+
+	networks, err := client.Networks.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(networks) != 0 {
+		t.Fatalf("expected 0 networks, got %d", len(networks))
+	}
+}
+
+// --- Get ---
+
+func TestNetworkService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Network{
+				ID:        1,
+				Name:      "internal",
+				Type:      "internal",
+				Enabled:   true,
+				IPAddress: "10.0.0.1",
+			})
+		},
+	}))
+
+	net, err := client.Networks.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if net.Name != "internal" {
+		t.Errorf("expected name 'internal', got %q", net.Name)
+	}
+	if net.IPAddress != "10.0.0.1" {
+		t.Errorf("expected IP '10.0.0.1', got %q", net.IPAddress)
+	}
+}
+
+func TestNetworkService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnets/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Networks.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// --- Create ---
+
+func TestNetworkService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnets": func(w http.ResponseWriter, r *http.Request) {
+			var req NetworkCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "test-net" {
+				t.Errorf("expected name 'test-net', got %q", req.Name)
+			}
+			if req.Enabled == nil || !*req.Enabled {
+				t.Error("expected enabled to default to true")
+			}
+			jsonResponse(w, 200, apiResponse{Key: 42})
+		},
+		"GET /api/v4/vnets/42": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Network{ID: 42, Name: "test-net", Enabled: true})
+		},
+	}))
+
+	net, err := client.Networks.Create(context.Background(), &NetworkCreateRequest{
+		Name: "test-net",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if int(net.ID) != 42 {
+		t.Errorf("expected ID 42, got %d", int(net.ID))
+	}
+	if net.Name != "test-net" {
+		t.Errorf("expected name 'test-net', got %q", net.Name)
+	}
+}
+
+func TestNetworkService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Networks.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestNetworkService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Networks.Create(context.Background(), &NetworkCreateRequest{})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+// --- Update ---
+
+func TestNetworkService_Update(t *testing.T) {
+	newName := "renamed-net"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			var req NetworkUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Network{ID: 1, Name: newName})
+		},
+	}))
+
+	net, err := client.Networks.Update(context.Background(), 1, &NetworkUpdateRequest{
+		Name: &newName,
+	})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if net.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, net.Name)
+	}
+}
+
+func TestNetworkService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Networks.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestNetworkService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnets/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newName := "nope"
+	_, err := client.Networks.Update(context.Background(), 999, &NetworkUpdateRequest{
+		Name: &newName,
+	})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// --- Delete ---
+
+func TestNetworkService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Networks.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestNetworkService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnets/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	// Delete returns nil for not-found (idempotent)
+	err := client.Networks.Delete(context.Background(), 999)
+	if err != nil {
+		t.Fatalf("Delete should succeed for not-found, got: %v", err)
+	}
+}
+
+// --- Kill ---
+
+func TestNetworkService_Kill(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body vnetAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.VNet != 5 {
+				t.Errorf("expected vnet 5, got %d", body.VNet)
+			}
+			if body.Action != "killpower" {
+				t.Errorf("expected action 'killpower', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Networks.Kill(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("Kill failed: %v", err)
+	}
+}
+
+// --- Reset ---
+
+func TestNetworkService_Reset(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "reset" {
+				t.Errorf("expected action 'reset', got %v", body["action"])
+			}
+			params, ok := body["params"].(map[string]interface{})
+			if !ok {
+				t.Fatal("expected params to be a map")
+			}
+			if params["apply"] != true {
+				t.Errorf("expected apply=true, got %v", params["apply"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Networks.Reset(context.Background(), 3, true)
+	if err != nil {
+		t.Fatalf("Reset failed: %v", err)
+	}
+}
+
+func TestNetworkService_Reset_NoApply(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			params, _ := body["params"].(map[string]interface{})
+			if params["apply"] != false {
+				t.Errorf("expected apply=false, got %v", params["apply"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Networks.Reset(context.Background(), 3, false)
+	if err != nil {
+		t.Fatalf("Reset failed: %v", err)
+	}
+}
+
+// --- ApplyRules ---
+
+func TestNetworkService_ApplyRules(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body vnetAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.VNet != 7 {
+				t.Errorf("expected vnet 7, got %d", body.VNet)
+			}
+			if body.Action != "refresh" {
+				t.Errorf("expected action 'refresh', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Networks.ApplyRules(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("ApplyRules failed: %v", err)
+	}
+}
+
+// --- ApplyDNS ---
+
+func TestNetworkService_ApplyDNS(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body vnetAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.VNet != 7 {
+				t.Errorf("expected vnet 7, got %d", body.VNet)
+			}
+			if body.Action != "applydns" {
+				t.Errorf("expected action 'applydns', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Networks.ApplyDNS(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("ApplyDNS failed: %v", err)
+	}
+}
+
+// --- RunQuery ---
+
+func TestNetworkService_RunQuery(t *testing.T) {
+	queryID := "abc123def456"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_queries": func(w http.ResponseWriter, r *http.Request) {
+			var req NetworkQueryRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.VNet != 10 {
+				t.Errorf("expected vnet 10, got %d", req.VNet)
+			}
+			if req.Query != "ping" {
+				t.Errorf("expected query 'ping', got %q", req.Query)
+			}
+			jsonResponse(w, 200, map[string]string{"id": queryID})
+		},
+		"GET /api/v4/vnet_queries/": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NetworkQuery{
+				ID:     queryID,
+				VNet:   10,
+				Query:  "ping",
+				Status: NetworkQueryStatusComplete,
+			})
+		},
+	}))
+
+	q, err := client.Networks.RunQuery(context.Background(), &NetworkQueryRequest{
+		VNet:  10,
+		Query: NetworkQueryPing,
+	})
+	if err != nil {
+		t.Fatalf("RunQuery failed: %v", err)
+	}
+	if q.ID != queryID {
+		t.Errorf("expected query ID %q, got %q", queryID, q.ID)
+	}
+}
+
+func TestNetworkService_RunQuery_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Networks.RunQuery(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestNetworkService_RunQuery_MissingVNet(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Networks.RunQuery(context.Background(), &NetworkQueryRequest{
+		Query: "ping",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing vnet")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestNetworkService_RunQuery_MissingQuery(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Networks.RunQuery(context.Background(), &NetworkQueryRequest{
+		VNet: 10,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing query")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+// --- GetQuery ---
+
+func TestNetworkService_GetQuery(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_queries/abc123": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NetworkQuery{
+				ID:     "abc123",
+				VNet:   10,
+				Query:  "ping",
+				Status: NetworkQueryStatusComplete,
+			})
+		},
+	}))
+
+	q, err := client.Networks.GetQuery(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("GetQuery failed: %v", err)
+	}
+	if q.Status != NetworkQueryStatusComplete {
+		t.Errorf("expected status 'complete', got %q", q.Status)
+	}
+}
+
+func TestNetworkService_GetQuery_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_queries/nope": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Networks.GetQuery(context.Background(), "nope")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// --- Ping ---
+
+func TestNetworkService_Ping(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_queries": func(w http.ResponseWriter, r *http.Request) {
+			var req NetworkQueryRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Query != "ping" {
+				t.Errorf("expected query 'ping', got %q", req.Query)
+			}
+			if req.Params["address"] != "8.8.8.8" {
+				t.Errorf("expected address '8.8.8.8', got %v", req.Params["address"])
+			}
+			jsonResponse(w, 200, map[string]string{"id": "ping-001"})
+		},
+		"GET /api/v4/vnet_queries/": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NetworkQuery{
+				ID:     "ping-001",
+				VNet:   1,
+				Query:  "ping",
+				Status: NetworkQueryStatusComplete,
+			})
+		},
+	}))
+
+	q, err := client.Networks.Ping(context.Background(), 1, "8.8.8.8", 4)
+	if err != nil {
+		t.Fatalf("Ping failed: %v", err)
+	}
+	if q.Query != "ping" {
+		t.Errorf("expected query 'ping', got %q", q.Query)
+	}
+}
+
+func TestNetworkService_Ping_DefaultCount(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_queries": func(w http.ResponseWriter, r *http.Request) {
+			var req NetworkQueryRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			count, ok := req.Params["count"].(float64) // JSON numbers are float64
+			if !ok || int(count) != 4 {
+				t.Errorf("expected default count 4, got %v", req.Params["count"])
+			}
+			jsonResponse(w, 200, map[string]string{"id": "ping-002"})
+		},
+		"GET /api/v4/vnet_queries/": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NetworkQuery{
+				ID:     "ping-002",
+				Status: NetworkQueryStatusComplete,
+			})
+		},
+	}))
+
+	_, err := client.Networks.Ping(context.Background(), 1, "10.0.0.1", 0)
+	if err != nil {
+		t.Fatalf("Ping with default count failed: %v", err)
+	}
+}
+
+// --- Traceroute ---
+
+func TestNetworkService_Traceroute(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_queries": func(w http.ResponseWriter, r *http.Request) {
+			var req NetworkQueryRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Query != "traceroute" {
+				t.Errorf("expected query 'traceroute', got %q", req.Query)
+			}
+			if req.Params["address"] != "1.1.1.1" {
+				t.Errorf("expected address '1.1.1.1', got %v", req.Params["address"])
+			}
+			jsonResponse(w, 200, map[string]string{"id": "trace-001"})
+		},
+		"GET /api/v4/vnet_queries/": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NetworkQuery{
+				ID:     "trace-001",
+				Query:  "traceroute",
+				Status: NetworkQueryStatusComplete,
+			})
+		},
+	}))
+
+	q, err := client.Networks.Traceroute(context.Background(), 1, "1.1.1.1")
+	if err != nil {
+		t.Fatalf("Traceroute failed: %v", err)
+	}
+	if q.Query != "traceroute" {
+		t.Errorf("expected query 'traceroute', got %q", q.Query)
+	}
+}
+
+// --- DNSLookup ---
+
+func TestNetworkService_DNSLookup(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_queries": func(w http.ResponseWriter, r *http.Request) {
+			var req NetworkQueryRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Query != "dns" {
+				t.Errorf("expected query 'dns', got %q", req.Query)
+			}
+			if req.Params["hostname"] != "example.com" {
+				t.Errorf("expected hostname 'example.com', got %v", req.Params["hostname"])
+			}
+			jsonResponse(w, 200, map[string]string{"id": "dns-001"})
+		},
+		"GET /api/v4/vnet_queries/": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NetworkQuery{
+				ID:     "dns-001",
+				Query:  "dns",
+				Status: NetworkQueryStatusComplete,
+			})
+		},
+	}))
+
+	q, err := client.Networks.DNSLookup(context.Background(), 1, "example.com")
+	if err != nil {
+		t.Fatalf("DNSLookup failed: %v", err)
+	}
+	if q.Query != "dns" {
+		t.Errorf("expected query 'dns', got %q", q.Query)
+	}
+}
+
+// --- GetDiagnostics ---
+
+func TestNetworkService_GetDiagnostics(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_queries": func(w http.ResponseWriter, r *http.Request) {
+			var req NetworkQueryRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Query != "whatsmyip" {
+				t.Errorf("expected query 'whatsmyip', got %q", req.Query)
+			}
+			jsonResponse(w, 200, map[string]string{"id": "diag-001"})
+		},
+		"GET /api/v4/vnet_queries/": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, NetworkQuery{
+				ID:     "diag-001",
+				Query:  "whatsmyip",
+				Status: NetworkQueryStatusComplete,
+			})
+		},
+	}))
+
+	q, err := client.Networks.GetDiagnostics(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("GetDiagnostics failed: %v", err)
+	}
+	if q.Query != "whatsmyip" {
+		t.Errorf("expected query 'whatsmyip', got %q", q.Query)
+	}
+}
+
+// --- GetStatistics ---
+
+func TestNetworkService_GetStatistics(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_monitor_stats_history_short": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "vnet eq 1" {
+				t.Errorf("expected filter 'vnet eq 1', got %q", filter)
+			}
+			jsonResponse(w, 200, []NetworkMonitorStats{
+				{Key: 100, VNet: 1, Quality: 99},
+				{Key: 101, VNet: 1, Quality: 95},
+			})
+		},
+	}))
+
+	stats, err := client.Networks.GetStatistics(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetStatistics failed: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("expected 2 stats, got %d", len(stats))
+	}
+	if stats[0].Quality != 99 {
+		t.Errorf("expected quality 99, got %d", stats[0].Quality)
+	}
+}
+
+func TestNetworkService_GetStatistics_Empty(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_monitor_stats_history_short": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []NetworkMonitorStats{})
+		},
+	}))
+
+	stats, err := client.Networks.GetStatistics(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetStatistics failed: %v", err)
+	}
+	if len(stats) != 0 {
+		t.Fatalf("expected 0 stats, got %d", len(stats))
+	}
+}
+
+// --- GetLatestStatistics ---
+
+func TestNetworkService_GetLatestStatistics(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_monitor_stats_history_short": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []NetworkMonitorStats{
+				{Key: 100, VNet: 1, Quality: 99},
+				{Key: 101, VNet: 1, Quality: 95},
+			})
+		},
+	}))
+
+	stat, err := client.Networks.GetLatestStatistics(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetLatestStatistics failed: %v", err)
+	}
+	if stat == nil {
+		t.Fatal("expected non-nil stat")
+	}
+	if stat.Quality != 99 {
+		t.Errorf("expected quality 99, got %d", stat.Quality)
+	}
+}
+
+func TestNetworkService_GetLatestStatistics_Empty(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_monitor_stats_history_short": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []NetworkMonitorStats{})
+		},
+	}))
+
+	stat, err := client.Networks.GetLatestStatistics(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetLatestStatistics failed: %v", err)
+	}
+	if stat != nil {
+		t.Errorf("expected nil for empty stats, got %+v", stat)
+	}
+}
+
+// --- PowerOn ---
+
+func TestNetworkService_PowerOn_AlreadyRunning(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Network{ID: 1, Name: "net", PowerState: true})
+		},
+	}))
+
+	// Should return nil immediately since already running
+	err := client.Networks.PowerOn(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("PowerOn (already running) failed: %v", err)
+	}
+}
+
+// --- PowerOff ---
+
+func TestNetworkService_PowerOff_AlreadyStopped(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Network{ID: 1, Name: "net", PowerState: false})
+		},
+	}))
+
+	// Should return nil immediately since already stopped
+	err := client.Networks.PowerOff(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("PowerOff (already stopped) failed: %v", err)
+	}
+}
+
+// --- Action server errors ---
+
+func TestNetworkService_Kill_ServerError(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_actions": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 500, map[string]string{"err": "internal error"})
+		},
+	}))
+
+	err := client.Networks.Kill(context.Background(), 1)
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+func TestNetworkService_ApplyRules_ServerError(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_actions": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 500, map[string]string{"err": "internal error"})
+		},
+	}))
+
+	err := client.Networks.ApplyRules(context.Background(), 1)
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+func TestNetworkService_ApplyDNS_ServerError(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_actions": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 500, map[string]string{"err": "internal error"})
+		},
+	}))
+
+	err := client.Networks.ApplyDNS(context.Background(), 1)
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}

--- a/network_test.go
+++ b/network_test.go
@@ -252,8 +252,11 @@ func TestNetworkService_Delete_NotFound(t *testing.T) {
 
 	// Delete returns nil for not-found (idempotent)
 	err := client.Networks.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("Delete should succeed for not-found, got: %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted network")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }
 

--- a/node.go
+++ b/node.go
@@ -18,7 +18,7 @@ const (
 type nodeAction struct {
 	Node   int         `json:"node"`
 	Action string      `json:"action"`
-	Params interface{} `json:"params"`
+	Params any `json:"params"`
 }
 
 // NodeService handles node read operations.

--- a/node.go
+++ b/node.go
@@ -82,23 +82,6 @@ func (s *NodeService) GetByName(ctx context.Context, name string) (*Node, error)
 	return &nodes[0], nil
 }
 
-// GetDashboard returns detailed dashboard information for a node.
-func (s *NodeService) GetDashboard(ctx context.Context, id int) (*Node, error) {
-	params := url.Values{}
-	params.Set("fields", "dashboard")
-
-	var node Node
-	endpoint := fmt.Sprintf("/nodes/%d", id)
-	if err := s.client.get(ctx, endpoint, params, &node); err != nil {
-		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Node", ID: id}
-		}
-		return nil, err
-	}
-
-	return &node, nil
-}
-
 // EnableMaintenance puts a node into maintenance mode.
 // In maintenance mode, VMs are migrated off the node and no new VMs will be scheduled to it.
 func (s *NodeService) EnableMaintenance(ctx context.Context, id int) error {

--- a/node.go
+++ b/node.go
@@ -70,7 +70,7 @@ func (s *NodeService) Get(ctx context.Context, id int) (*Node, error) {
 
 // GetByName returns a node by name.
 func (s *NodeService) GetByName(ctx context.Context, name string) (*Node, error) {
-	nodes, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	nodes, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/node_test.go
+++ b/node_test.go
@@ -1,0 +1,197 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestNodeService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/nodes": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Node{
+				{ID: 1, Name: "node1", Physical: true},
+				{ID: 2, Name: "node2", Physical: false},
+			})
+		},
+	}))
+
+	nodes, err := client.Nodes.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(nodes))
+	}
+	if nodes[0].Name != "node1" {
+		t.Errorf("expected name 'node1', got %q", nodes[0].Name)
+	}
+}
+
+func TestNodeService_ListPhysical(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/nodes": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter for physical nodes")
+			}
+			jsonResponse(w, 200, []Node{
+				{ID: 1, Name: "node1", Physical: true},
+			})
+		},
+	}))
+
+	nodes, err := client.Nodes.ListPhysical(context.Background())
+	if err != nil {
+		t.Fatalf("ListPhysical failed: %v", err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(nodes))
+	}
+	if !nodes[0].Physical {
+		t.Error("expected physical node")
+	}
+}
+
+func TestNodeService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/nodes/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Node{ID: 1, Name: "node1", Cores: 16, Physical: true})
+		},
+	}))
+
+	node, err := client.Nodes.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if node.Name != "node1" {
+		t.Errorf("expected name 'node1', got %q", node.Name)
+	}
+	if node.Cores != 16 {
+		t.Errorf("expected 16 cores, got %d", node.Cores)
+	}
+}
+
+func TestNodeService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/nodes/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Nodes.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestNodeService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/nodes": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Node{{ID: 1, Name: "node1", Physical: true}})
+		},
+	}))
+
+	node, err := client.Nodes.GetByName(context.Background(), "node1")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if node.Name != "node1" {
+		t.Errorf("expected name 'node1', got %q", node.Name)
+	}
+}
+
+func TestNodeService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/nodes": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Node{})
+		},
+	}))
+
+	_, err := client.Nodes.GetByName(context.Background(), "nope")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestNodeService_EnableMaintenance(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/node_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body nodeAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "enable_maintenance" {
+				t.Errorf("expected action 'enable_maintenance', got %q", body.Action)
+			}
+			if body.Node != 1 {
+				t.Errorf("expected node 1, got %d", body.Node)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Nodes.EnableMaintenance(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("EnableMaintenance failed: %v", err)
+	}
+}
+
+func TestNodeService_DisableMaintenance(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/node_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body nodeAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "disable_maintenance" {
+				t.Errorf("expected action 'disable_maintenance', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Nodes.DisableMaintenance(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("DisableMaintenance failed: %v", err)
+	}
+}
+
+func TestNodeService_MaintenanceReboot(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/node_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body nodeAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "maintenance_reboot" {
+				t.Errorf("expected action 'maintenance_reboot', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Nodes.MaintenanceReboot(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("MaintenanceReboot failed: %v", err)
+	}
+}
+
+func TestNodeService_ClearPStore(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/node_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body nodeAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "clear_pstore" {
+				t.Errorf("expected action 'clear_pstore', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Nodes.ClearPStore(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ClearPStore failed: %v", err)
+	}
+}

--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package vergeos
 import (
 	"fmt"
 	"net/url"
+	"strings"
 )
 
 // ListOptions contains options for list operations.
@@ -107,4 +108,11 @@ func (opts *ListOptions) toQueryParams() url.Values {
 	}
 
 	return params
+}
+
+// escapeFilterValue escapes single quotes in a string value for use in
+// VergeOS API filter expressions. A value containing an unescaped single
+// quote would break the filter syntax.
+func escapeFilterValue(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
 }

--- a/options.go
+++ b/options.go
@@ -30,7 +30,11 @@ type ListOption func(*ListOptions)
 //   - "name eq 'vm1' and enabled eq true"
 func WithFilter(filter string) ListOption {
 	return func(opts *ListOptions) {
-		opts.Filter = filter
+		if opts.Filter != "" {
+			opts.Filter = opts.Filter + " and " + filter
+		} else {
+			opts.Filter = filter
+		}
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -48,13 +48,25 @@ func TestApplyListOptions_AllOptions(t *testing.T) {
 	}
 }
 
-func TestApplyListOptions_LastOneWins(t *testing.T) {
+func TestApplyListOptions_FilterCombination(t *testing.T) {
 	opts := applyListOptions([]ListOption{
 		WithFilter("first"),
 		WithFilter("second"),
 	})
-	if opts.Filter != "second" {
-		t.Errorf("expected last filter to win, got %q", opts.Filter)
+	if opts.Filter != "first and second" {
+		t.Errorf("expected combined filter, got %q", opts.Filter)
+	}
+}
+
+func TestApplyListOptions_TripleFilterCombination(t *testing.T) {
+	opts := applyListOptions([]ListOption{
+		WithFilter("a eq 1"),
+		WithFilter("b eq 2"),
+		WithFilter("c eq 3"),
+	})
+	expected := "a eq 1 and b eq 2 and c eq 3"
+	if opts.Filter != expected {
+		t.Errorf("expected %q, got %q", expected, opts.Filter)
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -171,3 +171,23 @@ func TestWithOffset(t *testing.T) {
 		t.Errorf("got %d", opts.Offset)
 	}
 }
+
+func TestEscapeFilterValue(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"normal", "normal"},
+		{"it's", "it''s"},
+		{"can't won't", "can''t won''t"},
+		{"no quotes", "no quotes"},
+		{"", ""},
+		{"'", "''"},
+	}
+	for _, tt := range tests {
+		got := escapeFilterValue(tt.input)
+		if got != tt.want {
+			t.Errorf("escapeFilterValue(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,161 @@
+package vergeos
+
+import (
+	"testing"
+)
+
+func TestApplyListOptions_Defaults(t *testing.T) {
+	opts := applyListOptions(nil)
+	if opts.Fields != "most" {
+		t.Errorf("expected default fields 'most', got %q", opts.Fields)
+	}
+	if opts.Filter != "" {
+		t.Errorf("expected empty filter, got %q", opts.Filter)
+	}
+	if opts.Sort != "" {
+		t.Errorf("expected empty sort, got %q", opts.Sort)
+	}
+	if opts.Limit != 0 {
+		t.Errorf("expected limit 0, got %d", opts.Limit)
+	}
+	if opts.Offset != 0 {
+		t.Errorf("expected offset 0, got %d", opts.Offset)
+	}
+}
+
+func TestApplyListOptions_AllOptions(t *testing.T) {
+	opts := applyListOptions([]ListOption{
+		WithFilter("name eq 'test'"),
+		WithFields("all"),
+		WithSort("-created"),
+		WithLimit(50),
+		WithOffset(10),
+	})
+	if opts.Filter != "name eq 'test'" {
+		t.Errorf("expected filter \"name eq 'test'\", got %q", opts.Filter)
+	}
+	if opts.Fields != "all" {
+		t.Errorf("expected fields 'all', got %q", opts.Fields)
+	}
+	if opts.Sort != "-created" {
+		t.Errorf("expected sort '-created', got %q", opts.Sort)
+	}
+	if opts.Limit != 50 {
+		t.Errorf("expected limit 50, got %d", opts.Limit)
+	}
+	if opts.Offset != 10 {
+		t.Errorf("expected offset 10, got %d", opts.Offset)
+	}
+}
+
+func TestApplyListOptions_LastOneWins(t *testing.T) {
+	opts := applyListOptions([]ListOption{
+		WithFilter("first"),
+		WithFilter("second"),
+	})
+	if opts.Filter != "second" {
+		t.Errorf("expected last filter to win, got %q", opts.Filter)
+	}
+}
+
+func TestToQueryParams_Empty(t *testing.T) {
+	opts := &ListOptions{}
+	params := opts.toQueryParams()
+	if len(params) != 0 {
+		t.Errorf("expected no params for empty options, got %v", params)
+	}
+}
+
+func TestToQueryParams_FieldsOnly(t *testing.T) {
+	opts := &ListOptions{Fields: "name,enabled"}
+	params := opts.toQueryParams()
+	if params.Get("fields") != "name,enabled" {
+		t.Errorf("expected fields 'name,enabled', got %q", params.Get("fields"))
+	}
+	if params.Get("filter") != "" {
+		t.Error("expected no filter param")
+	}
+}
+
+func TestToQueryParams_AllParams(t *testing.T) {
+	opts := &ListOptions{
+		Fields: "all",
+		Filter: "enabled eq true",
+		Sort:   "-name",
+		Limit:  25,
+		Offset: 5,
+	}
+	params := opts.toQueryParams()
+
+	if params.Get("fields") != "all" {
+		t.Errorf("fields: got %q", params.Get("fields"))
+	}
+	if params.Get("filter") != "enabled eq true" {
+		t.Errorf("filter: got %q", params.Get("filter"))
+	}
+	if params.Get("sort") != "-name" {
+		t.Errorf("sort: got %q", params.Get("sort"))
+	}
+	if params.Get("limit") != "25" {
+		t.Errorf("limit: got %q", params.Get("limit"))
+	}
+	if params.Get("offset") != "5" {
+		t.Errorf("offset: got %q", params.Get("offset"))
+	}
+}
+
+func TestToQueryParams_ZeroLimitAndOffset(t *testing.T) {
+	opts := &ListOptions{
+		Fields: "most",
+		Limit:  0,
+		Offset: 0,
+	}
+	params := opts.toQueryParams()
+
+	if params.Get("limit") != "" {
+		t.Error("zero limit should not produce a param")
+	}
+	if params.Get("offset") != "" {
+		t.Error("zero offset should not produce a param")
+	}
+}
+
+func TestWithFilter(t *testing.T) {
+	opts := &ListOptions{}
+	WithFilter("name eq 'foo'")(opts)
+	if opts.Filter != "name eq 'foo'" {
+		t.Errorf("got %q", opts.Filter)
+	}
+}
+
+func TestWithFields(t *testing.T) {
+	opts := &ListOptions{}
+	WithFields("name,ram")(opts)
+	if opts.Fields != "name,ram" {
+		t.Errorf("got %q", opts.Fields)
+	}
+}
+
+func TestWithSort(t *testing.T) {
+	opts := &ListOptions{}
+	WithSort("-created")(opts)
+	if opts.Sort != "-created" {
+		t.Errorf("got %q", opts.Sort)
+	}
+}
+
+func TestWithLimit(t *testing.T) {
+	opts := &ListOptions{}
+	WithLimit(100)(opts)
+	if opts.Limit != 100 {
+		t.Errorf("got %d", opts.Limit)
+	}
+}
+
+func TestWithOffset(t *testing.T) {
+	opts := &ListOptions{}
+	WithOffset(20)(opts)
+	if opts.Offset != 20 {
+		t.Errorf("got %d", opts.Offset)
+	}
+}

--- a/permission.go
+++ b/permission.go
@@ -38,13 +38,13 @@ func (s *PermissionService) ListByIdentity(ctx context.Context, identityID int, 
 
 // ListByTable returns all permissions for a specific resource type.
 func (s *PermissionService) ListByTable(ctx context.Context, table string, opts ...ListOption) ([]Permission, error) {
-	opts = append([]ListOption{WithFilter(fmt.Sprintf("table eq '%s'", table))}, opts...)
+	opts = append([]ListOption{WithFilter(fmt.Sprintf("table eq '%s'", escapeFilterValue(table)))}, opts...)
 	return s.List(ctx, opts...)
 }
 
 // ListByResource returns all permissions for a specific resource instance.
 func (s *PermissionService) ListByResource(ctx context.Context, table string, rowID int64, opts ...ListOption) ([]Permission, error) {
-	opts = append([]ListOption{WithFilter(fmt.Sprintf("table eq '%s' and row eq %d", table, rowID))}, opts...)
+	opts = append([]ListOption{WithFilter(fmt.Sprintf("table eq '%s' and row eq %d", escapeFilterValue(table), rowID))}, opts...)
 	return s.List(ctx, opts...)
 }
 
@@ -67,7 +67,7 @@ func (s *PermissionService) Get(ctx context.Context, id int) (*Permission, error
 
 // GetByIdentityAndResource returns the permission for a specific identity and resource.
 func (s *PermissionService) GetByIdentityAndResource(ctx context.Context, identityID int, table string, rowID int64) (*Permission, error) {
-	permissions, err := s.List(ctx, WithFilter(fmt.Sprintf("identity eq %d and table eq '%s' and row eq %d", identityID, table, rowID)))
+	permissions, err := s.List(ctx, WithFilter(fmt.Sprintf("identity eq %d and table eq '%s' and row eq %d", identityID, escapeFilterValue(table), rowID)))
 	if err != nil {
 		return nil, err
 	}

--- a/permission_test.go
+++ b/permission_test.go
@@ -174,7 +174,7 @@ func TestPermissionService_Create(t *testing.T) {
 			if req.Row != 100 {
 				t.Errorf("expected row 100, got %d", req.Row)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, Permission{Key: 1, Identity: 10, Table: "vms", Row: 100, Read: true})
@@ -352,7 +352,7 @@ func TestPermissionService_Grant(t *testing.T) {
 			if req.Delete == nil || *req.Delete {
 				t.Error("expected delete=false")
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, Permission{Key: 1, Identity: 10, Table: "vms", Row: 100, List: true, Read: true, Modify: true})
@@ -382,7 +382,7 @@ func TestPermissionService_GrantReadOnly(t *testing.T) {
 			if req.Delete != nil && *req.Delete {
 				t.Error("expected delete=false")
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, Permission{Key: 1, Identity: 10, Table: "vms", Row: 100, List: true, Read: true})
@@ -418,7 +418,7 @@ func TestPermissionService_GrantFullAccess(t *testing.T) {
 			if req.Delete == nil || !*req.Delete {
 				t.Error("expected delete=true")
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, Permission{Key: 1, Identity: 10, Table: "vms", Row: 100, List: true, Read: true, Create: true, Modify: true, Delete: true})

--- a/permission_test.go
+++ b/permission_test.go
@@ -1,0 +1,469 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestPermissionService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/permissions": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Permission{
+				{Key: 1, Identity: 10, Table: "vms", Row: 100, Read: true},
+				{Key: 2, Identity: 20, Table: "vnets", Row: 200, Read: true, Modify: true},
+			})
+		},
+	}))
+
+	perms, err := client.Permissions.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(perms) != 2 {
+		t.Fatalf("expected 2 permissions, got %d", len(perms))
+	}
+	if !perms[0].Read {
+		t.Error("expected first permission to have read=true")
+	}
+}
+
+func TestPermissionService_ListByIdentity(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/permissions": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "identity eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Permission{{Key: 1, Identity: 10, Table: "vms"}})
+		},
+	}))
+
+	perms, err := client.Permissions.ListByIdentity(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListByIdentity failed: %v", err)
+	}
+	if len(perms) != 1 {
+		t.Fatalf("expected 1 permission, got %d", len(perms))
+	}
+}
+
+func TestPermissionService_ListByTable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/permissions": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "table eq 'vms'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Permission{{Key: 1, Table: "vms"}})
+		},
+	}))
+
+	perms, err := client.Permissions.ListByTable(context.Background(), "vms")
+	if err != nil {
+		t.Fatalf("ListByTable failed: %v", err)
+	}
+	if len(perms) != 1 {
+		t.Fatalf("expected 1 permission, got %d", len(perms))
+	}
+}
+
+func TestPermissionService_ListByResource(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/permissions": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "table eq 'vms' and row eq 100" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Permission{{Key: 1, Table: "vms", Row: 100}})
+		},
+	}))
+
+	perms, err := client.Permissions.ListByResource(context.Background(), "vms", 100)
+	if err != nil {
+		t.Fatalf("ListByResource failed: %v", err)
+	}
+	if len(perms) != 1 {
+		t.Fatalf("expected 1 permission, got %d", len(perms))
+	}
+}
+
+func TestPermissionService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Permission{Key: 1, Identity: 10, Table: "vms", Row: 100, Read: true, Modify: true})
+		},
+	}))
+
+	perm, err := client.Permissions.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if !perm.Modify {
+		t.Error("expected modify=true")
+	}
+	if perm.Table != "vms" {
+		t.Errorf("expected table 'vms', got %q", perm.Table)
+	}
+}
+
+func TestPermissionService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/permissions/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Permissions.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestPermissionService_GetByIdentityAndResource(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/permissions": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Permission{{Key: 1, Identity: 10, Table: "vms", Row: 100}})
+		},
+		"GET /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Permission{Key: 1, Identity: 10, Table: "vms", Row: 100, Read: true})
+		},
+	}))
+
+	perm, err := client.Permissions.GetByIdentityAndResource(context.Background(), 10, "vms", 100)
+	if err != nil {
+		t.Fatalf("GetByIdentityAndResource failed: %v", err)
+	}
+	if int(perm.Identity) != 10 {
+		t.Errorf("expected identity 10, got %d", perm.Identity)
+	}
+}
+
+func TestPermissionService_GetByIdentityAndResource_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/permissions": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Permission{})
+		},
+	}))
+
+	_, err := client.Permissions.GetByIdentityAndResource(context.Background(), 10, "vms", 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestPermissionService_Create(t *testing.T) {
+	readTrue := true
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/permissions": func(w http.ResponseWriter, r *http.Request) {
+			var req PermissionCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Identity != 10 {
+				t.Errorf("expected identity 10, got %d", req.Identity)
+			}
+			if req.Table != "vms" {
+				t.Errorf("expected table 'vms', got %q", req.Table)
+			}
+			if req.Row != 100 {
+				t.Errorf("expected row 100, got %d", req.Row)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+		},
+		"GET /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Permission{Key: 1, Identity: 10, Table: "vms", Row: 100, Read: true})
+		},
+	}))
+
+	perm, err := client.Permissions.Create(context.Background(), &PermissionCreateRequest{
+		Identity: 10,
+		Table:    "vms",
+		Row:      100,
+		Read:     &readTrue,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if !perm.Read {
+		t.Error("expected read=true")
+	}
+}
+
+func TestPermissionService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Permissions.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestPermissionService_Create_MissingIdentity(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Permissions.Create(context.Background(), &PermissionCreateRequest{
+		Table: "vms",
+		Row:   100,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing identity")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestPermissionService_Create_MissingTable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Permissions.Create(context.Background(), &PermissionCreateRequest{
+		Identity: 10,
+		Row:      100,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing table")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestPermissionService_Create_MissingRow(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Permissions.Create(context.Background(), &PermissionCreateRequest{
+		Identity: 10,
+		Table:    "vms",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing row")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestPermissionService_Update(t *testing.T) {
+	modifyTrue := true
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
+			var req PermissionUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Modify == nil || !*req.Modify {
+				t.Error("expected modify=true")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Permission{Key: 1, Identity: 10, Table: "vms", Row: 100, Read: true, Modify: true})
+		},
+	}))
+
+	perm, err := client.Permissions.Update(context.Background(), 1, &PermissionUpdateRequest{Modify: &modifyTrue})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if !perm.Modify {
+		t.Error("expected modify=true after update")
+	}
+}
+
+func TestPermissionService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Permissions.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestPermissionService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/permissions/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	modifyTrue := true
+	_, err := client.Permissions.Update(context.Background(), 999, &PermissionUpdateRequest{Modify: &modifyTrue})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestPermissionService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Permissions.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestPermissionService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/permissions/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.Permissions.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestPermissionService_Grant(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/permissions": func(w http.ResponseWriter, r *http.Request) {
+			var req PermissionCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Identity != 10 {
+				t.Errorf("expected identity 10, got %d", req.Identity)
+			}
+			if req.Read == nil || !*req.Read {
+				t.Error("expected read=true")
+			}
+			if req.Modify == nil || !*req.Modify {
+				t.Error("expected modify=true")
+			}
+			if req.Delete == nil || *req.Delete {
+				t.Error("expected delete=false")
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+		},
+		"GET /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Permission{Key: 1, Identity: 10, Table: "vms", Row: 100, List: true, Read: true, Modify: true})
+		},
+	}))
+
+	perm, err := client.Permissions.Grant(context.Background(), 10, "vms", 100, true, true, false)
+	if err != nil {
+		t.Fatalf("Grant failed: %v", err)
+	}
+	if !perm.Read || !perm.Modify {
+		t.Error("expected read and modify to be true")
+	}
+}
+
+func TestPermissionService_GrantReadOnly(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/permissions": func(w http.ResponseWriter, r *http.Request) {
+			var req PermissionCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Read == nil || !*req.Read {
+				t.Error("expected read=true")
+			}
+			if req.Modify != nil && *req.Modify {
+				t.Error("expected modify=false")
+			}
+			if req.Delete != nil && *req.Delete {
+				t.Error("expected delete=false")
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+		},
+		"GET /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Permission{Key: 1, Identity: 10, Table: "vms", Row: 100, List: true, Read: true})
+		},
+	}))
+
+	perm, err := client.Permissions.GrantReadOnly(context.Background(), 10, "vms", 100)
+	if err != nil {
+		t.Fatalf("GrantReadOnly failed: %v", err)
+	}
+	if !perm.Read {
+		t.Error("expected read=true")
+	}
+	if perm.Modify {
+		t.Error("expected modify=false for read-only")
+	}
+}
+
+func TestPermissionService_GrantFullAccess(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/permissions": func(w http.ResponseWriter, r *http.Request) {
+			var req PermissionCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Read == nil || !*req.Read {
+				t.Error("expected read=true")
+			}
+			if req.Create == nil || !*req.Create {
+				t.Error("expected create=true")
+			}
+			if req.Modify == nil || !*req.Modify {
+				t.Error("expected modify=true")
+			}
+			if req.Delete == nil || !*req.Delete {
+				t.Error("expected delete=true")
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+		},
+		"GET /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Permission{Key: 1, Identity: 10, Table: "vms", Row: 100, List: true, Read: true, Create: true, Modify: true, Delete: true})
+		},
+	}))
+
+	perm, err := client.Permissions.GrantFullAccess(context.Background(), 10, "vms", 100)
+	if err != nil {
+		t.Fatalf("GrantFullAccess failed: %v", err)
+	}
+	if !perm.Read || !perm.Create || !perm.Modify || !perm.Delete {
+		t.Error("expected all permissions to be true for full access")
+	}
+}
+
+func TestPermissionService_Revoke(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/permissions": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Permission{{Key: 1, Identity: 10, Table: "vms", Row: 100}})
+		},
+		"GET /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Permission{Key: 1, Identity: 10, Table: "vms", Row: 100})
+		},
+		"DELETE /api/v4/permissions/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Permissions.Revoke(context.Background(), 10, "vms", 100)
+	if err != nil {
+		t.Fatalf("Revoke failed: %v", err)
+	}
+}
+
+func TestPermissionService_Revoke_NotExists(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/permissions": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Permission{})
+		},
+	}))
+
+	// Revoke on nonexistent permission should not error (idempotent).
+	// GetByIdentityAndResource returns NotFoundError, which Revoke treats as success.
+	err := client.Permissions.Revoke(context.Background(), 10, "vms", 999)
+	if err != nil {
+		t.Fatalf("Revoke of nonexistent permission should not error, got: %v", err)
+	}
+}

--- a/resourcegroup.go
+++ b/resourcegroup.go
@@ -48,7 +48,7 @@ func (s *ResourceGroupService) Get(ctx context.Context, id int) (*ResourceGroup,
 
 // GetByName returns a resource group by name.
 func (s *ResourceGroupService) GetByName(ctx context.Context, name string) (*ResourceGroup, error) {
-	groups, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	groups, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/resourcegroup_test.go
+++ b/resourcegroup_test.go
@@ -1,0 +1,100 @@
+package vergeos
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestResourceGroupService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/resource_groups": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []ResourceGroup{
+				{Name: "compute", Type: "vm", Enabled: true},
+				{Name: "storage", Type: "volume", Enabled: true},
+			})
+		},
+	}))
+
+	groups, err := client.ResourceGroups.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+	if groups[0].Name != "compute" {
+		t.Errorf("expected name 'compute', got %q", groups[0].Name)
+	}
+}
+
+func TestResourceGroupService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/resource_groups/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, ResourceGroup{Name: "compute", Type: "vm", Enabled: true, Description: "Compute resources"})
+		},
+	}))
+
+	group, err := client.ResourceGroups.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if group.Name != "compute" {
+		t.Errorf("expected name 'compute', got %q", group.Name)
+	}
+	if group.Description != "Compute resources" {
+		t.Errorf("expected description 'Compute resources', got %q", group.Description)
+	}
+}
+
+func TestResourceGroupService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/resource_groups/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.ResourceGroups.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestResourceGroupService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/resource_groups": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "name eq 'compute'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []ResourceGroup{{Name: "compute", Type: "vm"}})
+		},
+	}))
+
+	group, err := client.ResourceGroups.GetByName(context.Background(), "compute")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if group.Name != "compute" {
+		t.Errorf("expected name 'compute', got %q", group.Name)
+	}
+}
+
+func TestResourceGroupService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/resource_groups": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []ResourceGroup{})
+		},
+	}))
+
+	_, err := client.ResourceGroups.GetByName(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,0 +1,140 @@
+package vergeos
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestSchemaService_GetTableSchema(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/$table": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TableSchema{
+				Fields: map[string]TableField{
+					"name":         {Type: "string", Required: true},
+					"machine_type": {Type: "string", List: map[string]string{"pc": "PC", "q35": "Q35"}},
+				},
+			})
+		},
+	}))
+
+	schema, err := client.Schema.GetTableSchema(context.Background(), "vms")
+	if err != nil {
+		t.Fatalf("GetTableSchema failed: %v", err)
+	}
+	if len(schema.Fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d", len(schema.Fields))
+	}
+	if schema.Fields["name"].Type != "string" {
+		t.Errorf("expected name type 'string', got %q", schema.Fields["name"].Type)
+	}
+	if !schema.Fields["name"].Required {
+		t.Error("expected name to be required")
+	}
+}
+
+func TestSchemaService_GetValidValues(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/$table": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TableSchema{
+				Fields: map[string]TableField{
+					"machine_type": {Type: "string", List: map[string]string{"pc": "Standard PC", "q35": "Q35 Chipset"}},
+				},
+			})
+		},
+	}))
+
+	values, err := client.Schema.GetValidValues(context.Background(), "vms", "machine_type")
+	if err != nil {
+		t.Fatalf("GetValidValues failed: %v", err)
+	}
+	if len(values) != 2 {
+		t.Fatalf("expected 2 values, got %d", len(values))
+	}
+	if values["pc"] != "Standard PC" {
+		t.Errorf("expected 'Standard PC', got %q", values["pc"])
+	}
+}
+
+func TestSchemaService_GetValidValues_FieldNotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/$table": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TableSchema{
+				Fields: map[string]TableField{
+					"name": {Type: "string"},
+				},
+			})
+		},
+	}))
+
+	_, err := client.Schema.GetValidValues(context.Background(), "vms", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent field")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSchemaService_GetValidValues_NoList(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/$table": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TableSchema{
+				Fields: map[string]TableField{
+					"name": {Type: "string"},
+				},
+			})
+		},
+	}))
+
+	values, err := client.Schema.GetValidValues(context.Background(), "vms", "name")
+	if err != nil {
+		t.Fatalf("GetValidValues failed: %v", err)
+	}
+	if len(values) != 0 {
+		t.Errorf("expected empty map, got %d values", len(values))
+	}
+}
+
+func TestSchemaService_GetVMMachineTypes(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/$table": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TableSchema{
+				Fields: map[string]TableField{
+					"machine_type": {Type: "string", List: map[string]string{"pc": "PC", "q35": "Q35"}},
+				},
+			})
+		},
+	}))
+
+	types, err := client.Schema.GetVMMachineTypes(context.Background())
+	if err != nil {
+		t.Fatalf("GetVMMachineTypes failed: %v", err)
+	}
+	if len(types) != 2 {
+		t.Fatalf("expected 2 types, got %d", len(types))
+	}
+}
+
+func TestSchemaService_GetVMOSFamilies(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/$table": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TableSchema{
+				Fields: map[string]TableField{
+					"os_family": {Type: "string", List: map[string]string{"linux": "Linux", "windows": "Windows"}},
+				},
+			})
+		},
+	}))
+
+	families, err := client.Schema.GetVMOSFamilies(context.Background())
+	if err != nil {
+		t.Fatalf("GetVMOSFamilies failed: %v", err)
+	}
+	if len(families) != 2 {
+		t.Fatalf("expected 2 families, got %d", len(families))
+	}
+	if families["linux"] != "Linux" {
+		t.Errorf("expected 'Linux', got %q", families["linux"])
+	}
+}

--- a/settings.go
+++ b/settings.go
@@ -48,7 +48,7 @@ func (s *SettingsService) Get(ctx context.Context, id int) (*Setting, error) {
 
 // GetByKey returns a setting by key name.
 func (s *SettingsService) GetByKey(ctx context.Context, key string) (*Setting, error) {
-	settings, err := s.List(ctx, WithFilter(fmt.Sprintf("key eq '%s'", key)))
+	settings, err := s.List(ctx, WithFilter(fmt.Sprintf("key eq '%s'", escapeFilterValue(key))))
 	if err != nil {
 		return nil, err
 	}

--- a/settings_test.go
+++ b/settings_test.go
@@ -1,0 +1,136 @@
+package vergeos
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestSettingsService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/settings": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Setting{
+				{Key: "cloud_name", Value: "mycloud"},
+				{Key: "timezone", Value: "UTC"},
+			})
+		},
+	}))
+
+	settings, err := client.Settings.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(settings) != 2 {
+		t.Fatalf("expected 2 settings, got %d", len(settings))
+	}
+	if settings[0].Key != "cloud_name" {
+		t.Errorf("expected key 'cloud_name', got %q", settings[0].Key)
+	}
+}
+
+func TestSettingsService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/settings/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Setting{Key: "cloud_name", Value: "mycloud", Description: "The cloud name"})
+		},
+	}))
+
+	setting, err := client.Settings.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if setting.Key != "cloud_name" {
+		t.Errorf("expected key 'cloud_name', got %q", setting.Key)
+	}
+	if setting.Value != "mycloud" {
+		t.Errorf("expected value 'mycloud', got %q", setting.Value)
+	}
+}
+
+func TestSettingsService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/settings/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Settings.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSettingsService_GetByKey(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/settings": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "key eq 'cloud_name'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Setting{{Key: "cloud_name", Value: "mycloud"}})
+		},
+	}))
+
+	setting, err := client.Settings.GetByKey(context.Background(), "cloud_name")
+	if err != nil {
+		t.Fatalf("GetByKey failed: %v", err)
+	}
+	if setting.Value != "mycloud" {
+		t.Errorf("expected value 'mycloud', got %q", setting.Value)
+	}
+}
+
+func TestSettingsService_GetByKey_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/settings": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Setting{})
+		},
+	}))
+
+	_, err := client.Settings.GetByKey(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSettingsService_GetValue(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/settings": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Setting{{Key: "timezone", Value: "America/Denver"}})
+		},
+	}))
+
+	val, err := client.Settings.GetValue(context.Background(), "timezone")
+	if err != nil {
+		t.Fatalf("GetValue failed: %v", err)
+	}
+	if val != "America/Denver" {
+		t.Errorf("expected 'America/Denver', got %q", val)
+	}
+}
+
+func TestSettingsService_GetCloudName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/settings": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "key eq 'cloud_name'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Setting{{Key: "cloud_name", Value: "prod-cloud"}})
+		},
+	}))
+
+	name, err := client.Settings.GetCloudName(context.Background())
+	if err != nil {
+		t.Fatalf("GetCloudName failed: %v", err)
+	}
+	if name != "prod-cloud" {
+		t.Errorf("expected 'prod-cloud', got %q", name)
+	}
+}

--- a/site.go
+++ b/site.go
@@ -38,7 +38,7 @@ func (s *SiteService) Get(ctx context.Context, id int) (*Site, error) {
 	endpoint := fmt.Sprintf("/sites/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &site); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Site", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Site", ID: id}
 		}
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (s *SiteService) Update(ctx context.Context, id int, req *SiteUpdateRequest
 	endpoint := fmt.Sprintf("/sites/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Site", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Site", ID: id}
 		}
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (s *SiteService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/sites/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "Site", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "Site", ID: id}
 		}
 		return err
 	}
@@ -224,7 +224,7 @@ func (s *SiteSyncIncomingService) Get(ctx context.Context, id int) (*SiteSyncInc
 	endpoint := fmt.Sprintf("/site_syncs_incoming/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &sync); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SiteSyncIncoming", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SiteSyncIncoming", ID: id}
 		}
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func (s *SiteSyncIncomingService) Update(ctx context.Context, id int, req *SiteS
 	endpoint := fmt.Sprintf("/site_syncs_incoming/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SiteSyncIncoming", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SiteSyncIncoming", ID: id}
 		}
 		return nil, err
 	}
@@ -305,7 +305,7 @@ func (s *SiteSyncIncomingService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/site_syncs_incoming/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "SiteSyncIncoming", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "SiteSyncIncoming", ID: id}
 		}
 		return err
 	}
@@ -376,7 +376,7 @@ func (s *SiteSyncOutgoingService) Get(ctx context.Context, id int) (*SiteSyncOut
 	endpoint := fmt.Sprintf("/site_syncs_outgoing/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &sync); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SiteSyncOutgoing", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SiteSyncOutgoing", ID: id}
 		}
 		return nil, err
 	}
@@ -432,7 +432,7 @@ func (s *SiteSyncOutgoingService) Update(ctx context.Context, id int, req *SiteS
 	endpoint := fmt.Sprintf("/site_syncs_outgoing/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SiteSyncOutgoing", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SiteSyncOutgoing", ID: id}
 		}
 		return nil, err
 	}
@@ -445,7 +445,7 @@ func (s *SiteSyncOutgoingService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/site_syncs_outgoing/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "SiteSyncOutgoing", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "SiteSyncOutgoing", ID: id}
 		}
 		return err
 	}
@@ -560,7 +560,7 @@ func (s *SiteSyncProfilePeriodService) Get(ctx context.Context, id int) (*SiteSy
 	endpoint := fmt.Sprintf("/site_syncs_outgoing_profile_periods/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &period); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SiteSyncProfilePeriod", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SiteSyncProfilePeriod", ID: id}
 		}
 		return nil, err
 	}
@@ -605,7 +605,7 @@ func (s *SiteSyncProfilePeriodService) Update(ctx context.Context, id int, req *
 	endpoint := fmt.Sprintf("/site_syncs_outgoing_profile_periods/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SiteSyncProfilePeriod", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SiteSyncProfilePeriod", ID: id}
 		}
 		return nil, err
 	}
@@ -618,7 +618,7 @@ func (s *SiteSyncProfilePeriodService) Delete(ctx context.Context, id int) error
 	endpoint := fmt.Sprintf("/site_syncs_outgoing_profile_periods/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "SiteSyncProfilePeriod", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "SiteSyncProfilePeriod", ID: id}
 		}
 		return err
 	}

--- a/site.go
+++ b/site.go
@@ -48,7 +48,7 @@ func (s *SiteService) Get(ctx context.Context, id int) (*Site, error) {
 
 // GetByName returns a site by name.
 func (s *SiteService) GetByName(ctx context.Context, name string) (*Site, error) {
-	sites, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	sites, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (s *SiteService) GetByName(ctx context.Context, name string) (*Site, error)
 
 // GetBySiteID returns a site by its 40-character SHA1 site ID.
 func (s *SiteService) GetBySiteID(ctx context.Context, siteID string) (*Site, error) {
-	sites, err := s.List(ctx, WithFilter(fmt.Sprintf("id eq '%s'", siteID)))
+	sites, err := s.List(ctx, WithFilter(fmt.Sprintf("id eq '%s'", escapeFilterValue(siteID))))
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +235,7 @@ func (s *SiteSyncIncomingService) Get(ctx context.Context, id int) (*SiteSyncInc
 // GetByName returns an incoming sync by name within a site.
 func (s *SiteSyncIncomingService) GetByName(ctx context.Context, siteID int, name string) (*SiteSyncIncoming, error) {
 	syncs, err := s.List(ctx,
-		WithFilter(fmt.Sprintf("site eq %d and name eq '%s'", siteID, name)),
+		WithFilter(fmt.Sprintf("site eq %d and name eq '%s'", siteID, escapeFilterValue(name))),
 	)
 	if err != nil {
 		return nil, err
@@ -248,7 +248,7 @@ func (s *SiteSyncIncomingService) GetByName(ctx context.Context, siteID int, nam
 
 // GetBySyncID returns an incoming sync by its 40-character sync ID.
 func (s *SiteSyncIncomingService) GetBySyncID(ctx context.Context, syncID string) (*SiteSyncIncoming, error) {
-	syncs, err := s.List(ctx, WithFilter(fmt.Sprintf("sync_id eq '%s'", syncID)))
+	syncs, err := s.List(ctx, WithFilter(fmt.Sprintf("sync_id eq '%s'", escapeFilterValue(syncID))))
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +387,7 @@ func (s *SiteSyncOutgoingService) Get(ctx context.Context, id int) (*SiteSyncOut
 // GetByName returns an outgoing sync by name within a site.
 func (s *SiteSyncOutgoingService) GetByName(ctx context.Context, siteID int, name string) (*SiteSyncOutgoing, error) {
 	syncs, err := s.List(ctx,
-		WithFilter(fmt.Sprintf("site eq %d and name eq '%s'", siteID, name)),
+		WithFilter(fmt.Sprintf("site eq %d and name eq '%s'", siteID, escapeFilterValue(name))),
 	)
 	if err != nil {
 		return nil, err

--- a/site.go
+++ b/site.go
@@ -484,7 +484,7 @@ func (s *SiteSyncOutgoingService) Throttle(ctx context.Context, id int, throttle
 	action := siteSyncOutgoingAction{
 		SiteSyncOutgoing: id,
 		Action:           "throttle",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"throttle": throttle,
 		},
 	}

--- a/site_test.go
+++ b/site_test.go
@@ -1,0 +1,1190 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// SiteService
+// ---------------------------------------------------------------------------
+
+func TestSiteService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/sites": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Site{
+				{Key: 1, Name: "site-alpha", Status: "idle"},
+				{Key: 2, Name: "site-beta", Status: "syncing"},
+			})
+		},
+	}))
+
+	sites, err := client.Sites.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(sites) != 2 {
+		t.Fatalf("expected 2 sites, got %d", len(sites))
+	}
+	if sites[0].Name != "site-alpha" {
+		t.Errorf("expected name 'site-alpha', got %q", sites[0].Name)
+	}
+}
+
+func TestSiteService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/sites/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Site{Key: 1, Name: "site-alpha", URL: "https://remote.example.com"})
+		},
+	}))
+
+	site, err := client.Sites.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if site.Name != "site-alpha" {
+		t.Errorf("expected name 'site-alpha', got %q", site.Name)
+	}
+	if site.URL != "https://remote.example.com" {
+		t.Errorf("expected URL 'https://remote.example.com', got %q", site.URL)
+	}
+}
+
+func TestSiteService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/sites/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Sites.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/sites": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Site{{Key: 1, Name: "site-alpha"}})
+		},
+		"GET /api/v4/sites/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Site{Key: 1, Name: "site-alpha", URL: "https://remote.example.com"})
+		},
+	}))
+
+	site, err := client.Sites.GetByName(context.Background(), "site-alpha")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if site.Name != "site-alpha" {
+		t.Errorf("expected name 'site-alpha', got %q", site.Name)
+	}
+}
+
+func TestSiteService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/sites": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Site{})
+		},
+	}))
+
+	_, err := client.Sites.GetByName(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteService_GetBySiteID(t *testing.T) {
+	siteID := "abcdef1234567890abcdef1234567890abcdef12"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/sites": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Site{{Key: 1, ID: siteID}})
+		},
+		"GET /api/v4/sites/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Site{Key: 1, ID: siteID, Name: "site-alpha"})
+		},
+	}))
+
+	site, err := client.Sites.GetBySiteID(context.Background(), siteID)
+	if err != nil {
+		t.Fatalf("GetBySiteID failed: %v", err)
+	}
+	if site.ID != siteID {
+		t.Errorf("expected ID %q, got %q", siteID, site.ID)
+	}
+}
+
+func TestSiteService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/sites": func(w http.ResponseWriter, r *http.Request) {
+			var req SiteCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.URL == "" {
+				t.Error("expected url in request body")
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+		},
+		"GET /api/v4/sites/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Site{Key: 1, Name: "new-site", URL: "https://remote.example.com"})
+		},
+	}))
+
+	site, err := client.Sites.Create(context.Background(), &SiteCreateRequest{
+		Name: "new-site",
+		URL:  "https://remote.example.com",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if site.Name != "new-site" {
+		t.Errorf("expected name 'new-site', got %q", site.Name)
+	}
+}
+
+func TestSiteService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Sites.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteService_Create_MissingURL(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Sites.Create(context.Background(), &SiteCreateRequest{Name: "test"})
+	if err == nil {
+		t.Fatal("expected error for missing url")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteService_Update(t *testing.T) {
+	newName := "updated-site"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/sites/1": func(w http.ResponseWriter, r *http.Request) {
+			var req SiteUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/sites/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Site{Key: 1, Name: newName})
+		},
+	}))
+
+	site, err := client.Sites.Update(context.Background(), 1, &SiteUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if site.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, site.Name)
+	}
+}
+
+func TestSiteService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Sites.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/sites/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Sites.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestSiteService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/sites/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.Sites.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteService_Refresh(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/site_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "refresh" {
+				t.Errorf("expected action 'refresh', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Sites.Refresh(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Refresh failed: %v", err)
+	}
+}
+
+func TestSiteService_RefreshSettings(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/site_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "refresh_settings" {
+				t.Errorf("expected action 'refresh_settings', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Sites.RefreshSettings(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("RefreshSettings failed: %v", err)
+	}
+}
+
+func TestSiteService_Reauthenticate(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/site_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "reauthenticate" {
+				t.Errorf("expected action 'reauthenticate', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Sites.Reauthenticate(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Reauthenticate failed: %v", err)
+	}
+}
+
+func TestSiteService_RunUpdates(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/site_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "run_updates" {
+				t.Errorf("expected action 'run_updates', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Sites.RunUpdates(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("RunUpdates failed: %v", err)
+	}
+}
+
+func TestSiteService_ClearSyncedLogs(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/site_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "clear_synced_logs" {
+				t.Errorf("expected action 'clear_synced_logs', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Sites.ClearSyncedLogs(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ClearSyncedLogs failed: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SiteSyncIncomingService
+// ---------------------------------------------------------------------------
+
+func TestSiteSyncIncomingService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_incoming": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []SiteSyncIncoming{
+				{Key: 1, Name: "inc-sync-1", Site: 10},
+				{Key: 2, Name: "inc-sync-2", Site: 10},
+			})
+		},
+	}))
+
+	syncs, err := client.SiteSyncsIncoming.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(syncs) != 2 {
+		t.Fatalf("expected 2 syncs, got %d", len(syncs))
+	}
+}
+
+func TestSiteSyncIncomingService_ListBySite(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_incoming": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter for site")
+			}
+			jsonResponse(w, 200, []SiteSyncIncoming{{Key: 1, Site: 10}})
+		},
+	}))
+
+	syncs, err := client.SiteSyncsIncoming.ListBySite(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListBySite failed: %v", err)
+	}
+	if len(syncs) != 1 {
+		t.Fatalf("expected 1 sync, got %d", len(syncs))
+	}
+}
+
+func TestSiteSyncIncomingService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_incoming/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SiteSyncIncoming{Key: 1, Name: "inc-sync-1", Site: 10})
+		},
+	}))
+
+	sync, err := client.SiteSyncsIncoming.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if sync.Name != "inc-sync-1" {
+		t.Errorf("expected name 'inc-sync-1', got %q", sync.Name)
+	}
+}
+
+func TestSiteSyncIncomingService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_incoming/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.SiteSyncsIncoming.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncIncomingService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_incoming": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []SiteSyncIncoming{{Key: 1, Name: "inc-sync-1", Site: 10}})
+		},
+		"GET /api/v4/site_syncs_incoming/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SiteSyncIncoming{Key: 1, Name: "inc-sync-1", Site: 10})
+		},
+	}))
+
+	sync, err := client.SiteSyncsIncoming.GetByName(context.Background(), 10, "inc-sync-1")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if sync.Name != "inc-sync-1" {
+		t.Errorf("expected name 'inc-sync-1', got %q", sync.Name)
+	}
+}
+
+func TestSiteSyncIncomingService_GetBySyncID(t *testing.T) {
+	syncID := "abcdef1234567890abcdef1234567890abcdef12"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_incoming": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []SiteSyncIncoming{{Key: 1, SyncID: syncID}})
+		},
+		"GET /api/v4/site_syncs_incoming/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SiteSyncIncoming{Key: 1, SyncID: syncID, Name: "inc-sync-1"})
+		},
+	}))
+
+	sync, err := client.SiteSyncsIncoming.GetBySyncID(context.Background(), syncID)
+	if err != nil {
+		t.Fatalf("GetBySyncID failed: %v", err)
+	}
+	if sync.SyncID != syncID {
+		t.Errorf("expected sync_id %q, got %q", syncID, sync.SyncID)
+	}
+}
+
+func TestSiteSyncIncomingService_GetBySyncID_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_incoming": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []SiteSyncIncoming{})
+		},
+	}))
+
+	_, err := client.SiteSyncsIncoming.GetBySyncID(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncIncomingService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/site_syncs_incoming": func(w http.ResponseWriter, r *http.Request) {
+			var req SiteSyncIncomingCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Site != 10 {
+				t.Errorf("expected site 10, got %d", req.Site)
+			}
+			if req.Name != "new-inc-sync" {
+				t.Errorf("expected name 'new-inc-sync', got %q", req.Name)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+		},
+		"GET /api/v4/site_syncs_incoming/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SiteSyncIncoming{Key: 1, Name: "new-inc-sync", Site: 10})
+		},
+	}))
+
+	sync, err := client.SiteSyncsIncoming.Create(context.Background(), &SiteSyncIncomingCreateRequest{
+		Site: 10,
+		Name: "new-inc-sync",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if sync.Name != "new-inc-sync" {
+		t.Errorf("expected name 'new-inc-sync', got %q", sync.Name)
+	}
+}
+
+func TestSiteSyncIncomingService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SiteSyncsIncoming.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncIncomingService_Create_MissingSite(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SiteSyncsIncoming.Create(context.Background(), &SiteSyncIncomingCreateRequest{
+		Name: "test",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing site")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncIncomingService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SiteSyncsIncoming.Create(context.Background(), &SiteSyncIncomingCreateRequest{
+		Site: 10,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncIncomingService_Update(t *testing.T) {
+	newName := "updated-inc-sync"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/site_syncs_incoming/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/site_syncs_incoming/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SiteSyncIncoming{Key: 1, Name: newName})
+		},
+	}))
+
+	sync, err := client.SiteSyncsIncoming.Update(context.Background(), 1, &SiteSyncIncomingUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if sync.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, sync.Name)
+	}
+}
+
+func TestSiteSyncIncomingService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SiteSyncsIncoming.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncIncomingService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/site_syncs_incoming/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.SiteSyncsIncoming.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestSiteSyncIncomingService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/site_syncs_incoming/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.SiteSyncsIncoming.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncIncomingService_Enable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/site_syncs_incoming_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "enable" {
+				t.Errorf("expected action 'enable', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.SiteSyncsIncoming.Enable(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Enable failed: %v", err)
+	}
+}
+
+func TestSiteSyncIncomingService_Disable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/site_syncs_incoming_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "disable" {
+				t.Errorf("expected action 'disable', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.SiteSyncsIncoming.Disable(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Disable failed: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SiteSyncOutgoingService
+// ---------------------------------------------------------------------------
+
+func TestSiteSyncOutgoingService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_outgoing": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []SiteSyncOutgoing{
+				{Key: 1, Name: "out-sync-1", Site: 10},
+				{Key: 2, Name: "out-sync-2", Site: 10},
+			})
+		},
+	}))
+
+	syncs, err := client.SiteSyncsOutgoing.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(syncs) != 2 {
+		t.Fatalf("expected 2 syncs, got %d", len(syncs))
+	}
+}
+
+func TestSiteSyncOutgoingService_ListBySite(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_outgoing": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter for site")
+			}
+			jsonResponse(w, 200, []SiteSyncOutgoing{{Key: 1, Site: 10}})
+		},
+	}))
+
+	syncs, err := client.SiteSyncsOutgoing.ListBySite(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListBySite failed: %v", err)
+	}
+	if len(syncs) != 1 {
+		t.Fatalf("expected 1 sync, got %d", len(syncs))
+	}
+}
+
+func TestSiteSyncOutgoingService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_outgoing/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SiteSyncOutgoing{Key: 1, Name: "out-sync-1", Site: 10})
+		},
+	}))
+
+	sync, err := client.SiteSyncsOutgoing.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if sync.Name != "out-sync-1" {
+		t.Errorf("expected name 'out-sync-1', got %q", sync.Name)
+	}
+}
+
+func TestSiteSyncOutgoingService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_outgoing/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.SiteSyncsOutgoing.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncOutgoingService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_outgoing": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []SiteSyncOutgoing{{Key: 1, Name: "out-sync-1", Site: 10}})
+		},
+		"GET /api/v4/site_syncs_outgoing/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SiteSyncOutgoing{Key: 1, Name: "out-sync-1", Site: 10})
+		},
+	}))
+
+	sync, err := client.SiteSyncsOutgoing.GetByName(context.Background(), 10, "out-sync-1")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if sync.Name != "out-sync-1" {
+		t.Errorf("expected name 'out-sync-1', got %q", sync.Name)
+	}
+}
+
+func TestSiteSyncOutgoingService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_outgoing": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []SiteSyncOutgoing{})
+		},
+	}))
+
+	_, err := client.SiteSyncsOutgoing.GetByName(context.Background(), 10, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncOutgoingService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/site_syncs_outgoing": func(w http.ResponseWriter, r *http.Request) {
+			var req SiteSyncOutgoingCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Site != 10 {
+				t.Errorf("expected site 10, got %d", req.Site)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+		},
+		"GET /api/v4/site_syncs_outgoing/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SiteSyncOutgoing{Key: 1, Name: "new-out-sync", Site: 10})
+		},
+	}))
+
+	sync, err := client.SiteSyncsOutgoing.Create(context.Background(), &SiteSyncOutgoingCreateRequest{
+		Site: 10,
+		Name: "new-out-sync",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if sync.Name != "new-out-sync" {
+		t.Errorf("expected name 'new-out-sync', got %q", sync.Name)
+	}
+}
+
+func TestSiteSyncOutgoingService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SiteSyncsOutgoing.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncOutgoingService_Create_MissingSite(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SiteSyncsOutgoing.Create(context.Background(), &SiteSyncOutgoingCreateRequest{
+		Name: "test",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing site")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncOutgoingService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SiteSyncsOutgoing.Create(context.Background(), &SiteSyncOutgoingCreateRequest{
+		Site: 10,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncOutgoingService_Update(t *testing.T) {
+	newName := "updated-out-sync"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/site_syncs_outgoing/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/site_syncs_outgoing/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SiteSyncOutgoing{Key: 1, Name: newName})
+		},
+	}))
+
+	sync, err := client.SiteSyncsOutgoing.Update(context.Background(), 1, &SiteSyncOutgoingUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if sync.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, sync.Name)
+	}
+}
+
+func TestSiteSyncOutgoingService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SiteSyncsOutgoing.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncOutgoingService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/site_syncs_outgoing/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.SiteSyncsOutgoing.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestSiteSyncOutgoingService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/site_syncs_outgoing/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.SiteSyncsOutgoing.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncOutgoingService_Enable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/site_syncs_outgoing_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "enable" {
+				t.Errorf("expected action 'enable', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.SiteSyncsOutgoing.Enable(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Enable failed: %v", err)
+	}
+}
+
+func TestSiteSyncOutgoingService_Disable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/site_syncs_outgoing_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "disable" {
+				t.Errorf("expected action 'disable', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.SiteSyncsOutgoing.Disable(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Disable failed: %v", err)
+	}
+}
+
+func TestSiteSyncOutgoingService_Throttle(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/site_syncs_outgoing_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "throttle" {
+				t.Errorf("expected action 'throttle', got %v", body["action"])
+			}
+			params, ok := body["params"].(map[string]interface{})
+			if !ok {
+				t.Fatal("expected params in body")
+			}
+			if params["throttle"] != float64(1024) {
+				t.Errorf("expected throttle 1024, got %v", params["throttle"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.SiteSyncsOutgoing.Throttle(context.Background(), 1, 1024)
+	if err != nil {
+		t.Fatalf("Throttle failed: %v", err)
+	}
+}
+
+func TestSiteSyncOutgoingService_DisableThrottle(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/site_syncs_outgoing_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "throttle_disable" {
+				t.Errorf("expected action 'throttle_disable', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.SiteSyncsOutgoing.DisableThrottle(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("DisableThrottle failed: %v", err)
+	}
+}
+
+func TestSiteSyncOutgoingService_RefreshSnapshots(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/site_syncs_outgoing_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "refresh" {
+				t.Errorf("expected action 'refresh', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.SiteSyncsOutgoing.RefreshSnapshots(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("RefreshSnapshots failed: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SiteSyncProfilePeriodService
+// ---------------------------------------------------------------------------
+
+func TestSiteSyncProfilePeriodService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_outgoing_profile_periods": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []SiteSyncProfilePeriod{
+				{Key: 1, SiteSyncsOutgoing: 5, Retention: 86400},
+				{Key: 2, SiteSyncsOutgoing: 5, Retention: 604800},
+			})
+		},
+	}))
+
+	periods, err := client.SiteSyncProfilePeriods.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(periods) != 2 {
+		t.Fatalf("expected 2 periods, got %d", len(periods))
+	}
+}
+
+func TestSiteSyncProfilePeriodService_ListByOutgoingSync(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_outgoing_profile_periods": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter for outgoing sync")
+			}
+			jsonResponse(w, 200, []SiteSyncProfilePeriod{{Key: 1, SiteSyncsOutgoing: 5}})
+		},
+	}))
+
+	periods, err := client.SiteSyncProfilePeriods.ListByOutgoingSync(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("ListByOutgoingSync failed: %v", err)
+	}
+	if len(periods) != 1 {
+		t.Fatalf("expected 1 period, got %d", len(periods))
+	}
+}
+
+func TestSiteSyncProfilePeriodService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_outgoing_profile_periods/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SiteSyncProfilePeriod{Key: 1, Retention: 86400})
+		},
+	}))
+
+	period, err := client.SiteSyncProfilePeriods.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if period.Retention != 86400 {
+		t.Errorf("expected retention 86400, got %d", period.Retention)
+	}
+}
+
+func TestSiteSyncProfilePeriodService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/site_syncs_outgoing_profile_periods/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.SiteSyncProfilePeriods.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncProfilePeriodService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/site_syncs_outgoing_profile_periods": func(w http.ResponseWriter, r *http.Request) {
+			var req SiteSyncProfilePeriodCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.SiteSyncsOutgoing != 5 {
+				t.Errorf("expected outgoing sync 5, got %d", req.SiteSyncsOutgoing)
+			}
+			if req.ProfilePeriod != 3 {
+				t.Errorf("expected profile period 3, got %d", req.ProfilePeriod)
+			}
+			if req.Retention != 86400 {
+				t.Errorf("expected retention 86400, got %d", req.Retention)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+		},
+		"GET /api/v4/site_syncs_outgoing_profile_periods/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SiteSyncProfilePeriod{Key: 1, SiteSyncsOutgoing: 5, ProfilePeriod: 3, Retention: 86400})
+		},
+	}))
+
+	period, err := client.SiteSyncProfilePeriods.Create(context.Background(), &SiteSyncProfilePeriodCreateRequest{
+		SiteSyncsOutgoing: 5,
+		ProfilePeriod:     3,
+		Retention:         86400,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if period.Retention != 86400 {
+		t.Errorf("expected retention 86400, got %d", period.Retention)
+	}
+}
+
+func TestSiteSyncProfilePeriodService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SiteSyncProfilePeriods.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncProfilePeriodService_Create_MissingOutgoingSync(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SiteSyncProfilePeriods.Create(context.Background(), &SiteSyncProfilePeriodCreateRequest{
+		ProfilePeriod: 3,
+		Retention:     86400,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing outgoing sync")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncProfilePeriodService_Create_MissingProfilePeriod(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SiteSyncProfilePeriods.Create(context.Background(), &SiteSyncProfilePeriodCreateRequest{
+		SiteSyncsOutgoing: 5,
+		Retention:         86400,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing profile period")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncProfilePeriodService_Create_MissingRetention(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SiteSyncProfilePeriods.Create(context.Background(), &SiteSyncProfilePeriodCreateRequest{
+		SiteSyncsOutgoing: 5,
+		ProfilePeriod:     3,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing retention")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncProfilePeriodService_Update(t *testing.T) {
+	newRetention := 172800
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/site_syncs_outgoing_profile_periods/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/site_syncs_outgoing_profile_periods/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SiteSyncProfilePeriod{Key: 1, Retention: newRetention})
+		},
+	}))
+
+	period, err := client.SiteSyncProfilePeriods.Update(context.Background(), 1, &SiteSyncProfilePeriodUpdateRequest{Retention: &newRetention})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if period.Retention != newRetention {
+		t.Errorf("expected retention %d, got %d", newRetention, period.Retention)
+	}
+}
+
+func TestSiteSyncProfilePeriodService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SiteSyncProfilePeriods.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSiteSyncProfilePeriodService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/site_syncs_outgoing_profile_periods/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.SiteSyncProfilePeriods.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestSiteSyncProfilePeriodService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/site_syncs_outgoing_profile_periods/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.SiteSyncProfilePeriods.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/site_test.go
+++ b/site_test.go
@@ -131,7 +131,7 @@ func TestSiteService_Create(t *testing.T) {
 			if req.URL == "" {
 				t.Error("expected url in request body")
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/sites/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, Site{Key: 1, Name: "new-site", URL: "https://remote.example.com"})
@@ -243,7 +243,7 @@ func TestSiteService_Delete_NotFound(t *testing.T) {
 func TestSiteService_Refresh(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "refresh" {
 				t.Errorf("expected action 'refresh', got %v", body["action"])
@@ -261,7 +261,7 @@ func TestSiteService_Refresh(t *testing.T) {
 func TestSiteService_RefreshSettings(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "refresh_settings" {
 				t.Errorf("expected action 'refresh_settings', got %v", body["action"])
@@ -279,7 +279,7 @@ func TestSiteService_RefreshSettings(t *testing.T) {
 func TestSiteService_Reauthenticate(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "reauthenticate" {
 				t.Errorf("expected action 'reauthenticate', got %v", body["action"])
@@ -297,7 +297,7 @@ func TestSiteService_Reauthenticate(t *testing.T) {
 func TestSiteService_RunUpdates(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "run_updates" {
 				t.Errorf("expected action 'run_updates', got %v", body["action"])
@@ -315,7 +315,7 @@ func TestSiteService_RunUpdates(t *testing.T) {
 func TestSiteService_ClearSyncedLogs(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "clear_synced_logs" {
 				t.Errorf("expected action 'clear_synced_logs', got %v", body["action"])
@@ -471,7 +471,7 @@ func TestSiteSyncIncomingService_Create(t *testing.T) {
 			if req.Name != "new-inc-sync" {
 				t.Errorf("expected name 'new-inc-sync', got %q", req.Name)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/site_syncs_incoming/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, SiteSyncIncoming{Key: 1, Name: "new-inc-sync", Site: 10})
@@ -594,7 +594,7 @@ func TestSiteSyncIncomingService_Delete_NotFound(t *testing.T) {
 func TestSiteSyncIncomingService_Enable(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_syncs_incoming_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "enable" {
 				t.Errorf("expected action 'enable', got %v", body["action"])
@@ -612,7 +612,7 @@ func TestSiteSyncIncomingService_Enable(t *testing.T) {
 func TestSiteSyncIncomingService_Disable(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_syncs_incoming_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "disable" {
 				t.Errorf("expected action 'disable', got %v", body["action"])
@@ -745,7 +745,7 @@ func TestSiteSyncOutgoingService_Create(t *testing.T) {
 			if req.Site != 10 {
 				t.Errorf("expected site 10, got %d", req.Site)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/site_syncs_outgoing/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, SiteSyncOutgoing{Key: 1, Name: "new-out-sync", Site: 10})
@@ -868,7 +868,7 @@ func TestSiteSyncOutgoingService_Delete_NotFound(t *testing.T) {
 func TestSiteSyncOutgoingService_Enable(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_syncs_outgoing_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "enable" {
 				t.Errorf("expected action 'enable', got %v", body["action"])
@@ -886,7 +886,7 @@ func TestSiteSyncOutgoingService_Enable(t *testing.T) {
 func TestSiteSyncOutgoingService_Disable(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_syncs_outgoing_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "disable" {
 				t.Errorf("expected action 'disable', got %v", body["action"])
@@ -904,12 +904,12 @@ func TestSiteSyncOutgoingService_Disable(t *testing.T) {
 func TestSiteSyncOutgoingService_Throttle(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_syncs_outgoing_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "throttle" {
 				t.Errorf("expected action 'throttle', got %v", body["action"])
 			}
-			params, ok := body["params"].(map[string]interface{})
+			params, ok := body["params"].(map[string]any)
 			if !ok {
 				t.Fatal("expected params in body")
 			}
@@ -929,7 +929,7 @@ func TestSiteSyncOutgoingService_Throttle(t *testing.T) {
 func TestSiteSyncOutgoingService_DisableThrottle(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_syncs_outgoing_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "throttle_disable" {
 				t.Errorf("expected action 'throttle_disable', got %v", body["action"])
@@ -947,7 +947,7 @@ func TestSiteSyncOutgoingService_DisableThrottle(t *testing.T) {
 func TestSiteSyncOutgoingService_RefreshSnapshots(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/site_syncs_outgoing_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "refresh" {
 				t.Errorf("expected action 'refresh', got %v", body["action"])
@@ -1051,7 +1051,7 @@ func TestSiteSyncProfilePeriodService_Create(t *testing.T) {
 			if req.Retention != 86400 {
 				t.Errorf("expected retention 86400, got %d", req.Retention)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/site_syncs_outgoing_profile_periods/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, SiteSyncProfilePeriod{Key: 1, SiteSyncsOutgoing: 5, ProfilePeriod: 3, Retention: 86400})

--- a/snapshot_profile.go
+++ b/snapshot_profile.go
@@ -39,7 +39,7 @@ func (s *SnapshotProfileService) Get(ctx context.Context, id int) (*SnapshotProf
 	endpoint := fmt.Sprintf("/snapshot_profiles/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &profile); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SnapshotProfile", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SnapshotProfile", ID: id}
 		}
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (s *SnapshotProfileService) Update(ctx context.Context, id int, req *Snapsh
 	endpoint := fmt.Sprintf("/snapshot_profiles/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SnapshotProfile", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SnapshotProfile", ID: id}
 		}
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (s *SnapshotProfileService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/snapshot_profiles/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "SnapshotProfile", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "SnapshotProfile", ID: id}
 		}
 		return err
 	}
@@ -155,7 +155,7 @@ func (s *SnapshotProfilePeriodService) Get(ctx context.Context, id int) (*Snapsh
 	endpoint := fmt.Sprintf("/snapshot_profile_periods/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &period); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SnapshotProfilePeriod", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SnapshotProfilePeriod", ID: id}
 		}
 		return nil, err
 	}
@@ -215,7 +215,7 @@ func (s *SnapshotProfilePeriodService) Update(ctx context.Context, id int, req *
 	endpoint := fmt.Sprintf("/snapshot_profile_periods/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "SnapshotProfilePeriod", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "SnapshotProfilePeriod", ID: id}
 		}
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (s *SnapshotProfilePeriodService) Delete(ctx context.Context, id int) error
 	endpoint := fmt.Sprintf("/snapshot_profile_periods/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "SnapshotProfilePeriod", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "SnapshotProfilePeriod", ID: id}
 		}
 		return err
 	}

--- a/snapshot_profile.go
+++ b/snapshot_profile.go
@@ -49,7 +49,7 @@ func (s *SnapshotProfileService) Get(ctx context.Context, id int) (*SnapshotProf
 
 // GetByName returns a snapshot profile by name.
 func (s *SnapshotProfileService) GetByName(ctx context.Context, name string) (*SnapshotProfile, error) {
-	profiles, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	profiles, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (s *SnapshotProfilePeriodService) Get(ctx context.Context, id int) (*Snapsh
 
 // GetByName returns a snapshot profile period by name within a specific profile.
 func (s *SnapshotProfilePeriodService) GetByName(ctx context.Context, profileID int, name string) (*SnapshotProfilePeriod, error) {
-	periods, err := s.List(ctx, WithFilter(fmt.Sprintf("profile eq %d and name eq '%s'", profileID, name)))
+	periods, err := s.List(ctx, WithFilter(fmt.Sprintf("profile eq %d and name eq '%s'", profileID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/snapshot_profile_test.go
+++ b/snapshot_profile_test.go
@@ -1,0 +1,521 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// SnapshotProfile tests
+
+func TestSnapshotProfileService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/snapshot_profiles": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []SnapshotProfile{
+				{Key: 1, Name: "default"},
+				{Key: 2, Name: "custom"},
+			})
+		},
+	}))
+
+	profiles, err := client.SnapshotProfiles.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(profiles) != 2 {
+		t.Fatalf("expected 2 profiles, got %d", len(profiles))
+	}
+	if profiles[0].Name != "default" {
+		t.Errorf("expected name 'default', got %q", profiles[0].Name)
+	}
+}
+
+func TestSnapshotProfileService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/snapshot_profiles/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SnapshotProfile{Key: 1, Name: "default", Description: "Default profile"})
+		},
+	}))
+
+	profile, err := client.SnapshotProfiles.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if profile.Name != "default" {
+		t.Errorf("expected name 'default', got %q", profile.Name)
+	}
+	if profile.Description != "Default profile" {
+		t.Errorf("expected description 'Default profile', got %q", profile.Description)
+	}
+}
+
+func TestSnapshotProfileService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/snapshot_profiles/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.SnapshotProfiles.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSnapshotProfileService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/snapshot_profiles": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []SnapshotProfile{{Key: 1, Name: "default"}})
+		},
+		"GET /api/v4/snapshot_profiles/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SnapshotProfile{Key: 1, Name: "default", Description: "Default profile"})
+		},
+	}))
+
+	profile, err := client.SnapshotProfiles.GetByName(context.Background(), "default")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if profile.Name != "default" {
+		t.Errorf("expected name 'default', got %q", profile.Name)
+	}
+}
+
+func TestSnapshotProfileService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/snapshot_profiles": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []SnapshotProfile{})
+		},
+	}))
+
+	_, err := client.SnapshotProfiles.GetByName(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSnapshotProfileService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/snapshot_profiles": func(w http.ResponseWriter, r *http.Request) {
+			var req SnapshotProfileCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "weekly" {
+				t.Errorf("expected name 'weekly', got %q", req.Name)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 3})
+		},
+		"GET /api/v4/snapshot_profiles/3": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SnapshotProfile{Key: 3, Name: "weekly"})
+		},
+	}))
+
+	profile, err := client.SnapshotProfiles.Create(context.Background(), &SnapshotProfileCreateRequest{
+		Name: "weekly",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if profile.Name != "weekly" {
+		t.Errorf("expected name 'weekly', got %q", profile.Name)
+	}
+}
+
+func TestSnapshotProfileService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SnapshotProfiles.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSnapshotProfileService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SnapshotProfiles.Create(context.Background(), &SnapshotProfileCreateRequest{})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSnapshotProfileService_Update(t *testing.T) {
+	newName := "monthly"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/snapshot_profiles/1": func(w http.ResponseWriter, r *http.Request) {
+			var req SnapshotProfileUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/snapshot_profiles/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SnapshotProfile{Key: 1, Name: newName})
+		},
+	}))
+
+	profile, err := client.SnapshotProfiles.Update(context.Background(), 1, &SnapshotProfileUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if profile.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, profile.Name)
+	}
+}
+
+func TestSnapshotProfileService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SnapshotProfiles.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSnapshotProfileService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/snapshot_profiles/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newName := "updated"
+	_, err := client.SnapshotProfiles.Update(context.Background(), 999, &SnapshotProfileUpdateRequest{Name: &newName})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSnapshotProfileService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/snapshot_profiles/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.SnapshotProfiles.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestSnapshotProfileService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/snapshot_profiles/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.SnapshotProfiles.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// SnapshotProfilePeriod tests
+
+func TestSnapshotProfilePeriodService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/snapshot_profile_periods": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []SnapshotProfilePeriod{
+				{Key: 1, Name: "hourly", Frequency: "hourly", Retention: 86400},
+				{Key: 2, Name: "daily", Frequency: "daily", Retention: 604800},
+			})
+		},
+	}))
+
+	periods, err := client.SnapshotProfilePeriods.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(periods) != 2 {
+		t.Fatalf("expected 2 periods, got %d", len(periods))
+	}
+	if periods[0].Name != "hourly" {
+		t.Errorf("expected name 'hourly', got %q", periods[0].Name)
+	}
+}
+
+func TestSnapshotProfilePeriodService_ListByProfile(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/snapshot_profile_periods": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "profile eq 5" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []SnapshotProfilePeriod{{Key: 1, Profile: 5, Name: "hourly"}})
+		},
+	}))
+
+	periods, err := client.SnapshotProfilePeriods.ListByProfile(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("ListByProfile failed: %v", err)
+	}
+	if len(periods) != 1 {
+		t.Fatalf("expected 1 period, got %d", len(periods))
+	}
+}
+
+func TestSnapshotProfilePeriodService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/snapshot_profile_periods/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SnapshotProfilePeriod{Key: 1, Name: "hourly", Frequency: "hourly", Retention: 86400})
+		},
+	}))
+
+	period, err := client.SnapshotProfilePeriods.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if period.Name != "hourly" {
+		t.Errorf("expected name 'hourly', got %q", period.Name)
+	}
+	if period.Retention != 86400 {
+		t.Errorf("expected retention 86400, got %d", period.Retention)
+	}
+}
+
+func TestSnapshotProfilePeriodService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/snapshot_profile_periods/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.SnapshotProfilePeriods.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSnapshotProfilePeriodService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/snapshot_profile_periods": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []SnapshotProfilePeriod{{Key: 1, Profile: 5, Name: "hourly"}})
+		},
+		"GET /api/v4/snapshot_profile_periods/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SnapshotProfilePeriod{Key: 1, Profile: 5, Name: "hourly", Frequency: "hourly"})
+		},
+	}))
+
+	period, err := client.SnapshotProfilePeriods.GetByName(context.Background(), 5, "hourly")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if period.Name != "hourly" {
+		t.Errorf("expected name 'hourly', got %q", period.Name)
+	}
+}
+
+func TestSnapshotProfilePeriodService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/snapshot_profile_periods": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []SnapshotProfilePeriod{})
+		},
+	}))
+
+	_, err := client.SnapshotProfilePeriods.GetByName(context.Background(), 5, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSnapshotProfilePeriodService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/snapshot_profile_periods": func(w http.ResponseWriter, r *http.Request) {
+			var req SnapshotProfilePeriodCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "hourly" {
+				t.Errorf("expected name 'hourly', got %q", req.Name)
+			}
+			if req.Profile != 5 {
+				t.Errorf("expected profile 5, got %d", req.Profile)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 10})
+		},
+		"GET /api/v4/snapshot_profile_periods/10": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SnapshotProfilePeriod{Key: 10, Profile: 5, Name: "hourly", Frequency: "hourly", Retention: 86400})
+		},
+	}))
+
+	period, err := client.SnapshotProfilePeriods.Create(context.Background(), &SnapshotProfilePeriodCreateRequest{
+		Profile:   5,
+		Name:      "hourly",
+		Frequency: "hourly",
+		Retention: 86400,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if period.Name != "hourly" {
+		t.Errorf("expected name 'hourly', got %q", period.Name)
+	}
+}
+
+func TestSnapshotProfilePeriodService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SnapshotProfilePeriods.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSnapshotProfilePeriodService_Create_MissingProfile(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SnapshotProfilePeriods.Create(context.Background(), &SnapshotProfilePeriodCreateRequest{
+		Name:      "hourly",
+		Retention: 86400,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing profile")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSnapshotProfilePeriodService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SnapshotProfilePeriods.Create(context.Background(), &SnapshotProfilePeriodCreateRequest{
+		Profile:   5,
+		Retention: 86400,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSnapshotProfilePeriodService_Create_MissingRetention(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SnapshotProfilePeriods.Create(context.Background(), &SnapshotProfilePeriodCreateRequest{
+		Profile: 5,
+		Name:    "hourly",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing retention")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSnapshotProfilePeriodService_Update(t *testing.T) {
+	newName := "daily"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/snapshot_profile_periods/1": func(w http.ResponseWriter, r *http.Request) {
+			var req SnapshotProfilePeriodUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/snapshot_profile_periods/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SnapshotProfilePeriod{Key: 1, Name: newName})
+		},
+	}))
+
+	period, err := client.SnapshotProfilePeriods.Update(context.Background(), 1, &SnapshotProfilePeriodUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if period.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, period.Name)
+	}
+}
+
+func TestSnapshotProfilePeriodService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.SnapshotProfilePeriods.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestSnapshotProfilePeriodService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/snapshot_profile_periods/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newName := "updated"
+	_, err := client.SnapshotProfilePeriods.Update(context.Background(), 999, &SnapshotProfilePeriodUpdateRequest{Name: &newName})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestSnapshotProfilePeriodService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/snapshot_profile_periods/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.SnapshotProfilePeriods.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestSnapshotProfilePeriodService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/snapshot_profile_periods/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.SnapshotProfilePeriods.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/snapshot_profile_test.go
+++ b/snapshot_profile_test.go
@@ -109,7 +109,7 @@ func TestSnapshotProfileService_Create(t *testing.T) {
 			if req.Name != "weekly" {
 				t.Errorf("expected name 'weekly', got %q", req.Name)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 3})
+			jsonResponse(w, 200, map[string]any{"$key": 3})
 		},
 		"GET /api/v4/snapshot_profiles/3": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, SnapshotProfile{Key: 3, Name: "weekly"})
@@ -359,7 +359,7 @@ func TestSnapshotProfilePeriodService_Create(t *testing.T) {
 			if req.Profile != 5 {
 				t.Errorf("expected profile 5, got %d", req.Profile)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 10})
+			jsonResponse(w, 200, map[string]any{"$key": 10})
 		},
 		"GET /api/v4/snapshot_profile_periods/10": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, SnapshotProfilePeriod{Key: 10, Profile: 5, Name: "hourly", Frequency: "hourly", Retention: 86400})

--- a/system.go
+++ b/system.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 )
 
 // SystemService handles system information operations.
@@ -18,13 +19,18 @@ func (s *SystemService) GetInfo(ctx context.Context) (*SystemInfo, error) {
 	// Build URL for version.json (not under /api/v4/)
 	u := fmt.Sprintf("%s/version.json", s.client.baseURL)
 
-	req, err := s.client.httpClient.Get(u)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("vergeos: failed to create version request: %w", err)
+	}
+
+	resp, err := s.client.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("vergeos: failed to get version info: %w", err)
 	}
-	defer func() { _ = req.Body.Close() }()
+	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(req.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("vergeos: failed to read version response: %w", err)
 	}

--- a/system_test.go
+++ b/system_test.go
@@ -1,0 +1,59 @@
+package vergeos
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestSystemService_GetInfo(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /version.json": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SystemInfo{Name: "v4", Version: "4.13.1", Hash: "abc123"})
+		},
+	}))
+
+	info, err := client.System.GetInfo(context.Background())
+	if err != nil {
+		t.Fatalf("GetInfo failed: %v", err)
+	}
+	if info.Version != "4.13.1" {
+		t.Errorf("expected version '4.13.1', got %q", info.Version)
+	}
+	if info.Name != "v4" {
+		t.Errorf("expected name 'v4', got %q", info.Name)
+	}
+	if info.Hash != "abc123" {
+		t.Errorf("expected hash 'abc123', got %q", info.Hash)
+	}
+}
+
+func TestSystemService_GetVersion(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /version.json": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, SystemInfo{Name: "v4", Version: "4.13.1"})
+		},
+	}))
+
+	version, err := client.System.GetVersion(context.Background())
+	if err != nil {
+		t.Fatalf("GetVersion failed: %v", err)
+	}
+	if version != "4.13.1" {
+		t.Errorf("expected '4.13.1', got %q", version)
+	}
+}
+
+func TestSystemService_GetInfo_ServerError(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /version.json": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(500)
+			w.Write([]byte("not json"))
+		},
+	}))
+
+	_, err := client.System.GetInfo(context.Background())
+	if err == nil {
+		t.Fatal("expected error for invalid response")
+	}
+}

--- a/tag.go
+++ b/tag.go
@@ -49,7 +49,7 @@ func (s *TagService) Get(ctx context.Context, id int) (*Tag, error) {
 
 // GetByName returns a tag by name.
 func (s *TagService) GetByName(ctx context.Context, name string) (*Tag, error) {
-	tags, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	tags, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/tag_category.go
+++ b/tag_category.go
@@ -49,7 +49,7 @@ func (s *TagCategoryService) Get(ctx context.Context, id int) (*TagCategory, err
 
 // GetByName returns a tag category by name.
 func (s *TagCategoryService) GetByName(ctx context.Context, name string) (*TagCategory, error) {
-	categories, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	categories, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/tag_category_test.go
+++ b/tag_category_test.go
@@ -125,7 +125,7 @@ func TestTagCategoryService_Create(t *testing.T) {
 			if req.Name != "environment" {
 				t.Errorf("expected name 'environment', got %q", req.Name)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/tag_categories/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, TagCategory{Key: 1, Name: "environment", TaggableVMs: true})

--- a/tag_category_test.go
+++ b/tag_category_test.go
@@ -1,0 +1,252 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestTagCategoryService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tag_categories": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TagCategory{
+				{Key: 1, Name: "environment", TaggableVMs: true},
+				{Key: 2, Name: "department", TaggableUsers: true},
+			})
+		},
+	}))
+
+	categories, err := client.TagCategories.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(categories) != 2 {
+		t.Fatalf("expected 2 categories, got %d", len(categories))
+	}
+	if categories[0].Name != "environment" {
+		t.Errorf("expected name 'environment', got %q", categories[0].Name)
+	}
+}
+
+func TestTagCategoryService_List_WithFilter(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tag_categories": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter parameter")
+			}
+			jsonResponse(w, 200, []TagCategory{{Key: 1, Name: "environment"}})
+		},
+	}))
+
+	categories, err := client.TagCategories.List(context.Background(), WithFilter("name eq 'environment'"))
+	if err != nil {
+		t.Fatalf("List with filter failed: %v", err)
+	}
+	if len(categories) != 1 {
+		t.Fatalf("expected 1 category, got %d", len(categories))
+	}
+}
+
+func TestTagCategoryService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tag_categories/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TagCategory{Key: 1, Name: "environment", TaggableVMs: true, TaggableVNets: true})
+		},
+	}))
+
+	cat, err := client.TagCategories.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if cat.Name != "environment" {
+		t.Errorf("expected name 'environment', got %q", cat.Name)
+	}
+	if !cat.TaggableVMs {
+		t.Error("expected TaggableVMs to be true")
+	}
+}
+
+func TestTagCategoryService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tag_categories/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.TagCategories.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTagCategoryService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tag_categories": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TagCategory{{Key: 1, Name: "environment"}})
+		},
+	}))
+
+	cat, err := client.TagCategories.GetByName(context.Background(), "environment")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if cat.Name != "environment" {
+		t.Errorf("expected name 'environment', got %q", cat.Name)
+	}
+}
+
+func TestTagCategoryService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tag_categories": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TagCategory{})
+		},
+	}))
+
+	_, err := client.TagCategories.GetByName(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTagCategoryService_Create(t *testing.T) {
+	taggableVMs := true
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tag_categories": func(w http.ResponseWriter, r *http.Request) {
+			var req TagCategoryCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "environment" {
+				t.Errorf("expected name 'environment', got %q", req.Name)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+		},
+		"GET /api/v4/tag_categories/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TagCategory{Key: 1, Name: "environment", TaggableVMs: true})
+		},
+	}))
+
+	cat, err := client.TagCategories.Create(context.Background(), &TagCategoryCreateRequest{
+		Name:        "environment",
+		TaggableVMs: &taggableVMs,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if cat.Name != "environment" {
+		t.Errorf("expected name 'environment', got %q", cat.Name)
+	}
+}
+
+func TestTagCategoryService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TagCategories.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTagCategoryService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TagCategories.Create(context.Background(), &TagCategoryCreateRequest{})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTagCategoryService_Update(t *testing.T) {
+	newName := "env"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tag_categories/1": func(w http.ResponseWriter, r *http.Request) {
+			var req TagCategoryUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/tag_categories/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TagCategory{Key: 1, Name: newName})
+		},
+	}))
+
+	cat, err := client.TagCategories.Update(context.Background(), 1, &TagCategoryUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if cat.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, cat.Name)
+	}
+}
+
+func TestTagCategoryService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TagCategories.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTagCategoryService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tag_categories/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newName := "updated"
+	_, err := client.TagCategories.Update(context.Background(), 999, &TagCategoryUpdateRequest{Name: &newName})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTagCategoryService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/tag_categories/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.TagCategories.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestTagCategoryService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/tag_categories/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.TagCategories.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/tag_test.go
+++ b/tag_test.go
@@ -1,0 +1,203 @@
+package vergeos
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestTagService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tags": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Tag{
+				{Key: 1, Name: "production"},
+				{Key: 2, Name: "staging"},
+			})
+		},
+	}))
+
+	tags, err := client.Tags.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(tags) != 2 {
+		t.Fatalf("expected 2 tags, got %d", len(tags))
+	}
+}
+
+func TestTagService_ListWithOptions(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tags": func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("limit") != "5" {
+				t.Errorf("expected limit=5, got %s", r.URL.Query().Get("limit"))
+			}
+			if r.URL.Query().Get("sort") != "-name" {
+				t.Errorf("expected sort=-name, got %s", r.URL.Query().Get("sort"))
+			}
+			jsonResponse(w, 200, []Tag{{Key: 1, Name: "z-tag"}})
+		},
+	}))
+
+	tags, err := client.Tags.List(context.Background(), WithLimit(5), WithSort("-name"))
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(tags) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(tags))
+	}
+}
+
+func TestTagService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tags/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Tag{Key: 1, Name: "production"})
+		},
+	}))
+
+	tag, err := client.Tags.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if tag.Name != "production" {
+		t.Errorf("expected name 'production', got %q", tag.Name)
+	}
+}
+
+func TestTagService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tags": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Tag{{Key: 1, Name: "production"}})
+		},
+	}))
+
+	tag, err := client.Tags.GetByName(context.Background(), "production")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if tag.Name != "production" {
+		t.Errorf("expected name 'production', got %q", tag.Name)
+	}
+}
+
+func TestTagService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tags": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Tag{})
+		},
+	}))
+
+	_, err := client.Tags.GetByName(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T", err)
+	}
+}
+
+func TestTagService_ListByCategory(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tags": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Tag{{Key: 1, Name: "production"}})
+		},
+	}))
+
+	tags, err := client.Tags.ListByCategory(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("ListByCategory failed: %v", err)
+	}
+	if len(tags) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(tags))
+	}
+}
+
+func TestTagService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tags": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, apiResponse{Key: float64(1)})
+		},
+		"GET /api/v4/tags/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Tag{Key: 1, Name: "new-tag", Category: 5})
+		},
+	}))
+
+	tag, err := client.Tags.Create(context.Background(), &TagCreateRequest{Name: "new-tag", Category: 5})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if tag.Name != "new-tag" {
+		t.Errorf("expected name 'new-tag', got %q", tag.Name)
+	}
+}
+
+func TestTagService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Tags.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestTagService_Create_MissingCategory(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Tags.Create(context.Background(), &TagCreateRequest{Name: "test"})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestTagService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Tags.Create(context.Background(), &TagCreateRequest{Category: 5})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+}
+
+func TestTagService_Update(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tags/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/tags/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Tag{Key: 1, Name: "updated"})
+		},
+	}))
+
+	newName := "updated"
+	tag, err := client.Tags.Update(context.Background(), 1, &TagUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if tag.Name != "updated" {
+		t.Errorf("expected name 'updated', got %q", tag.Name)
+	}
+}
+
+func TestTagService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Tags.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestTagService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/tags/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Tags.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}

--- a/tagmember.go
+++ b/tagmember.go
@@ -115,7 +115,7 @@ func (s *TagMemberService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/tag_members/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "TagMember", ID: id}
 		}
 		return err
 	}

--- a/tagmember.go
+++ b/tagmember.go
@@ -39,7 +39,7 @@ func (s *TagMemberService) ListByTag(ctx context.Context, tagID int) ([]TagMembe
 // ListByMember returns all tag members for a specific object.
 // member should be in format "object_type/object_id" (e.g., "vms/123").
 func (s *TagMemberService) ListByMember(ctx context.Context, member string) ([]TagMember, error) {
-	return s.List(ctx, WithFilter(fmt.Sprintf("member eq '%s'", member)))
+	return s.List(ctx, WithFilter(fmt.Sprintf("member eq '%s'", escapeFilterValue(member))))
 }
 
 // Get returns a single tag member by ID.
@@ -136,7 +136,7 @@ func (s *TagMemberService) Assign(ctx context.Context, tagID int, member string)
 func (s *TagMemberService) Unassign(ctx context.Context, tagID int, member string) error {
 	// Find the tag member
 	members, err := s.List(ctx,
-		WithFilter(fmt.Sprintf("tag eq %d and member eq '%s'", tagID, member)),
+		WithFilter(fmt.Sprintf("tag eq %d and member eq '%s'", tagID, escapeFilterValue(member))),
 	)
 	if err != nil {
 		return err

--- a/tagmember_test.go
+++ b/tagmember_test.go
@@ -112,7 +112,7 @@ func TestTagMemberService_Create(t *testing.T) {
 			if req.Member != "vms/123" {
 				t.Errorf("expected member 'vms/123', got %q", req.Member)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/tag_members/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, TagMember{Key: 1, Tag: 10, Member: "vms/123"})
@@ -294,7 +294,7 @@ func TestTagMemberService_Assign(t *testing.T) {
 			if req.Member != "vms/123" {
 				t.Errorf("expected member 'vms/123', got %q", req.Member)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 5})
+			jsonResponse(w, 200, map[string]any{"$key": 5})
 		},
 		"GET /api/v4/tag_members/5": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, TagMember{Key: 5, Tag: 10, Member: "vms/123"})

--- a/tagmember_test.go
+++ b/tagmember_test.go
@@ -1,0 +1,341 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestTagMemberService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tag_members": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TagMember{
+				{Key: 1, Tag: 10, Member: "vms/123"},
+				{Key: 2, Tag: 10, Member: "vms/456"},
+			})
+		},
+	}))
+
+	members, err := client.TagMembers.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("expected 2 members, got %d", len(members))
+	}
+	if members[0].Member != "vms/123" {
+		t.Errorf("expected member 'vms/123', got %q", members[0].Member)
+	}
+}
+
+func TestTagMemberService_ListByTag(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tag_members": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "tag eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []TagMember{{Key: 1, Tag: 10, Member: "vms/123"}})
+		},
+	}))
+
+	members, err := client.TagMembers.ListByTag(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListByTag failed: %v", err)
+	}
+	if len(members) != 1 {
+		t.Fatalf("expected 1 member, got %d", len(members))
+	}
+}
+
+func TestTagMemberService_ListByMember(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tag_members": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "member eq 'vms/123'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []TagMember{{Key: 1, Tag: 10, Member: "vms/123"}})
+		},
+	}))
+
+	members, err := client.TagMembers.ListByMember(context.Background(), "vms/123")
+	if err != nil {
+		t.Fatalf("ListByMember failed: %v", err)
+	}
+	if len(members) != 1 {
+		t.Fatalf("expected 1 member, got %d", len(members))
+	}
+}
+
+func TestTagMemberService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tag_members/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TagMember{Key: 1, Tag: 10, Member: "vms/123"})
+		},
+	}))
+
+	member, err := client.TagMembers.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if member.Member != "vms/123" {
+		t.Errorf("expected member 'vms/123', got %q", member.Member)
+	}
+}
+
+func TestTagMemberService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tag_members/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.TagMembers.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTagMemberService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tag_members": func(w http.ResponseWriter, r *http.Request) {
+			var req TagMemberCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Tag != 10 {
+				t.Errorf("expected tag 10, got %d", req.Tag)
+			}
+			if req.Member != "vms/123" {
+				t.Errorf("expected member 'vms/123', got %q", req.Member)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+		},
+		"GET /api/v4/tag_members/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TagMember{Key: 1, Tag: 10, Member: "vms/123"})
+		},
+	}))
+
+	member, err := client.TagMembers.Create(context.Background(), &TagMemberCreateRequest{
+		Tag:    10,
+		Member: "vms/123",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if member.Member != "vms/123" {
+		t.Errorf("expected member 'vms/123', got %q", member.Member)
+	}
+}
+
+func TestTagMemberService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TagMembers.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTagMemberService_Create_MissingTag(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TagMembers.Create(context.Background(), &TagMemberCreateRequest{
+		Member: "vms/123",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing tag")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTagMemberService_Create_MissingMember(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TagMembers.Create(context.Background(), &TagMemberCreateRequest{
+		Tag: 10,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing member")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTagMemberService_Create_InvalidMemberFormat(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TagMembers.Create(context.Background(), &TagMemberCreateRequest{
+		Tag:    10,
+		Member: "invalid-no-slash",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid member format")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTagMemberService_Update(t *testing.T) {
+	newMember := "vms/456"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tag_members/1": func(w http.ResponseWriter, r *http.Request) {
+			var req TagMemberUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Member == nil || *req.Member != newMember {
+				t.Errorf("expected member %q, got %v", newMember, req.Member)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/tag_members/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TagMember{Key: 1, Tag: 10, Member: newMember})
+		},
+	}))
+
+	member, err := client.TagMembers.Update(context.Background(), 1, &TagMemberUpdateRequest{Member: &newMember})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if member.Member != newMember {
+		t.Errorf("expected member %q, got %q", newMember, member.Member)
+	}
+}
+
+func TestTagMemberService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TagMembers.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTagMemberService_Update_InvalidMemberFormat(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	badMember := "invalid-no-slash"
+	_, err := client.TagMembers.Update(context.Background(), 1, &TagMemberUpdateRequest{Member: &badMember})
+	if err == nil {
+		t.Fatal("expected error for invalid member format")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTagMemberService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tag_members/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newMember := "vms/456"
+	_, err := client.TagMembers.Update(context.Background(), 999, &TagMemberUpdateRequest{Member: &newMember})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTagMemberService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/tag_members/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.TagMembers.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestTagMemberService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/tag_members/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	// Delete returns nil for not found (already deleted)
+	err := client.TagMembers.Delete(context.Background(), 999)
+	if err != nil {
+		t.Fatalf("Delete should not error for not found, got: %v", err)
+	}
+}
+
+func TestTagMemberService_Assign(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tag_members": func(w http.ResponseWriter, r *http.Request) {
+			var req TagMemberCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Tag != 10 {
+				t.Errorf("expected tag 10, got %d", req.Tag)
+			}
+			if req.Member != "vms/123" {
+				t.Errorf("expected member 'vms/123', got %q", req.Member)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 5})
+		},
+		"GET /api/v4/tag_members/5": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TagMember{Key: 5, Tag: 10, Member: "vms/123"})
+		},
+	}))
+
+	member, err := client.TagMembers.Assign(context.Background(), 10, "vms/123")
+	if err != nil {
+		t.Fatalf("Assign failed: %v", err)
+	}
+	if member.Tag.Int() != 10 {
+		t.Errorf("expected tag 10, got %d", member.Tag.Int())
+	}
+	if member.Member != "vms/123" {
+		t.Errorf("expected member 'vms/123', got %q", member.Member)
+	}
+}
+
+func TestTagMemberService_Unassign(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tag_members": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TagMember{{Key: 5, Tag: 10, Member: "vms/123"}})
+		},
+		"DELETE /api/v4/tag_members/5": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.TagMembers.Unassign(context.Background(), 10, "vms/123")
+	if err != nil {
+		t.Fatalf("Unassign failed: %v", err)
+	}
+}
+
+func TestTagMemberService_Unassign_AlreadyUnassigned(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tag_members": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TagMember{})
+		},
+	}))
+
+	// Should not error when already unassigned
+	err := client.TagMembers.Unassign(context.Background(), 10, "vms/123")
+	if err != nil {
+		t.Fatalf("Unassign should not error when already unassigned, got: %v", err)
+	}
+}

--- a/tagmember_test.go
+++ b/tagmember_test.go
@@ -275,8 +275,11 @@ func TestTagMemberService_Delete_NotFound(t *testing.T) {
 
 	// Delete returns nil for not found (already deleted)
 	err := client.TagMembers.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("Delete should not error for not found, got: %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted tag member")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }
 

--- a/task.go
+++ b/task.go
@@ -40,7 +40,7 @@ func (s *TaskService) ListRunning(ctx context.Context, opts ...ListOption) ([]Ta
 // ListByOwner returns all tasks for a specific owner resource.
 // owner should be a resource path like "vms/123".
 func (s *TaskService) ListByOwner(ctx context.Context, owner string, opts ...ListOption) ([]Task, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("owner eq '%s'", owner))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("owner eq '%s'", escapeFilterValue(owner)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }
@@ -71,7 +71,7 @@ func (s *TaskService) Get(ctx context.Context, id int) (*Task, error) {
 
 // GetByID returns a task by its 40-character SHA1 ID.
 func (s *TaskService) GetByID(ctx context.Context, taskID string) (*Task, error) {
-	tasks, err := s.List(ctx, WithFilter(fmt.Sprintf("id eq '%s'", taskID)))
+	tasks, err := s.List(ctx, WithFilter(fmt.Sprintf("id eq '%s'", escapeFilterValue(taskID))))
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (s *TaskService) GetByID(ctx context.Context, taskID string) (*Task, error)
 
 // GetByName returns a task by name for a specific owner.
 func (s *TaskService) GetByName(ctx context.Context, owner, name string) (*Task, error) {
-	tasks, err := s.List(ctx, WithFilter(fmt.Sprintf("owner eq '%s' and name eq '%s'", owner, name)))
+	tasks, err := s.List(ctx, WithFilter(fmt.Sprintf("owner eq '%s' and name eq '%s'", escapeFilterValue(owner), escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/task.go
+++ b/task.go
@@ -61,7 +61,7 @@ func (s *TaskService) Get(ctx context.Context, id int) (*Task, error) {
 	endpoint := fmt.Sprintf("/tasks/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &task); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Task", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Task", ID: id}
 		}
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func (s *TaskService) Update(ctx context.Context, id int, req *TaskUpdateRequest
 	endpoint := fmt.Sprintf("/tasks/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Task", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Task", ID: id}
 		}
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func (s *TaskService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/tasks/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "Task", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "Task", ID: id}
 		}
 		return err
 	}

--- a/task.go
+++ b/task.go
@@ -158,7 +158,7 @@ func (s *TaskService) Delete(ctx context.Context, id int) error {
 // Execute triggers immediate execution of a task.
 func (s *TaskService) Execute(ctx context.Context, id int, opts *TaskExecuteOptions) error {
 	endpoint := "/task_actions"
-	body := map[string]interface{}{
+	body := map[string]any{
 		"task":   id,
 		"action": "execute",
 	}

--- a/task_test.go
+++ b/task_test.go
@@ -205,7 +205,7 @@ func TestTaskService_Create(t *testing.T) {
 			if req.Owner != "vms/123" {
 				t.Errorf("expected owner 'vms/123', got %q", req.Owner)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+			jsonResponse(w, 200, map[string]any{"$key": 1})
 		},
 		"GET /api/v4/tasks/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, Task{Key: 1, Name: "daily-snapshot", Owner: "vms/123", Action: "snapshot"})
@@ -368,7 +368,7 @@ func TestTaskService_Delete_NotFound(t *testing.T) {
 func TestTaskService_Execute(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/task_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "execute" {
 				t.Errorf("expected action 'execute', got %v", body["action"])
@@ -390,9 +390,9 @@ func TestTaskService_Execute(t *testing.T) {
 func TestTaskService_Execute_WithParams(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/task_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
-			params, ok := body["params"].(map[string]interface{})
+			params, ok := body["params"].(map[string]any)
 			if !ok {
 				t.Error("expected params in request body")
 			}
@@ -404,7 +404,7 @@ func TestTaskService_Execute_WithParams(t *testing.T) {
 	}))
 
 	err := client.Tasks.Execute(context.Background(), 1, &TaskExecuteOptions{
-		Params: map[string]interface{}{"force": true},
+		Params: map[string]any{"force": true},
 	})
 	if err != nil {
 		t.Fatalf("Execute with params failed: %v", err)

--- a/task_test.go
+++ b/task_test.go
@@ -1,0 +1,454 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestTaskService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tasks": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Task{
+				{Key: 1, Name: "daily-snapshot", Action: "snapshot"},
+				{Key: 2, Name: "weekly-backup", Action: "backup"},
+			})
+		},
+	}))
+
+	tasks, err := client.Tasks.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(tasks))
+	}
+	if tasks[0].Name != "daily-snapshot" {
+		t.Errorf("expected name 'daily-snapshot', got %q", tasks[0].Name)
+	}
+}
+
+func TestTaskService_ListRunning(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tasks": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter for running tasks")
+			}
+			jsonResponse(w, 200, []Task{{Key: 1, Name: "active-task", Status: "running"}})
+		},
+	}))
+
+	tasks, err := client.Tasks.ListRunning(context.Background())
+	if err != nil {
+		t.Fatalf("ListRunning failed: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+}
+
+func TestTaskService_ListByOwner(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tasks": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "owner eq 'vms/123'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Task{{Key: 1, Owner: "vms/123"}})
+		},
+	}))
+
+	tasks, err := client.Tasks.ListByOwner(context.Background(), "vms/123")
+	if err != nil {
+		t.Fatalf("ListByOwner failed: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+}
+
+func TestTaskService_ListEnabled(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tasks": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter for enabled tasks")
+			}
+			jsonResponse(w, 200, []Task{{Key: 1, Enabled: true}})
+		},
+	}))
+
+	tasks, err := client.Tasks.ListEnabled(context.Background())
+	if err != nil {
+		t.Fatalf("ListEnabled failed: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+}
+
+func TestTaskService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tasks/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Task{Key: 1, Name: "daily-snapshot", Action: "snapshot", Owner: "vms/123"})
+		},
+	}))
+
+	task, err := client.Tasks.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if task.Name != "daily-snapshot" {
+		t.Errorf("expected name 'daily-snapshot', got %q", task.Name)
+	}
+	if task.Owner != "vms/123" {
+		t.Errorf("expected owner 'vms/123', got %q", task.Owner)
+	}
+}
+
+func TestTaskService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tasks/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Tasks.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTaskService_GetByID(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tasks": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Task{{Key: 5, ID: "abc123def456", Name: "my-task"}})
+		},
+		"GET /api/v4/tasks/5": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Task{Key: 5, ID: "abc123def456", Name: "my-task", Owner: "vms/1"})
+		},
+	}))
+
+	task, err := client.Tasks.GetByID(context.Background(), "abc123def456")
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if task.Name != "my-task" {
+		t.Errorf("expected name 'my-task', got %q", task.Name)
+	}
+}
+
+func TestTaskService_GetByID_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tasks": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Task{})
+		},
+	}))
+
+	_, err := client.Tasks.GetByID(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTaskService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tasks": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Task{{Key: 3, Name: "daily-snapshot", Owner: "vms/123"}})
+		},
+		"GET /api/v4/tasks/3": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Task{Key: 3, Name: "daily-snapshot", Owner: "vms/123", Action: "snapshot"})
+		},
+	}))
+
+	task, err := client.Tasks.GetByName(context.Background(), "vms/123", "daily-snapshot")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if task.Action != "snapshot" {
+		t.Errorf("expected action 'snapshot', got %q", task.Action)
+	}
+}
+
+func TestTaskService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tasks": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Task{})
+		},
+	}))
+
+	_, err := client.Tasks.GetByName(context.Background(), "vms/123", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTaskService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tasks": func(w http.ResponseWriter, r *http.Request) {
+			var req TaskCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "daily-snapshot" {
+				t.Errorf("expected name 'daily-snapshot', got %q", req.Name)
+			}
+			if req.Owner != "vms/123" {
+				t.Errorf("expected owner 'vms/123', got %q", req.Owner)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1})
+		},
+		"GET /api/v4/tasks/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Task{Key: 1, Name: "daily-snapshot", Owner: "vms/123", Action: "snapshot"})
+		},
+	}))
+
+	task, err := client.Tasks.Create(context.Background(), &TaskCreateRequest{
+		Owner:  "vms/123",
+		Action: "snapshot",
+		Name:   "daily-snapshot",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if task.Name != "daily-snapshot" {
+		t.Errorf("expected name 'daily-snapshot', got %q", task.Name)
+	}
+}
+
+func TestTaskService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Tasks.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTaskService_Create_MissingOwner(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Tasks.Create(context.Background(), &TaskCreateRequest{
+		Action: "snapshot",
+		Name:   "test",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing owner")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTaskService_Create_MissingAction(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Tasks.Create(context.Background(), &TaskCreateRequest{
+		Owner: "vms/123",
+		Name:  "test",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing action")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTaskService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Tasks.Create(context.Background(), &TaskCreateRequest{
+		Owner:  "vms/123",
+		Action: "snapshot",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTaskService_Update(t *testing.T) {
+	newName := "weekly-snapshot"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tasks/1": func(w http.ResponseWriter, r *http.Request) {
+			var req TaskUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/tasks/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Task{Key: 1, Name: newName})
+		},
+	}))
+
+	task, err := client.Tasks.Update(context.Background(), 1, &TaskUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if task.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, task.Name)
+	}
+}
+
+func TestTaskService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Tasks.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTaskService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tasks/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newName := "updated"
+	_, err := client.Tasks.Update(context.Background(), 999, &TaskUpdateRequest{Name: &newName})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTaskService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/tasks/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Tasks.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestTaskService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/tasks/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.Tasks.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTaskService_Execute(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/task_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "execute" {
+				t.Errorf("expected action 'execute', got %v", body["action"])
+			}
+			// task ID should be present as a float64 from JSON
+			if body["task"] != float64(1) {
+				t.Errorf("expected task 1, got %v", body["task"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Tasks.Execute(context.Background(), 1, nil)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+}
+
+func TestTaskService_Execute_WithParams(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/task_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			params, ok := body["params"].(map[string]interface{})
+			if !ok {
+				t.Error("expected params in request body")
+			}
+			if params["force"] != true {
+				t.Errorf("expected force=true, got %v", params["force"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Tasks.Execute(context.Background(), 1, &TaskExecuteOptions{
+		Params: map[string]interface{}{"force": true},
+	})
+	if err != nil {
+		t.Fatalf("Execute with params failed: %v", err)
+	}
+}
+
+func TestTaskService_Enable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tasks/1": func(w http.ResponseWriter, r *http.Request) {
+			var req TaskUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Enabled == nil || !*req.Enabled {
+				t.Error("expected enabled=true")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/tasks/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Task{Key: 1, Enabled: true})
+		},
+	}))
+
+	err := client.Tasks.Enable(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Enable failed: %v", err)
+	}
+}
+
+func TestTaskService_Disable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tasks/1": func(w http.ResponseWriter, r *http.Request) {
+			var req TaskUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Enabled == nil || *req.Enabled {
+				t.Error("expected enabled=false")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/tasks/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Task{Key: 1, Enabled: false})
+		},
+	}))
+
+	err := client.Tasks.Disable(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Disable failed: %v", err)
+	}
+}

--- a/tenant.go
+++ b/tenant.go
@@ -422,6 +422,124 @@ type tenantNodeAction struct {
 	Params     map[string]interface{} `json:"params,omitempty"`
 }
 
+// TenantStatusService handles tenant status read operations.
+// Each tenant has exactly one status record.
+type TenantStatusService struct {
+	client *Client
+}
+
+// List returns all tenant statuses.
+func (s *TenantStatusService) List(ctx context.Context, opts ...ListOption) ([]TenantStatus, error) {
+	options := applyListOptions(opts)
+	if options.Fields == "most" {
+		options.Fields = tenantStatusListFields
+	}
+	params := options.toQueryParams()
+
+	var statuses []TenantStatus
+	if err := s.client.get(ctx, "/tenant_status", params, &statuses); err != nil {
+		return nil, err
+	}
+
+	return statuses, nil
+}
+
+// Get returns the status for a specific tenant by its tenant key.
+func (s *TenantStatusService) Get(ctx context.Context, tenantKey int) (*TenantStatus, error) {
+	params := url.Values{}
+	params.Set("fields", tenantStatusGetFields)
+	params.Set("filter", fmt.Sprintf("tenant eq %d", tenantKey))
+
+	var statuses []TenantStatus
+	if err := s.client.get(ctx, "/tenant_status", params, &statuses); err != nil {
+		return nil, err
+	}
+
+	if len(statuses) == 0 {
+		return nil, &NotFoundError{Resource: "TenantStatus", ID: tenantKey}
+	}
+
+	return &statuses[0], nil
+}
+
+// GetByKey returns the status by its direct row key.
+func (s *TenantStatusService) GetByKey(ctx context.Context, key int) (*TenantStatus, error) {
+	params := url.Values{}
+	params.Set("fields", tenantStatusGetFields)
+
+	var status TenantStatus
+	endpoint := fmt.Sprintf("/tenant_status/%d", key)
+	if err := s.client.get(ctx, endpoint, params, &status); err != nil {
+		if IsNotFoundError(err) {
+			return nil, &NotFoundError{Resource: "TenantStatus", ID: key}
+		}
+		return nil, err
+	}
+
+	return &status, nil
+}
+
+// TenantStatsHistoryShortService handles tenant short-term statistics history read operations.
+// This service provides high-resolution historical metrics for tenant monitoring.
+type TenantStatsHistoryShortService struct {
+	client *Client
+}
+
+// List returns short-term historical stats for all tenants.
+func (s *TenantStatsHistoryShortService) List(ctx context.Context, opts ...ListOption) ([]TenantStatsHistoryShort, error) {
+	options := applyListOptions(opts)
+
+	if options.Fields == "most" {
+		options.Fields = tenantStatsHistoryShortFields
+	}
+
+	params := options.toQueryParams()
+
+	var stats []TenantStatsHistoryShort
+	if err := s.client.get(ctx, "/tenant_stats_history_short", params, &stats); err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}
+
+// ListByTenant returns short-term historical stats for a specific tenant.
+func (s *TenantStatsHistoryShortService) ListByTenant(ctx context.Context, tenantID int, opts ...ListOption) ([]TenantStatsHistoryShort, error) {
+	opts = append(opts, WithFilter(fmt.Sprintf("tenant eq %d", tenantID)))
+	return s.List(ctx, opts...)
+}
+
+// GetLatest returns the most recent short-term stats record for a tenant.
+func (s *TenantStatsHistoryShortService) GetLatest(ctx context.Context, tenantID int) (*TenantStatsHistoryShort, error) {
+	stats, err := s.ListByTenant(ctx, tenantID, WithSort("-timestamp"), WithLimit(1))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(stats) == 0 {
+		return nil, &NotFoundError{Resource: "TenantStatsHistoryShort", ID: fmt.Sprintf("tenant=%d", tenantID)}
+	}
+
+	return &stats[0], nil
+}
+
+// Get returns a single short-term stats record by ID.
+func (s *TenantStatsHistoryShortService) Get(ctx context.Context, id int) (*TenantStatsHistoryShort, error) {
+	params := url.Values{}
+	params.Set("fields", tenantStatsHistoryShortFields)
+
+	var stats TenantStatsHistoryShort
+	endpoint := fmt.Sprintf("/tenant_stats_history_short/%d", id)
+	if err := s.client.get(ctx, endpoint, params, &stats); err != nil {
+		if IsNotFoundError(err) {
+			return nil, &NotFoundError{Resource: "TenantStatsHistoryShort", ID: id}
+		}
+		return nil, err
+	}
+
+	return &stats, nil
+}
+
 // TenantStorageService handles tenant storage allocation operations.
 type TenantStorageService struct {
 	client *Client

--- a/tenant.go
+++ b/tenant.go
@@ -39,7 +39,7 @@ func (s *TenantService) Get(ctx context.Context, id int) (*Tenant, error) {
 	endpoint := fmt.Sprintf("/tenants/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &tenant); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Tenant", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Tenant", ID: id}
 		}
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (s *TenantService) Update(ctx context.Context, id int, req *TenantUpdateReq
 	endpoint := fmt.Sprintf("/tenants/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Tenant", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Tenant", ID: id}
 		}
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (s *TenantService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/tenants/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "Tenant", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "Tenant", ID: id}
 		}
 		return err
 	}
@@ -264,7 +264,7 @@ func (s *TenantNodeService) Get(ctx context.Context, id int) (*TenantNode, error
 	endpoint := fmt.Sprintf("/tenant_nodes/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &node); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "TenantNode", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "TenantNode", ID: id}
 		}
 		return nil, err
 	}
@@ -324,7 +324,7 @@ func (s *TenantNodeService) Update(ctx context.Context, id int, req *TenantNodeU
 	endpoint := fmt.Sprintf("/tenant_nodes/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "TenantNode", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "TenantNode", ID: id}
 		}
 		return nil, err
 	}
@@ -338,7 +338,7 @@ func (s *TenantNodeService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/tenant_nodes/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "TenantNode", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "TenantNode", ID: id}
 		}
 		return err
 	}
@@ -581,7 +581,7 @@ func (s *TenantStorageService) Get(ctx context.Context, id int) (*TenantStorage,
 	endpoint := fmt.Sprintf("/tenant_storage/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &storage); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "TenantStorage", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "TenantStorage", ID: id}
 		}
 		return nil, err
 	}
@@ -628,7 +628,7 @@ func (s *TenantStorageService) Update(ctx context.Context, id int, req *TenantSt
 	endpoint := fmt.Sprintf("/tenant_storage/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "TenantStorage", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "TenantStorage", ID: id}
 		}
 		return nil, err
 	}
@@ -642,7 +642,7 @@ func (s *TenantStorageService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/tenant_storage/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "TenantStorage", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "TenantStorage", ID: id}
 		}
 		return err
 	}

--- a/tenant.go
+++ b/tenant.go
@@ -49,7 +49,7 @@ func (s *TenantService) Get(ctx context.Context, id int) (*Tenant, error) {
 
 // GetByName returns a tenant by name.
 func (s *TenantService) GetByName(ctx context.Context, name string) (*Tenant, error) {
-	tenants, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	tenants, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +274,7 @@ func (s *TenantNodeService) Get(ctx context.Context, id int) (*TenantNode, error
 
 // GetByName returns a tenant node by name within a specific tenant.
 func (s *TenantNodeService) GetByName(ctx context.Context, tenantID int, name string) (*TenantNode, error) {
-	nodes, err := s.List(ctx, WithFilter(fmt.Sprintf("tenant eq %d and name eq '%s'", tenantID, name)))
+	nodes, err := s.List(ctx, WithFilter(fmt.Sprintf("tenant eq %d and name eq '%s'", tenantID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/tenant.go
+++ b/tenant.go
@@ -127,7 +127,7 @@ func (s *TenantService) PowerOnWithNode(ctx context.Context, id int, preferredNo
 		Action: "poweron",
 	}
 	if preferredNode > 0 {
-		action.Params = map[string]interface{}{
+		action.Params = map[string]any{
 			"preferred_node": preferredNode,
 		}
 	}
@@ -176,7 +176,7 @@ func (s *TenantService) Clone(ctx context.Context, id int, opts *TenantCloneOpti
 	action := tenantAction{
 		Tenant: id,
 		Action: "clone",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"name":       opts.Name,
 			"no_vnet":    opts.NoVNet,
 			"no_storage": opts.NoStorage,
@@ -220,7 +220,7 @@ func (s *TenantService) IsolateOff(ctx context.Context, id int) error {
 type tenantAction struct {
 	Tenant int                    `json:"tenant"`
 	Action string                 `json:"action"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 // TenantNodeService handles tenant node operations.
@@ -404,7 +404,7 @@ func (s *TenantNodeService) Migrate(ctx context.Context, id int, targetNode int)
 		Action:     "migrate",
 	}
 	if targetNode > 0 {
-		action.Params = map[string]interface{}{
+		action.Params = map[string]any{
 			"node": targetNode,
 		}
 	}
@@ -419,7 +419,7 @@ func (s *TenantNodeService) Migrate(ctx context.Context, id int, targetNode int)
 type tenantNodeAction struct {
 	TenantNode int                    `json:"tenant_node"`
 	Action     string                 `json:"action"`
-	Params     map[string]interface{} `json:"params,omitempty"`
+	Params     map[string]any `json:"params,omitempty"`
 }
 
 // TenantStatusService handles tenant status read operations.

--- a/tenant_layer2.go
+++ b/tenant_layer2.go
@@ -128,15 +128,17 @@ func (s *TenantLayer2NetworkService) Delete(ctx context.Context, id int) error {
 }
 
 // Enable enables a tenant layer2 network assignment.
-func (s *TenantLayer2NetworkService) Enable(ctx context.Context, id int) (*TenantLayer2Network, error) {
+func (s *TenantLayer2NetworkService) Enable(ctx context.Context, id int) error {
 	enabled := true
-	return s.Update(ctx, id, &TenantLayer2NetworkUpdateRequest{Enabled: &enabled})
+	_, err := s.Update(ctx, id, &TenantLayer2NetworkUpdateRequest{Enabled: &enabled})
+	return err
 }
 
 // Disable disables a tenant layer2 network assignment.
-func (s *TenantLayer2NetworkService) Disable(ctx context.Context, id int) (*TenantLayer2Network, error) {
+func (s *TenantLayer2NetworkService) Disable(ctx context.Context, id int) error {
 	enabled := false
-	return s.Update(ctx, id, &TenantLayer2NetworkUpdateRequest{Enabled: &enabled})
+	_, err := s.Update(ctx, id, &TenantLayer2NetworkUpdateRequest{Enabled: &enabled})
+	return err
 }
 
 // Assign is a convenience method to assign a network to a tenant.

--- a/tenant_layer2.go
+++ b/tenant_layer2.go
@@ -51,7 +51,7 @@ func (s *TenantLayer2NetworkService) Get(ctx context.Context, id int) (*TenantLa
 	endpoint := fmt.Sprintf("/tenant_layer2_vnets/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &network); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "TenantLayer2Network", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "TenantLayer2Network", ID: id}
 		}
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (s *TenantLayer2NetworkService) Update(ctx context.Context, id int, req *Te
 	endpoint := fmt.Sprintf("/tenant_layer2_vnets/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "TenantLayer2Network", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "TenantLayer2Network", ID: id}
 		}
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (s *TenantLayer2NetworkService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/tenant_layer2_vnets/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "TenantLayer2Network", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "TenantLayer2Network", ID: id}
 		}
 		return err
 	}

--- a/tenant_layer2_test.go
+++ b/tenant_layer2_test.go
@@ -292,12 +292,9 @@ func TestTenantLayer2NetworkService_Enable(t *testing.T) {
 		},
 	}))
 
-	network, err := client.TenantLayer2Networks.Enable(context.Background(), 1)
+	err := client.TenantLayer2Networks.Enable(context.Background(), 1)
 	if err != nil {
 		t.Fatalf("Enable failed: %v", err)
-	}
-	if !network.Enabled {
-		t.Error("expected enabled to be true")
 	}
 }
 
@@ -316,12 +313,9 @@ func TestTenantLayer2NetworkService_Disable(t *testing.T) {
 		},
 	}))
 
-	network, err := client.TenantLayer2Networks.Disable(context.Background(), 1)
+	err := client.TenantLayer2Networks.Disable(context.Background(), 1)
 	if err != nil {
 		t.Fatalf("Disable failed: %v", err)
-	}
-	if network.Enabled {
-		t.Error("expected enabled to be false")
 	}
 }
 

--- a/tenant_layer2_test.go
+++ b/tenant_layer2_test.go
@@ -1,0 +1,407 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestTenantLayer2NetworkService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_layer2_vnets": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TenantLayer2Network{
+				{Key: 1, Tenant: 10, VNet: 100, Enabled: true},
+				{Key: 2, Tenant: 20, VNet: 200, Enabled: false},
+			})
+		},
+	}))
+
+	networks, err := client.TenantLayer2Networks.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(networks) != 2 {
+		t.Fatalf("expected 2 networks, got %d", len(networks))
+	}
+	if !networks[0].Enabled {
+		t.Error("expected first network to be enabled")
+	}
+}
+
+func TestTenantLayer2NetworkService_ListByTenant(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_layer2_vnets": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "tenant eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []TenantLayer2Network{{Key: 1, Tenant: 10, VNet: 100}})
+		},
+	}))
+
+	networks, err := client.TenantLayer2Networks.ListByTenant(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListByTenant failed: %v", err)
+	}
+	if len(networks) != 1 {
+		t.Fatalf("expected 1 network, got %d", len(networks))
+	}
+}
+
+func TestTenantLayer2NetworkService_ListByNetwork(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_layer2_vnets": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "vnet eq 100" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []TenantLayer2Network{{Key: 1, Tenant: 10, VNet: 100}})
+		},
+	}))
+
+	networks, err := client.TenantLayer2Networks.ListByNetwork(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("ListByNetwork failed: %v", err)
+	}
+	if len(networks) != 1 {
+		t.Fatalf("expected 1 network, got %d", len(networks))
+	}
+}
+
+func TestTenantLayer2NetworkService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_layer2_vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantLayer2Network{Key: 1, Tenant: 10, VNet: 100, Enabled: true})
+		},
+	}))
+
+	network, err := client.TenantLayer2Networks.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if int(network.Tenant) != 10 {
+		t.Errorf("expected tenant 10, got %d", int(network.Tenant))
+	}
+	if int(network.VNet) != 100 {
+		t.Errorf("expected vnet 100, got %d", int(network.VNet))
+	}
+}
+
+func TestTenantLayer2NetworkService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_layer2_vnets/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.TenantLayer2Networks.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantLayer2NetworkService_GetByTenantAndNetwork(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_layer2_vnets": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TenantLayer2Network{{Key: 1, Tenant: 10, VNet: 100}})
+		},
+		"GET /api/v4/tenant_layer2_vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantLayer2Network{Key: 1, Tenant: 10, VNet: 100, Enabled: true})
+		},
+	}))
+
+	network, err := client.TenantLayer2Networks.GetByTenantAndNetwork(context.Background(), 10, 100)
+	if err != nil {
+		t.Fatalf("GetByTenantAndNetwork failed: %v", err)
+	}
+	if int(network.Key) != 1 {
+		t.Errorf("expected key 1, got %d", int(network.Key))
+	}
+}
+
+func TestTenantLayer2NetworkService_GetByTenantAndNetwork_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_layer2_vnets": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TenantLayer2Network{})
+		},
+	}))
+
+	_, err := client.TenantLayer2Networks.GetByTenantAndNetwork(context.Background(), 10, 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantLayer2NetworkService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenant_layer2_vnets": func(w http.ResponseWriter, r *http.Request) {
+			var req TenantLayer2NetworkCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Tenant != 10 {
+				t.Errorf("expected tenant 10, got %d", req.Tenant)
+			}
+			if req.VNet != 100 {
+				t.Errorf("expected vnet 100, got %d", req.VNet)
+			}
+			jsonResponse(w, 200, apiResponse{Key: float64(5)})
+		},
+		"GET /api/v4/tenant_layer2_vnets/5": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantLayer2Network{Key: 5, Tenant: 10, VNet: 100, Enabled: true})
+		},
+	}))
+
+	enabled := true
+	network, err := client.TenantLayer2Networks.Create(context.Background(), &TenantLayer2NetworkCreateRequest{
+		Tenant:  10,
+		VNet:    100,
+		Enabled: &enabled,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if int(network.Key) != 5 {
+		t.Errorf("expected key 5, got %d", int(network.Key))
+	}
+}
+
+func TestTenantLayer2NetworkService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TenantLayer2Networks.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantLayer2NetworkService_Create_MissingTenant(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TenantLayer2Networks.Create(context.Background(), &TenantLayer2NetworkCreateRequest{
+		VNet: 100,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing tenant")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantLayer2NetworkService_Create_MissingVNet(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TenantLayer2Networks.Create(context.Background(), &TenantLayer2NetworkCreateRequest{
+		Tenant: 10,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing vnet")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantLayer2NetworkService_Update(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tenant_layer2_vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			var req TenantLayer2NetworkUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Enabled == nil || *req.Enabled {
+				t.Error("expected enabled to be false")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/tenant_layer2_vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantLayer2Network{Key: 1, Tenant: 10, VNet: 100, Enabled: false})
+		},
+	}))
+
+	enabled := false
+	network, err := client.TenantLayer2Networks.Update(context.Background(), 1, &TenantLayer2NetworkUpdateRequest{Enabled: &enabled})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if network.Enabled {
+		t.Error("expected enabled to be false")
+	}
+}
+
+func TestTenantLayer2NetworkService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TenantLayer2Networks.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantLayer2NetworkService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/tenant_layer2_vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.TenantLayer2Networks.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestTenantLayer2NetworkService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/tenant_layer2_vnets/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.TenantLayer2Networks.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantLayer2NetworkService_Enable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tenant_layer2_vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			var req TenantLayer2NetworkUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Enabled == nil || !*req.Enabled {
+				t.Error("expected enabled to be true")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/tenant_layer2_vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantLayer2Network{Key: 1, Enabled: true})
+		},
+	}))
+
+	network, err := client.TenantLayer2Networks.Enable(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Enable failed: %v", err)
+	}
+	if !network.Enabled {
+		t.Error("expected enabled to be true")
+	}
+}
+
+func TestTenantLayer2NetworkService_Disable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tenant_layer2_vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			var req TenantLayer2NetworkUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Enabled == nil || *req.Enabled {
+				t.Error("expected enabled to be false")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/tenant_layer2_vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantLayer2Network{Key: 1, Enabled: false})
+		},
+	}))
+
+	network, err := client.TenantLayer2Networks.Disable(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Disable failed: %v", err)
+	}
+	if network.Enabled {
+		t.Error("expected enabled to be false")
+	}
+}
+
+func TestTenantLayer2NetworkService_Assign(t *testing.T) {
+	// Test assign when assignment doesn't exist yet
+	callCount := 0
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_layer2_vnets": func(w http.ResponseWriter, r *http.Request) {
+			// First call: GetByTenantAndNetwork returns empty (not found)
+			// Second call (if any): also empty
+			jsonResponse(w, 200, []TenantLayer2Network{})
+		},
+		"POST /api/v4/tenant_layer2_vnets": func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			jsonResponse(w, 200, apiResponse{Key: float64(5)})
+		},
+		"GET /api/v4/tenant_layer2_vnets/5": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantLayer2Network{Key: 5, Tenant: 10, VNet: 100, Enabled: true})
+		},
+	}))
+
+	network, err := client.TenantLayer2Networks.Assign(context.Background(), 10, 100)
+	if err != nil {
+		t.Fatalf("Assign failed: %v", err)
+	}
+	if int(network.Key) != 5 {
+		t.Errorf("expected key 5, got %d", int(network.Key))
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 create call, got %d", callCount)
+	}
+}
+
+func TestTenantLayer2NetworkService_Assign_AlreadyExists(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_layer2_vnets": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TenantLayer2Network{{Key: 3, Tenant: 10, VNet: 100}})
+		},
+		"GET /api/v4/tenant_layer2_vnets/3": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantLayer2Network{Key: 3, Tenant: 10, VNet: 100, Enabled: true})
+		},
+	}))
+
+	network, err := client.TenantLayer2Networks.Assign(context.Background(), 10, 100)
+	if err != nil {
+		t.Fatalf("Assign failed: %v", err)
+	}
+	if int(network.Key) != 3 {
+		t.Errorf("expected existing key 3, got %d", int(network.Key))
+	}
+}
+
+func TestTenantLayer2NetworkService_Unassign(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_layer2_vnets": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TenantLayer2Network{{Key: 3, Tenant: 10, VNet: 100}})
+		},
+		"GET /api/v4/tenant_layer2_vnets/3": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantLayer2Network{Key: 3, Tenant: 10, VNet: 100})
+		},
+		"DELETE /api/v4/tenant_layer2_vnets/3": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.TenantLayer2Networks.Unassign(context.Background(), 10, 100)
+	if err != nil {
+		t.Fatalf("Unassign failed: %v", err)
+	}
+}
+
+func TestTenantLayer2NetworkService_Unassign_AlreadyUnassigned(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_layer2_vnets": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TenantLayer2Network{})
+		},
+	}))
+
+	err := client.TenantLayer2Networks.Unassign(context.Background(), 10, 999)
+	if err != nil {
+		t.Fatalf("expected no error for already unassigned, got: %v", err)
+	}
+}

--- a/tenant_snapshot.go
+++ b/tenant_snapshot.go
@@ -51,7 +51,7 @@ func (s *TenantSnapshotService) Get(ctx context.Context, id int) (*TenantSnapsho
 	endpoint := fmt.Sprintf("/tenant_snapshots/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &snapshot); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "TenantSnapshot", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "TenantSnapshot", ID: id}
 		}
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func (s *TenantSnapshotService) Update(ctx context.Context, id int, req *TenantS
 	endpoint := fmt.Sprintf("/tenant_snapshots/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "TenantSnapshot", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "TenantSnapshot", ID: id}
 		}
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (s *TenantSnapshotService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/tenant_snapshots/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "TenantSnapshot", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "TenantSnapshot", ID: id}
 		}
 		return err
 	}

--- a/tenant_snapshot.go
+++ b/tenant_snapshot.go
@@ -131,5 +131,5 @@ func (s *TenantSnapshotService) SetExpires(ctx context.Context, id int, expires 
 type tenantSnapshotAction struct {
 	Tenant int                    `json:"tenant"`
 	Action string                 `json:"action"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	Params map[string]any `json:"params,omitempty"`
 }

--- a/tenant_snapshot.go
+++ b/tenant_snapshot.go
@@ -62,7 +62,7 @@ func (s *TenantSnapshotService) Get(ctx context.Context, id int) (*TenantSnapsho
 // GetByName returns a tenant snapshot by name within a specific tenant.
 func (s *TenantSnapshotService) GetByName(ctx context.Context, tenantID int, name string) (*TenantSnapshot, error) {
 	snapshots, err := s.List(ctx,
-		WithFilter(fmt.Sprintf("tenant eq %d and name eq '%s'", tenantID, name)),
+		WithFilter(fmt.Sprintf("tenant eq %d and name eq '%s'", tenantID, escapeFilterValue(name))),
 	)
 	if err != nil {
 		return nil, err

--- a/tenant_snapshot_test.go
+++ b/tenant_snapshot_test.go
@@ -210,7 +210,7 @@ func TestTenantSnapshotService_Delete_NotFound(t *testing.T) {
 func TestTenantSnapshotService_Refresh(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/tenant_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "refresh" {
 				t.Errorf("expected action 'refresh', got %v", body["action"])

--- a/tenant_snapshot_test.go
+++ b/tenant_snapshot_test.go
@@ -1,0 +1,278 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestTenantSnapshotService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TenantSnapshot{
+				{Key: 1, Tenant: 10, Name: "snap1"},
+				{Key: 2, Tenant: 10, Name: "snap2"},
+			})
+		},
+	}))
+
+	snapshots, err := client.TenantSnapshots.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(snapshots) != 2 {
+		t.Fatalf("expected 2 snapshots, got %d", len(snapshots))
+	}
+	if snapshots[0].Name != "snap1" {
+		t.Errorf("expected name 'snap1', got %q", snapshots[0].Name)
+	}
+}
+
+func TestTenantSnapshotService_ListByTenant(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "tenant eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []TenantSnapshot{{Key: 1, Tenant: 10, Name: "snap1"}})
+		},
+	}))
+
+	snapshots, err := client.TenantSnapshots.ListByTenant(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListByTenant failed: %v", err)
+	}
+	if len(snapshots) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(snapshots))
+	}
+}
+
+func TestTenantSnapshotService_ListExpiring(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			// 7 days = 604800 seconds
+			expected := "expires ne 0 and expires lt {$add({$now},604800)}"
+			if filter != expected {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []TenantSnapshot{{Key: 1, Expires: 1700000000}})
+		},
+	}))
+
+	snapshots, err := client.TenantSnapshots.ListExpiring(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("ListExpiring failed: %v", err)
+	}
+	if len(snapshots) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(snapshots))
+	}
+}
+
+func TestTenantSnapshotService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantSnapshot{Key: 1, Tenant: 10, Name: "snap1", Description: "test snapshot"})
+		},
+	}))
+
+	snapshot, err := client.TenantSnapshots.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if snapshot.Name != "snap1" {
+		t.Errorf("expected name 'snap1', got %q", snapshot.Name)
+	}
+	if snapshot.Description != "test snapshot" {
+		t.Errorf("expected description 'test snapshot', got %q", snapshot.Description)
+	}
+}
+
+func TestTenantSnapshotService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_snapshots/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.TenantSnapshots.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantSnapshotService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TenantSnapshot{{Key: 1, Tenant: 10, Name: "snap1"}})
+		},
+		"GET /api/v4/tenant_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantSnapshot{Key: 1, Tenant: 10, Name: "snap1"})
+		},
+	}))
+
+	snapshot, err := client.TenantSnapshots.GetByName(context.Background(), 10, "snap1")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if snapshot.Name != "snap1" {
+		t.Errorf("expected name 'snap1', got %q", snapshot.Name)
+	}
+}
+
+func TestTenantSnapshotService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TenantSnapshot{})
+		},
+	}))
+
+	_, err := client.TenantSnapshots.GetByName(context.Background(), 10, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantSnapshotService_Update(t *testing.T) {
+	newDesc := "updated description"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tenant_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			var req TenantSnapshotUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Description == nil || *req.Description != newDesc {
+				t.Errorf("expected description %q, got %v", newDesc, req.Description)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/tenant_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantSnapshot{Key: 1, Name: "snap1", Description: newDesc})
+		},
+	}))
+
+	snapshot, err := client.TenantSnapshots.Update(context.Background(), 1, &TenantSnapshotUpdateRequest{Description: &newDesc})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if snapshot.Description != newDesc {
+		t.Errorf("expected description %q, got %q", newDesc, snapshot.Description)
+	}
+}
+
+func TestTenantSnapshotService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TenantSnapshots.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantSnapshotService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/tenant_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.TenantSnapshots.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestTenantSnapshotService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/tenant_snapshots/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.TenantSnapshots.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantSnapshotService_Refresh(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenant_snapshot_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "refresh" {
+				t.Errorf("expected action 'refresh', got %v", body["action"])
+			}
+			if int(body["tenant"].(float64)) != 10 {
+				t.Errorf("expected tenant 10, got %v", body["tenant"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.TenantSnapshots.Refresh(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("Refresh failed: %v", err)
+	}
+}
+
+func TestTenantSnapshotService_SetNeverExpires(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tenant_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			var req TenantSnapshotUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Expires == nil || *req.Expires != 0 {
+				t.Errorf("expected expires 0, got %v", req.Expires)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/tenant_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantSnapshot{Key: 1, Expires: 0})
+		},
+	}))
+
+	snapshot, err := client.TenantSnapshots.SetNeverExpires(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("SetNeverExpires failed: %v", err)
+	}
+	if snapshot.Expires != 0 {
+		t.Errorf("expected expires 0, got %d", snapshot.Expires)
+	}
+}
+
+func TestTenantSnapshotService_SetExpires(t *testing.T) {
+	expiry := int64(1700000000)
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tenant_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			var req TenantSnapshotUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Expires == nil || *req.Expires != expiry {
+				t.Errorf("expected expires %d, got %v", expiry, req.Expires)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/tenant_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantSnapshot{Key: 1, Expires: expiry})
+		},
+	}))
+
+	snapshot, err := client.TenantSnapshots.SetExpires(context.Background(), 1, expiry)
+	if err != nil {
+		t.Fatalf("SetExpires failed: %v", err)
+	}
+	if snapshot.Expires != expiry {
+		t.Errorf("expected expires %d, got %d", expiry, snapshot.Expires)
+	}
+}

--- a/tenant_test.go
+++ b/tenant_test.go
@@ -1,0 +1,806 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// TenantService tests
+// ---------------------------------------------------------------------------
+
+func TestTenantService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenants": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Tenant{
+				{Key: 1, Name: "tenant-a"},
+				{Key: 2, Name: "tenant-b"},
+			})
+		},
+	}))
+
+	tenants, err := client.Tenants.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(tenants) != 2 {
+		t.Fatalf("expected 2 tenants, got %d", len(tenants))
+	}
+	if tenants[0].Name != "tenant-a" {
+		t.Errorf("expected name 'tenant-a', got %q", tenants[0].Name)
+	}
+}
+
+func TestTenantService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenants/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Tenant{Key: 1, Name: "tenant-a", Description: "first"})
+		},
+	}))
+
+	tenant, err := client.Tenants.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if tenant.Name != "tenant-a" {
+		t.Errorf("expected name 'tenant-a', got %q", tenant.Name)
+	}
+	if tenant.Description != "first" {
+		t.Errorf("expected description 'first', got %q", tenant.Description)
+	}
+}
+
+func TestTenantService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenants/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Tenants.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenants": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Tenant{{Key: 1, Name: "tenant-a"}})
+		},
+		"GET /api/v4/tenants/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Tenant{Key: 1, Name: "tenant-a", Description: "full"})
+		},
+	}))
+
+	tenant, err := client.Tenants.GetByName(context.Background(), "tenant-a")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if tenant.Description != "full" {
+		t.Errorf("expected description 'full', got %q", tenant.Description)
+	}
+}
+
+func TestTenantService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenants": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Tenant{})
+		},
+	}))
+
+	_, err := client.Tenants.GetByName(context.Background(), "nope")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenants": func(w http.ResponseWriter, r *http.Request) {
+			var req TenantCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "new-tenant" {
+				t.Errorf("expected name 'new-tenant', got %q", req.Name)
+			}
+			jsonResponse(w, 200, apiResponse{Key: 10})
+		},
+		"GET /api/v4/tenants/10": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Tenant{Key: 10, Name: "new-tenant"})
+		},
+	}))
+
+	tenant, err := client.Tenants.Create(context.Background(), &TenantCreateRequest{
+		Name: "new-tenant",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if tenant.Name != "new-tenant" {
+		t.Errorf("expected name 'new-tenant', got %q", tenant.Name)
+	}
+}
+
+func TestTenantService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Tenants.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantService_Create_EmptyName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Tenants.Create(context.Background(), &TenantCreateRequest{})
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantService_Update(t *testing.T) {
+	newDesc := "updated"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tenants/1": func(w http.ResponseWriter, r *http.Request) {
+			var req TenantUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Description == nil || *req.Description != newDesc {
+				t.Errorf("expected description %q, got %v", newDesc, req.Description)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/tenants/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Tenant{Key: 1, Name: "tenant-a", Description: newDesc})
+		},
+	}))
+
+	tenant, err := client.Tenants.Update(context.Background(), 1, &TenantUpdateRequest{
+		Description: &newDesc,
+	})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if tenant.Description != newDesc {
+		t.Errorf("expected description %q, got %q", newDesc, tenant.Description)
+	}
+}
+
+func TestTenantService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Tenants.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tenants/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newName := "nope"
+	_, err := client.Tenants.Update(context.Background(), 999, &TenantUpdateRequest{Name: &newName})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/tenants/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Tenants.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestTenantService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/tenants/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.Tenants.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantService_PowerOn(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenant_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body tenantAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "poweron" {
+				t.Errorf("expected action 'poweron', got %q", body.Action)
+			}
+			if body.Tenant != 1 {
+				t.Errorf("expected tenant 1, got %d", body.Tenant)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Tenants.PowerOn(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("PowerOn failed: %v", err)
+	}
+}
+
+func TestTenantService_PowerOnWithNode(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenant_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body tenantAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "poweron" {
+				t.Errorf("expected action 'poweron', got %q", body.Action)
+			}
+			if body.Params == nil {
+				t.Fatal("expected params with preferred_node")
+			}
+			if pn, ok := body.Params["preferred_node"].(float64); !ok || int(pn) != 5 {
+				t.Errorf("expected preferred_node 5, got %v", body.Params["preferred_node"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Tenants.PowerOnWithNode(context.Background(), 1, 5)
+	if err != nil {
+		t.Fatalf("PowerOnWithNode failed: %v", err)
+	}
+}
+
+func TestTenantService_PowerOff(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenant_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body tenantAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "poweroff" {
+				t.Errorf("expected action 'poweroff', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Tenants.PowerOff(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("PowerOff failed: %v", err)
+	}
+}
+
+func TestTenantService_Reset(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenant_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body tenantAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "reset" {
+				t.Errorf("expected action 'reset', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Tenants.Reset(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Reset failed: %v", err)
+	}
+}
+
+func TestTenantService_Clone(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenant_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body tenantAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "clone" {
+				t.Errorf("expected action 'clone', got %q", body.Action)
+			}
+			if body.Params == nil {
+				t.Fatal("expected params for clone")
+			}
+			if name, ok := body.Params["name"].(string); !ok || name != "cloned" {
+				t.Errorf("expected clone name 'cloned', got %v", body.Params["name"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Tenants.Clone(context.Background(), 1, &TenantCloneOptions{Name: "cloned"})
+	if err != nil {
+		t.Fatalf("Clone failed: %v", err)
+	}
+}
+
+func TestTenantService_Clone_NilOptions(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	err := client.Tenants.Clone(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil options")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantService_Clone_EmptyName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	err := client.Tenants.Clone(context.Background(), 1, &TenantCloneOptions{})
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantService_IsolateOn(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenant_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body tenantAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "isolateon" {
+				t.Errorf("expected action 'isolateon', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Tenants.IsolateOn(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("IsolateOn failed: %v", err)
+	}
+}
+
+func TestTenantService_IsolateOff(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenant_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body tenantAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "isolateoff" {
+				t.Errorf("expected action 'isolateoff', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Tenants.IsolateOff(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("IsolateOff failed: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TenantNodeService tests
+// ---------------------------------------------------------------------------
+
+func TestTenantNodeService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_nodes": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TenantNode{
+				{Key: 1, Name: "node-1", CPUCores: 4, RAM: 8192},
+				{Key: 2, Name: "node-2", CPUCores: 8, RAM: 16384},
+			})
+		},
+	}))
+
+	nodes, err := client.TenantNodes.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(nodes))
+	}
+	if nodes[0].Name != "node-1" {
+		t.Errorf("expected name 'node-1', got %q", nodes[0].Name)
+	}
+}
+
+func TestTenantNodeService_ListByTenant(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_nodes": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter for tenant")
+			}
+			jsonResponse(w, 200, []TenantNode{{Key: 1, Tenant: 5, Name: "node-1"}})
+		},
+	}))
+
+	nodes, err := client.TenantNodes.ListByTenant(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("ListByTenant failed: %v", err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(nodes))
+	}
+}
+
+func TestTenantNodeService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_nodes/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantNode{Key: 1, Name: "node-1", CPUCores: 4, RAM: 8192})
+		},
+	}))
+
+	node, err := client.TenantNodes.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if node.CPUCores != 4 {
+		t.Errorf("expected 4 cores, got %d", node.CPUCores)
+	}
+}
+
+func TestTenantNodeService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_nodes/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.TenantNodes.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantNodeService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_nodes": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TenantNode{{Key: 1, Tenant: 5, Name: "node-1"}})
+		},
+		"GET /api/v4/tenant_nodes/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantNode{Key: 1, Tenant: 5, Name: "node-1", CPUCores: 4})
+		},
+	}))
+
+	node, err := client.TenantNodes.GetByName(context.Background(), 5, "node-1")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if node.CPUCores != 4 {
+		t.Errorf("expected 4 cores, got %d", node.CPUCores)
+	}
+}
+
+func TestTenantNodeService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/tenant_nodes": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TenantNode{})
+		},
+	}))
+
+	_, err := client.TenantNodes.GetByName(context.Background(), 5, "nope")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantNodeService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenant_nodes": func(w http.ResponseWriter, r *http.Request) {
+			var req TenantNodeCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Tenant != 5 {
+				t.Errorf("expected tenant 5, got %d", req.Tenant)
+			}
+			if req.CPUCores != 4 {
+				t.Errorf("expected 4 cores, got %d", req.CPUCores)
+			}
+			jsonResponse(w, 200, apiResponse{Key: 10})
+		},
+		"GET /api/v4/tenant_nodes/10": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantNode{Key: 10, Tenant: 5, Name: "node-new", CPUCores: 4, RAM: 4096})
+		},
+	}))
+
+	node, err := client.TenantNodes.Create(context.Background(), &TenantNodeCreateRequest{
+		Tenant:   5,
+		CPUCores: 4,
+		RAM:      4096,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if node.Name != "node-new" {
+		t.Errorf("expected name 'node-new', got %q", node.Name)
+	}
+}
+
+func TestTenantNodeService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TenantNodes.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantNodeService_Create_MissingTenant(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TenantNodes.Create(context.Background(), &TenantNodeCreateRequest{
+		CPUCores: 4,
+		RAM:      4096,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing tenant")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantNodeService_Create_MissingCPUCores(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TenantNodes.Create(context.Background(), &TenantNodeCreateRequest{
+		Tenant: 5,
+		RAM:    4096,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing cpu_cores")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantNodeService_Create_InsufficientRAM(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TenantNodes.Create(context.Background(), &TenantNodeCreateRequest{
+		Tenant:   5,
+		CPUCores: 4,
+		RAM:      1024,
+	})
+	if err == nil {
+		t.Fatal("expected error for insufficient RAM")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantNodeService_Update(t *testing.T) {
+	newDesc := "updated node"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tenant_nodes/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/tenant_nodes/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, TenantNode{Key: 1, Name: "node-1", Description: newDesc})
+		},
+	}))
+
+	node, err := client.TenantNodes.Update(context.Background(), 1, &TenantNodeUpdateRequest{
+		Description: &newDesc,
+	})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if node.Description != newDesc {
+		t.Errorf("expected description %q, got %q", newDesc, node.Description)
+	}
+}
+
+func TestTenantNodeService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.TenantNodes.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantNodeService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/tenant_nodes/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newDesc := "nope"
+	_, err := client.TenantNodes.Update(context.Background(), 999, &TenantNodeUpdateRequest{Description: &newDesc})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantNodeService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/tenant_nodes/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.TenantNodes.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestTenantNodeService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/tenant_nodes/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.TenantNodes.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestTenantNodeService_PowerOn(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenant_node_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body tenantNodeAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "poweron" {
+				t.Errorf("expected action 'poweron', got %q", body.Action)
+			}
+			if body.TenantNode != 1 {
+				t.Errorf("expected tenant_node 1, got %d", body.TenantNode)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.TenantNodes.PowerOn(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("PowerOn failed: %v", err)
+	}
+}
+
+func TestTenantNodeService_PowerOff(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenant_node_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body tenantNodeAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "poweroff" {
+				t.Errorf("expected action 'poweroff', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.TenantNodes.PowerOff(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("PowerOff failed: %v", err)
+	}
+}
+
+func TestTenantNodeService_Reset(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenant_node_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body tenantNodeAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "reset" {
+				t.Errorf("expected action 'reset', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.TenantNodes.Reset(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Reset failed: %v", err)
+	}
+}
+
+func TestTenantNodeService_Kill(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenant_node_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body tenantNodeAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "kill" {
+				t.Errorf("expected action 'kill', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.TenantNodes.Kill(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Kill failed: %v", err)
+	}
+}
+
+func TestTenantNodeService_Migrate(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenant_node_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body tenantNodeAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "migrate" {
+				t.Errorf("expected action 'migrate', got %q", body.Action)
+			}
+			if body.Params == nil {
+				t.Fatal("expected params with target node")
+			}
+			if node, ok := body.Params["node"].(float64); !ok || int(node) != 3 {
+				t.Errorf("expected target node 3, got %v", body.Params["node"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.TenantNodes.Migrate(context.Background(), 1, 3)
+	if err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+}
+
+func TestTenantNodeService_Migrate_NoTarget(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/tenant_node_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body tenantNodeAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "migrate" {
+				t.Errorf("expected action 'migrate', got %q", body.Action)
+			}
+			if body.Params != nil {
+				t.Error("expected nil params when no target node specified")
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.TenantNodes.Migrate(context.Background(), 1, 0)
+	if err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+}

--- a/test/integration/nodes_test.go
+++ b/test/integration/nodes_test.go
@@ -1,0 +1,118 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+)
+
+// TestNodes tests the Nodes service against a live VergeOS API.
+func TestNodes(t *testing.T) {
+	client := setupTestClient(t)
+	ctx := context.Background()
+
+	t.Run("List", func(t *testing.T) {
+		nodes, err := client.Nodes.List(ctx)
+		if err != nil {
+			t.Fatalf("Nodes.List failed: %v", err)
+		}
+		t.Logf("Found %d nodes", len(nodes))
+
+		if len(nodes) == 0 {
+			t.Skip("No nodes found")
+		}
+
+		first := nodes[0]
+		t.Logf("First node: ID=%d, Name=%q, Cluster=%d, Physical=%v, Cores=%d, RAM=%d",
+			first.ID, first.Name, first.Cluster, first.Physical, first.Cores, first.RAM)
+
+		// Validate vm_stats_totals is populated
+		if first.VMStatsTotals == nil {
+			t.Error("VMStatsTotals is nil — running_machines aggregate field expression may not be working")
+		} else {
+			t.Logf("VMStatsTotals: RunningCores=%d, RunningRAM=%d",
+				first.VMStatsTotals.RunningCores, first.VMStatsTotals.RunningRAM)
+
+			if first.VMStatsTotals.RunningCores == 0 && first.VMStatsTotals.RunningRAM == 0 {
+				t.Log("Warning: both RunningCores and RunningRAM are 0 — node may have no running VMs")
+			}
+		}
+
+		prettyPrint(t, "Sample Node", first)
+	})
+
+	t.Run("ListPhysical", func(t *testing.T) {
+		physNodes, err := client.Nodes.ListPhysical(ctx)
+		if err != nil {
+			t.Fatalf("Nodes.ListPhysical failed: %v", err)
+		}
+		t.Logf("Found %d physical nodes", len(physNodes))
+
+		for _, n := range physNodes {
+			if !n.Physical {
+				t.Errorf("Node %q (ID=%d) returned by ListPhysical but Physical=%v", n.Name, n.ID, n.Physical)
+			}
+			if n.VMStatsTotals != nil {
+				t.Logf("Node %q: RunningCores=%d, RunningRAM=%d",
+					n.Name, n.VMStatsTotals.RunningCores, n.VMStatsTotals.RunningRAM)
+			}
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		nodes, err := client.Nodes.List(ctx)
+		if err != nil || len(nodes) == 0 {
+			t.Skip("No nodes available")
+		}
+
+		first := nodes[0]
+		fetched, err := client.Nodes.Get(ctx, first.ID)
+		if err != nil {
+			t.Fatalf("Nodes.Get(%d) failed: %v", first.ID, err)
+		}
+		t.Logf("Nodes.Get succeeded: ID=%d, Name=%q", fetched.ID, fetched.Name)
+
+		if fetched.VMStatsTotals != nil {
+			t.Logf("VMStatsTotals from Get: RunningCores=%d, RunningRAM=%d",
+				fetched.VMStatsTotals.RunningCores, fetched.VMStatsTotals.RunningRAM)
+		}
+	})
+
+	t.Run("GetByName", func(t *testing.T) {
+		nodes, err := client.Nodes.List(ctx)
+		if err != nil || len(nodes) == 0 {
+			t.Skip("No nodes available")
+		}
+
+		first := nodes[0]
+		fetched, err := client.Nodes.GetByName(ctx, first.Name)
+		if err != nil {
+			t.Fatalf("Nodes.GetByName(%q) failed: %v", first.Name, err)
+		}
+		t.Logf("Nodes.GetByName succeeded: ID=%d, Name=%q", fetched.ID, fetched.Name)
+	})
+
+	t.Run("VMStatsTotalsAllNodes", func(t *testing.T) {
+		nodes, err := client.Nodes.ListPhysical(ctx)
+		if err != nil {
+			t.Fatalf("Nodes.ListPhysical failed: %v", err)
+		}
+
+		totalCores := 0
+		totalRAM := 0
+		for _, n := range nodes {
+			if n.VMStatsTotals != nil {
+				totalCores += n.VMStatsTotals.RunningCores
+				totalRAM += n.VMStatsTotals.RunningRAM
+				t.Logf("vergeos_node_running_cores{node=%q} %d", n.Name, n.VMStatsTotals.RunningCores)
+				t.Logf("vergeos_node_running_ram{node=%q} %d", n.Name, n.VMStatsTotals.RunningRAM)
+			}
+		}
+		t.Logf("Totals across all nodes: RunningCores=%d, RunningRAM=%dMB", totalCores, totalRAM)
+
+		if totalCores == 0 {
+			t.Error("Total RunningCores across all nodes is 0 — expected at least some running VMs")
+		}
+	})
+}

--- a/test/integration/tenants_test.go
+++ b/test/integration/tenants_test.go
@@ -336,6 +336,131 @@ func TestTenantLayer2List(t *testing.T) {
 	})
 }
 
+// TestTenantStatusList tests the TenantStatus service.
+func TestTenantStatusList(t *testing.T) {
+	client := setupTestClient(t)
+	ctx := context.Background()
+
+	t.Log("Testing TenantStatus service...")
+
+	// List all tenant statuses
+	statuses, err := client.TenantStatus.List(ctx)
+	if err != nil {
+		t.Fatalf("TenantStatus.List failed: %v", err)
+	}
+
+	t.Logf("Found %d tenant statuses", len(statuses))
+
+	if len(statuses) == 0 {
+		t.Log("No tenant statuses found - this is expected on systems without tenants")
+		return
+	}
+
+	// Log first status to verify field mapping
+	first := statuses[0]
+	t.Logf("First tenant status: Key=%d, Tenant=%d, Status=%q, State=%q, Running=%v",
+		int(first.Key), first.Tenant, first.Status, first.State, first.Running)
+
+	// Test Get by tenant key
+	t.Run("Get", func(t *testing.T) {
+		if first.Tenant == 0 {
+			t.Skip("No tenant reference available")
+		}
+		fetched, err := client.TenantStatus.Get(ctx, first.Tenant)
+		if err != nil {
+			t.Errorf("TenantStatus.Get(%d) failed: %v", first.Tenant, err)
+		} else {
+			t.Logf("TenantStatus.Get succeeded: Status=%q, State=%q, Running=%v, Starting=%v, Stopping=%v",
+				fetched.Status, fetched.State, fetched.Running, fetched.Starting, fetched.Stopping)
+		}
+	})
+
+	// Test GetByKey
+	t.Run("GetByKey", func(t *testing.T) {
+		if first.Key == 0 {
+			t.Skip("No status key available")
+		}
+		fetched, err := client.TenantStatus.GetByKey(ctx, int(first.Key))
+		if err != nil {
+			t.Errorf("TenantStatus.GetByKey(%d) failed: %v", int(first.Key), err)
+		} else {
+			t.Logf("TenantStatus.GetByKey succeeded: Tenant=%d, Status=%q", fetched.Tenant, fetched.Status)
+		}
+	})
+
+	prettyPrint(t, "Sample TenantStatus", first)
+}
+
+// TestTenantStatsHistoryShort tests the TenantStatsHistoryShort service.
+func TestTenantStatsHistoryShort(t *testing.T) {
+	client := setupTestClient(t)
+	ctx := context.Background()
+
+	// Get tenants for testing
+	tenants, err := client.Tenants.List(ctx)
+	if err != nil {
+		t.Fatalf("Tenants.List failed: %v", err)
+	}
+	if len(tenants) == 0 {
+		t.Skip("No tenants found - skipping TenantStatsHistoryShort tests")
+	}
+	tenantID := int(tenants[0].Key)
+	t.Logf("Testing with tenant %d (%s)", tenantID, tenants[0].Name)
+
+	t.Run("List", func(t *testing.T) {
+		stats, err := client.TenantStatsHistoryShort.List(ctx, vergeos.WithLimit(5))
+		if err != nil {
+			t.Fatalf("TenantStatsHistoryShort.List failed: %v", err)
+		}
+		t.Logf("Found %d short-term history records (limited to 5)", len(stats))
+
+		if len(stats) > 0 {
+			first := stats[0]
+			t.Logf("First record: Key=%d, Tenant=%d, Timestamp=%d",
+				int(first.Key), first.Tenant, first.Timestamp)
+			t.Logf("Resources: RAMUsed=%d, VRAMUsed=%d, TotalCPU=%d, CoreCount=%d, IPCount=%d",
+				first.RAMUsed, first.VRAMUsed, first.TotalCPU, first.CoreCount, first.IPCount)
+			prettyPrint(t, "Sample TenantStatsHistoryShort", first)
+		}
+	})
+
+	t.Run("ListByTenant", func(t *testing.T) {
+		stats, err := client.TenantStatsHistoryShort.ListByTenant(ctx, tenantID, vergeos.WithLimit(5))
+		if err != nil {
+			t.Fatalf("TenantStatsHistoryShort.ListByTenant(%d) failed: %v", tenantID, err)
+		}
+		t.Logf("Found %d short-term records for tenant %d", len(stats), tenantID)
+	})
+
+	t.Run("GetLatest", func(t *testing.T) {
+		latest, err := client.TenantStatsHistoryShort.GetLatest(ctx, tenantID)
+		if err != nil {
+			if vergeos.IsNotFoundError(err) {
+				t.Logf("No recent stats for tenant %d (this is normal for new/idle tenants)", tenantID)
+			} else {
+				t.Fatalf("TenantStatsHistoryShort.GetLatest(%d) failed: %v", tenantID, err)
+			}
+		} else {
+			t.Logf("Latest stats for tenant %d: Timestamp=%d, RAMUsed=%d, RAMAllocated=%d, RAMPct=%d%%",
+				tenantID, latest.Timestamp, latest.RAMUsed, latest.RAMAllocated, latest.RAMPct)
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		stats, err := client.TenantStatsHistoryShort.List(ctx, vergeos.WithLimit(1))
+		if err != nil || len(stats) == 0 {
+			t.Skip("No stats history records available")
+		}
+
+		first := stats[0]
+		fetched, err := client.TenantStatsHistoryShort.Get(ctx, int(first.Key))
+		if err != nil {
+			t.Fatalf("TenantStatsHistoryShort.Get(%d) failed: %v", int(first.Key), err)
+		}
+		t.Logf("TenantStatsHistoryShort.Get succeeded: Tenant=%d, Timestamp=%d", fetched.Tenant, fetched.Timestamp)
+	})
+}
+
 // TestTenantsCRUD tests Create/Update/Delete operations for Tenant services.
 func TestTenantsCRUD(t *testing.T) {
 	client := setupTestClient(t)

--- a/test/integration/version_test.go
+++ b/test/integration/version_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -48,7 +49,7 @@ func TestVersionEnforcement(t *testing.T) {
 		t.Log("NewClient succeeded - server version check passed (v26 confirmed)")
 
 		// Verify client is functional by making a simple API call
-		version, err := client.System.GetVersion(nil)
+		version, err := client.System.GetVersion(context.Background())
 		if err != nil {
 			t.Fatalf("System.GetVersion failed after successful client creation: %v", err)
 		}

--- a/test/integration/vsan_test.go
+++ b/test/integration/vsan_test.go
@@ -72,7 +72,7 @@ func TestClusterTiers(t *testing.T) {
 
 		first := tiers[0]
 		t.Logf("First cluster tier: Key=%d, Cluster=%d, Tier=%d",
-			int(first.Key), first.Cluster, first.Tier)
+			first.Key.Int(), first.Cluster.Int(), first.Tier)
 
 		if first.Status != nil {
 			t.Logf("Cluster tier status: Status=%q, State=%q, Redundant=%v, Encrypted=%v",
@@ -81,6 +81,25 @@ func TestClusterTiers(t *testing.T) {
 				first.Status.Capacity, first.Status.Used, first.Status.UsedPct,
 				first.Status.Transaction, first.Status.Repairs)
 		}
+
+		// Validate nodes_online and drives_online are populated
+		onlineNodes := first.CountOnlineNodes()
+		onlineDrives := first.CountOnlineDrives()
+		t.Logf("Online counts: Nodes=%d, Drives=%d", onlineNodes, onlineDrives)
+
+		if first.NodesOnline == nil {
+			t.Error("NodesOnline is nil — computed field expression may not be working")
+		}
+		if len(first.DrivesOnline) == 0 {
+			t.Error("DrivesOnline is empty — computed field expression may not be working")
+		}
+		if onlineNodes == 0 {
+			t.Error("CountOnlineNodes returned 0 — expected at least 1 online node")
+		}
+		if onlineDrives == 0 {
+			t.Error("CountOnlineDrives returned 0 — expected at least 1 online drive")
+		}
+
 		prettyPrint(t, "Sample ClusterTier", first)
 	})
 
@@ -105,15 +124,15 @@ func TestClusterTiers(t *testing.T) {
 		}
 
 		first := tiers[0]
-		if first.Cluster == 0 {
+		if first.Cluster.Int() == 0 {
 			t.Skip("Cluster tier has no cluster reference")
 		}
 
-		clusterTiers, err := client.ClusterTiers.ListByCluster(ctx, first.Cluster)
+		clusterTiers, err := client.ClusterTiers.ListByCluster(ctx, first.Cluster.Int())
 		if err != nil {
-			t.Fatalf("ClusterTiers.ListByCluster(%d) failed: %v", first.Cluster, err)
+			t.Fatalf("ClusterTiers.ListByCluster(%d) failed: %v", first.Cluster.Int(), err)
 		}
-		t.Logf("Found %d tiers for cluster %d", len(clusterTiers), first.Cluster)
+		t.Logf("Found %d tiers for cluster %d", len(clusterTiers), first.Cluster.Int())
 	})
 
 	t.Run("GetByClusterAndTier", func(t *testing.T) {
@@ -123,13 +142,13 @@ func TestClusterTiers(t *testing.T) {
 		}
 
 		first := tiers[0]
-		if first.Cluster == 0 {
+		if first.Cluster.Int() == 0 {
 			t.Skip("Cluster tier has no cluster reference")
 		}
 
-		byClusterAndTier, err := client.ClusterTiers.GetByClusterAndTier(ctx, first.Cluster, first.Tier)
+		byClusterAndTier, err := client.ClusterTiers.GetByClusterAndTier(ctx, first.Cluster.Int(), first.Tier)
 		if err != nil {
-			t.Fatalf("ClusterTiers.GetByClusterAndTier(%d, %d) failed: %v", first.Cluster, first.Tier, err)
+			t.Fatalf("ClusterTiers.GetByClusterAndTier(%d, %d) failed: %v", first.Cluster.Int(), first.Tier, err)
 		}
 		t.Logf("ClusterTiers.GetByClusterAndTier succeeded: Key=%d", int(byClusterAndTier.Key))
 	})
@@ -344,13 +363,13 @@ func TestVSANMonitoringMetrics(t *testing.T) {
 		for _, tier := range tiers {
 			if tier.Status != nil {
 				t.Logf("vergeos_cluster_tier_redundant{cluster=\"%d\",tier=\"%d\"} %d",
-					tier.Cluster, tier.Tier, boolToInt(tier.Status.Redundant))
+					tier.Cluster.Int(), tier.Tier, boolToInt(tier.Status.Redundant))
 				t.Logf("vergeos_cluster_tier_encrypted{cluster=\"%d\",tier=\"%d\"} %d",
-					tier.Cluster, tier.Tier, boolToInt(tier.Status.Encrypted))
+					tier.Cluster.Int(), tier.Tier, boolToInt(tier.Status.Encrypted))
 				t.Logf("vergeos_cluster_tier_transaction{cluster=\"%d\",tier=\"%d\"} %d",
-					tier.Cluster, tier.Tier, tier.Status.Transaction)
+					tier.Cluster.Int(), tier.Tier, tier.Status.Transaction)
 				t.Logf("vergeos_cluster_tier_repairs{cluster=\"%d\",tier=\"%d\"} %d",
-					tier.Cluster, tier.Tier, tier.Status.Repairs)
+					tier.Cluster.Int(), tier.Tier, tier.Status.Repairs)
 			}
 		}
 	})

--- a/testhelper_test.go
+++ b/testhelper_test.go
@@ -111,7 +111,7 @@ func initServices(c *Client) {
 }
 
 // jsonResponse writes a JSON response with the given status code.
-func jsonResponse(w http.ResponseWriter, status int, v interface{}) {
+func jsonResponse(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	json.NewEncoder(w).Encode(v)

--- a/testhelper_test.go
+++ b/testhelper_test.go
@@ -1,0 +1,142 @@
+package vergeos
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newTestClient creates a Client pointing at an httptest.Server.
+// The handler receives requests under /api/v4/* for service calls.
+// No version check is performed.
+func newTestClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	c := &Client{
+		baseURL:    server.URL,
+		username:   "test",
+		password:   "test",
+		httpClient: server.Client(),
+		userAgent:  "govergeos-test",
+	}
+	initServices(c)
+	return c
+}
+
+// initServices initialises every service on the client.
+// Mirrors the block in NewClient() so unit tests have access to all services.
+func initServices(c *Client) {
+	c.VMs = &VMService{client: c}
+	c.VMSnapshots = &VMSnapshotService{client: c}
+	c.VMNICs = &VMNICService{client: c}
+	c.VMDrives = &VMDriveService{client: c}
+	c.VMDevices = &VMDeviceService{client: c}
+	c.Networks = &NetworkService{client: c}
+	c.Users = &UserService{client: c}
+	c.Members = &MemberService{client: c}
+	c.CloudInitFiles = &CloudInitService{client: c}
+	c.Clusters = &ClusterService{client: c}
+	c.Nodes = &NodeService{client: c}
+	c.Groups = &GroupService{client: c}
+	c.Files = &FileService{client: c}
+	c.ResourceGroups = &ResourceGroupService{client: c}
+	c.Settings = &SettingsService{client: c}
+	c.System = &SystemService{client: c}
+	c.Schema = &SchemaService{client: c}
+	c.Tags = &TagService{client: c}
+	c.TagCategories = &TagCategoryService{client: c}
+	c.TagMembers = &TagMemberService{client: c}
+	c.Volumes = &VolumeService{client: c}
+	c.VNetRules = &VNetRuleService{client: c}
+	c.VNetRuleAliases = &VNetRuleAliasService{client: c}
+	c.Tenants = &TenantService{client: c}
+	c.TenantNodes = &TenantNodeService{client: c}
+	c.TenantStorage = &TenantStorageService{client: c}
+	c.TenantStatus = &TenantStatusService{client: c}
+	c.TenantStatsHistoryShort = &TenantStatsHistoryShortService{client: c}
+	c.TenantSnapshots = &TenantSnapshotService{client: c}
+	c.TenantLayer2Networks = &TenantLayer2NetworkService{client: c}
+	c.SnapshotProfiles = &SnapshotProfileService{client: c}
+	c.SnapshotProfilePeriods = &SnapshotProfilePeriodService{client: c}
+	c.Alarms = &AlarmService{client: c}
+	c.AlarmTypes = &AlarmTypeService{client: c}
+	c.Tasks = &TaskService{client: c}
+	c.VNetAddresses = &VNetAddressService{client: c}
+	c.VNetDNSViews = &VNetDNSViewService{client: c}
+	c.VNetDNSZones = &VNetDNSZoneService{client: c}
+	c.VNetDNSRecords = &VNetDNSRecordService{client: c}
+	c.VNetHosts = &VNetHostService{client: c}
+	c.VNetWireGuards = &VNetWireGuardService{client: c}
+	c.VNetWireGuardPeers = &VNetWireGuardPeerService{client: c}
+	c.VNetWireGuardPeerStatus = &VNetWireGuardPeerStatusService{client: c}
+	c.Certificates = &CertificateService{client: c}
+	c.VNetIPSecs = &VNetIPSecService{client: c}
+	c.VNetIPSecPhase1s = &VNetIPSecPhase1Service{client: c}
+	c.VNetIPSecPhase2s = &VNetIPSecPhase2Service{client: c}
+	c.VNetIPSecConnections = &VNetIPSecConnectionService{client: c}
+	c.Sites = &SiteService{client: c}
+	c.SiteSyncsIncoming = &SiteSyncIncomingService{client: c}
+	c.SiteSyncsOutgoing = &SiteSyncOutgoingService{client: c}
+	c.SiteSyncProfilePeriods = &SiteSyncProfilePeriodService{client: c}
+	c.CloudSnapshots = &CloudSnapshotService{client: c}
+	c.CloudSnapshotVMs = &CloudSnapshotVMService{client: c}
+	c.CloudSnapshotTenants = &CloudSnapshotTenantService{client: c}
+	c.VolumeCIFSShares = &VolumeCIFSShareService{client: c}
+	c.VolumeNFSShares = &VolumeNFSShareService{client: c}
+	c.VolumeBrowser = &VolumeBrowserService{client: c}
+	c.WebhookURLs = &WebhookURLService{client: c}
+	c.Webhooks = &WebhookService{client: c}
+	c.UserAPIKeys = &UserAPIKeyService{client: c}
+	c.NASServices = &NASServiceService{client: c}
+	c.NASServiceUsers = &NASServiceUserService{client: c}
+	c.VolumeSyncs = &VolumeSyncService{client: c}
+	c.VolumeSnapshots = &VolumeSnapshotService{client: c}
+	c.Permissions = &PermissionService{client: c}
+	c.Logs = &LogService{client: c}
+	c.StorageTiers = &StorageTierService{client: c}
+	c.ClusterTiers = &ClusterTierService{client: c}
+	c.MachineDrivePhys = &MachineDrivePhysService{client: c}
+	c.ClusterStatsHistory = &ClusterStatsHistoryService{client: c}
+	c.MachineStatus = &MachineStatusService{client: c}
+	c.MachineStats = &MachineStatsService{client: c}
+	c.MachineDriveStats = &MachineDriveStatsService{client: c}
+	c.MachineNICs = &MachineNICService{client: c}
+	c.UpdateSettings = &UpdateSettingsService{client: c}
+	c.UpdateBranches = &UpdateBranchService{client: c}
+	c.UpdateSourcePackages = &UpdateSourcePackageService{client: c}
+}
+
+// jsonResponse writes a JSON response with the given status code.
+func jsonResponse(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+// apiMux builds an http.ServeMux with route handlers under /api/v4.
+// Routes are specified as "METHOD /path" keys.
+func apiMux(routes map[string]http.HandlerFunc) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		// Try exact match first
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+		// Try wildcard: match by method + prefix
+		for pattern, h := range routes {
+			parts := strings.SplitN(pattern, " ", 2)
+			if len(parts) == 2 && parts[0] == r.Method && strings.HasPrefix(r.URL.Path, parts[1]) {
+				h(w, r)
+				return
+			}
+		}
+		http.NotFound(w, r)
+	})
+	return mux
+}

--- a/types.go
+++ b/types.go
@@ -47,3 +47,66 @@ func (f FlexInt) MarshalJSON() ([]byte, error) {
 func (f FlexInt) Int() int {
 	return int(f)
 }
+
+// FlexFK is an int that can be unmarshaled from a JSON number, string, or
+// an object with a "$key" or "id" field. This handles VergeOS API responses
+// where foreign key fields may be returned as expanded objects depending on
+// the requested field selection.
+type FlexFK int
+
+// UnmarshalJSON implements json.Unmarshaler for FlexFK.
+func (f *FlexFK) UnmarshalJSON(data []byte) error {
+	// Try int first
+	var i int
+	if err := json.Unmarshal(data, &i); err == nil {
+		*f = FlexFK(i)
+		return nil
+	}
+
+	// Try string (some fields return IDs as strings)
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		if s == "" {
+			*f = 0
+			return nil
+		}
+		i, err := strconv.Atoi(s)
+		if err != nil {
+			return err
+		}
+		*f = FlexFK(i)
+		return nil
+	}
+
+	// Try object with $key or id (expanded FK)
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err == nil {
+		if raw, ok := obj["$key"]; ok {
+			var key int
+			if err := json.Unmarshal(raw, &key); err == nil {
+				*f = FlexFK(key)
+				return nil
+			}
+		}
+		if raw, ok := obj["id"]; ok {
+			var id int
+			if err := json.Unmarshal(raw, &id); err == nil {
+				*f = FlexFK(id)
+				return nil
+			}
+		}
+	}
+
+	*f = 0
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for FlexFK.
+func (f FlexFK) MarshalJSON() ([]byte, error) {
+	return json.Marshal(int(f))
+}
+
+// Int returns the FlexFK as an int.
+func (f FlexFK) Int() int {
+	return int(f)
+}

--- a/types.go
+++ b/types.go
@@ -2,6 +2,7 @@ package vergeos
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 )
 
@@ -33,9 +34,7 @@ func (f *FlexInt) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	// Default to 0
-	*f = 0
-	return nil
+	return fmt.Errorf("vergeos: cannot unmarshal %s into FlexInt", string(data))
 }
 
 // MarshalJSON implements json.Marshaler for FlexInt.
@@ -97,8 +96,7 @@ func (f *FlexFK) UnmarshalJSON(data []byte) error {
 		}
 	}
 
-	*f = 0
-	return nil
+	return fmt.Errorf("vergeos: cannot unmarshal %s into FlexFK", string(data))
 }
 
 // MarshalJSON implements json.Marshaler for FlexFK.

--- a/types_cloud_snapshot.go
+++ b/types_cloud_snapshot.go
@@ -47,7 +47,7 @@ type CloudSnapshotUpdateRequest struct {
 type cloudSnapshotAction struct {
 	CloudSnapshot int                    `json:"cloud_snapshot"`
 	Action        string                 `json:"action"`
-	Params        map[string]interface{} `json:"params,omitempty"`
+	Params        map[string]any `json:"params,omitempty"`
 }
 
 // CloudSnapshotCloneOptions specifies options for cloning a cloud snapshot.

--- a/types_machine_status.go
+++ b/types_machine_status.go
@@ -1,6 +1,7 @@
 package vergeos
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -73,6 +74,13 @@ type GuestInfo struct {
 // UnmarshalJSON handles the VergeOS API inconsistency where network and fsinfo
 // can be either a JSON array or a JSON object (map keyed by string).
 func (g *GuestInfo) UnmarshalJSON(data []byte) error {
+	// The API sends [] (empty array) instead of an object or null when no
+	// guest agent is running. Detect that case and return a zero-value.
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || trimmed[0] == '[' {
+		return nil
+	}
+
 	// Use an alias to avoid infinite recursion.
 	type guestInfoRaw struct {
 		OSInfo      *GuestOSInfo    `json:"osinfo,omitempty"`

--- a/types_network.go
+++ b/types_network.go
@@ -426,7 +426,7 @@ type NetworkUpdateRequest struct {
 type vnetAction struct {
 	VNet   int         `json:"vnet"`
 	Action string      `json:"action"`
-	Params interface{} `json:"params"`
+	Params any `json:"params"`
 }
 
 // networkListFields are the fields to request when listing networks.
@@ -470,7 +470,7 @@ type NetworkQuery struct {
 	// whatsmyip, arp, arp-scan, frr, trace, dhcp_release_renew, wireguard, firewall, nmap, tcp_connect
 	Query string `json:"query,omitempty"`
 	// Params contains query-specific parameters (JSON object).
-	Params map[string]interface{} `json:"params,omitempty"`
+	Params map[string]any `json:"params,omitempty"`
 	// Status is the query status (running, error, complete).
 	Status string `json:"status,omitempty"`
 	// Result is the query output.
@@ -494,7 +494,7 @@ type NetworkQueryRequest struct {
 	// whatsmyip, arp, arp-scan, frr, trace, dhcp_release_renew, wireguard, firewall, nmap, tcp_connect
 	Query string `json:"query"`
 	// Params contains query-specific parameters.
-	Params map[string]interface{} `json:"params,omitempty"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 // NetworkMonitorStats represents network monitoring statistics.

--- a/types_readonly.go
+++ b/types_readonly.go
@@ -241,6 +241,21 @@ type Node struct {
 	// Notes
 	// Note is a free-form note about the node.
 	Note string `json:"note,omitempty"`
+
+	// VMStatsTotals contains per-node aggregate of running VM cores and RAM.
+	// Computed server-side from running VMs on the node.
+	VMStatsTotals *NodeVMStatsTotals `json:"vm_stats_totals,omitempty"`
+}
+
+// NodeVMStatsTotals contains aggregated VM resource usage for a node.
+// Computed server-side from running VMs via:
+//
+//	running_machines[sum(running_cores),sum(running_ram)] as vm_stats_totals
+type NodeVMStatsTotals struct {
+	// RunningCores is the total CPU cores allocated to running VMs on this node.
+	RunningCores int `json:"running_cores,omitempty"`
+	// RunningRAM is the total RAM in MB allocated to running VMs on this node.
+	RunningRAM int `json:"running_ram,omitempty"`
 }
 
 // NodeStatus contains node status information.
@@ -558,7 +573,7 @@ type ClusterUpdateRequest struct {
 const (
 	clusterListFields       = "$key,id,system,name,description,enabled,created,storage,compute,kvm_nested,allow_nested_virt_migration,allow_vgpu_migration,enable_split_lock_detection,recommended_cpu_type,default_cpu,disable_cpu_security_mitigations,spec_store_bypass_disable,disable_smt,disable_sleep,enable_nvme_power_management,x86_energy_perf_policy,scaling_governor,ram_per_unit,cores_per_unit,cost_per_unit,price_per_unit,max_ram_per_vm,max_cores_per_vm,storage_cachesize,storage_buffersize,storage_hugepages,target_ram_pct,ram_overcommit_pct,swap_tier,swap_per_drive,log_filter,max_core_temp,max_core_temp_warn_perc,critical_core_temp"
 	clusterStatusFields     = "cluster,status,status_info,state,last_update,total_nodes,online_nodes,running_machines,total_ram,online_ram,used_ram,total_cores,online_cores,used_cores,phys_ram_used,phys_vram_used,phys_total_cpu"
-	nodeListFields          = "id,name,description,physical,cluster,machine,model,asset_tag,cpu,cpu_speed,cores,iommu,ram,overcommit,vm_ram,failover_ram,yb_version,os_version,kernel_version,appserver_version,vsan_version,qemu_version,vsan_nodeid,vsan_connected,maintenance,need_restart,restart_reason,ipmi_address,ipmi_user,ipmi_status,ipmi_status_info,max_core_temp,max_core_temp_warn_perc,critical_core_temp,pxe_vnet,capture_logs,lldp,note"
+	nodeListFields          = "id,name,description,physical,cluster,machine,model,asset_tag,cpu,cpu_speed,cores,iommu,ram,overcommit,vm_ram,failover_ram,yb_version,os_version,kernel_version,appserver_version,vsan_version,qemu_version,vsan_nodeid,vsan_connected,maintenance,need_restart,restart_reason,ipmi_address,ipmi_user,ipmi_status,ipmi_status_info,max_core_temp,max_core_temp_warn_perc,critical_core_temp,pxe_vnet,capture_logs,lldp,note,running_machines[sum(running_cores),sum(running_ram)] as vm_stats_totals"
 	groupListFields         = "$key,name,description,enabled,type,email,system_group,auth_source,created,creator"
 	fileListFields          = "$key,name,description,type,owner,allocated_bytes,used_bytes,filesize,modified,preferred_tier,url,creator"
 	resourceGroupListFields = "$key,name,description,type,enabled"

--- a/types_readonly_test.go
+++ b/types_readonly_test.go
@@ -1,0 +1,62 @@
+package vergeos
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNode_UnmarshalWithVMStatsTotals(t *testing.T) {
+	data := `{
+		"id": 1,
+		"name": "node1",
+		"cluster": 1,
+		"vm_stats_totals": {
+			"running_cores": 30,
+			"running_ram": 75776
+		}
+	}`
+
+	var node Node
+	if err := json.Unmarshal([]byte(data), &node); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if node.ID != 1 {
+		t.Errorf("ID: expected 1, got %d", node.ID)
+	}
+	if node.Name != "node1" {
+		t.Errorf("Name: expected node1, got %s", node.Name)
+	}
+	if node.VMStatsTotals == nil {
+		t.Fatal("VMStatsTotals is nil")
+	}
+	if node.VMStatsTotals.RunningCores != 30 {
+		t.Errorf("RunningCores: expected 30, got %d", node.VMStatsTotals.RunningCores)
+	}
+	if node.VMStatsTotals.RunningRAM != 75776 {
+		t.Errorf("RunningRAM: expected 75776, got %d", node.VMStatsTotals.RunningRAM)
+	}
+}
+
+func TestNode_UnmarshalWithoutVMStatsTotals(t *testing.T) {
+	data := `{"id": 1, "name": "node1"}`
+
+	var node Node
+	if err := json.Unmarshal([]byte(data), &node); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if node.VMStatsTotals != nil {
+		t.Errorf("VMStatsTotals: expected nil, got %+v", node.VMStatsTotals)
+	}
+}
+
+func TestNodeListFields_ContainsVMStatsTotals(t *testing.T) {
+	if !strings.Contains(nodeListFields, "vm_stats_totals") {
+		t.Error("nodeListFields missing vm_stats_totals expression")
+	}
+	if !strings.Contains(nodeListFields, "running_machines[sum(running_cores),sum(running_ram)]") {
+		t.Error("nodeListFields missing running_machines aggregate expression")
+	}
+}

--- a/types_site.go
+++ b/types_site.go
@@ -102,7 +102,7 @@ type SiteUpdateRequest struct {
 type siteAction struct {
 	Site   int                    `json:"site"`
 	Action string                 `json:"action"`
-	Params map[string]interface{} `json:"params,omitempty"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 // Site configuration options for sync direction
@@ -194,7 +194,7 @@ type SiteSyncIncomingUpdateRequest struct {
 type siteSyncIncomingAction struct {
 	SiteSyncIncoming int                    `json:"site_syncs_incoming"`
 	Action           string                 `json:"action"`
-	Params           map[string]interface{} `json:"params,omitempty"`
+	Params           map[string]any `json:"params,omitempty"`
 }
 
 // Incoming sync status values
@@ -291,7 +291,7 @@ type SiteSyncOutgoingUpdateRequest struct {
 type siteSyncOutgoingAction struct {
 	SiteSyncOutgoing int                    `json:"site_syncs_outgoing"`
 	Action           string                 `json:"action"`
-	Params           map[string]interface{} `json:"params,omitempty"`
+	Params           map[string]any `json:"params,omitempty"`
 }
 
 // Outgoing sync status values

--- a/types_task.go
+++ b/types_task.go
@@ -77,7 +77,7 @@ type TaskUpdateRequest struct {
 // TaskExecuteOptions are options for executing a task.
 type TaskExecuteOptions struct {
 	// Params are optional parameters to pass to the task action.
-	Params map[string]interface{} `json:"params,omitempty"`
+	Params map[string]any `json:"params,omitempty"`
 }
 
 // taskListFields are the fields to request when listing tasks.

--- a/types_tenant.go
+++ b/types_tenant.go
@@ -252,3 +252,146 @@ const tenantStorageListFields = "$key,tenant,tier,provisioned,used,allocated,use
 
 // tenantStorageGetFields are the fields to request when getting a single storage allocation.
 const tenantStorageGetFields = tenantStorageListFields
+
+// TenantStatus contains tenant runtime status information.
+// Each tenant has exactly one status record, accessed via the /tenant_status endpoint.
+type TenantStatus struct {
+	// Key is the status row key.
+	Key FlexInt `json:"$key,omitempty"`
+	// Tenant is the parent tenant ID.
+	Tenant int `json:"tenant,omitempty"`
+	// Running indicates whether the tenant is currently running.
+	Running bool `json:"running"`
+	// Starting indicates whether the tenant is currently starting.
+	Starting bool `json:"starting"`
+	// Stopping indicates whether the tenant is currently stopping.
+	Stopping bool `json:"stopping"`
+	// Migrating indicates whether the tenant is currently migrating.
+	Migrating bool `json:"migrating"`
+	// Started is the timestamp when the tenant was started (Unix epoch).
+	Started int64 `json:"started,omitempty"`
+	// Stopped is the timestamp when the tenant was stopped (Unix epoch).
+	Stopped int64 `json:"stopped,omitempty"`
+	// Status is the tenant status string.
+	// Valid values: "online", "starting", "migrating", "errormigrating", "reduced",
+	// "error", "nodesoffline", "stopping", "offline", "provisioning", "restarting"
+	Status string `json:"status,omitempty"`
+	// State is the simplified state (online, offline, warning, error).
+	State string `json:"state,omitempty"`
+	// LastUpdate is the timestamp of the last status update (Unix epoch).
+	LastUpdate int64 `json:"last_update,omitempty"`
+}
+
+// tenantStatusListFields are the fields to request when listing tenant statuses.
+const tenantStatusListFields = "$key,tenant,running,starting,stopping,migrating,started,stopped,status,state,last_update"
+
+// tenantStatusGetFields are the fields to request when getting a single tenant status.
+const tenantStatusGetFields = tenantStatusListFields
+
+// TenantStatsHistoryShort contains short-term historical statistics for a tenant.
+// These are high-resolution time-series records that auto-expire based on system settings.
+type TenantStatsHistoryShort struct {
+	// Key is the unique identifier for this record.
+	Key FlexInt `json:"$key,omitempty"`
+	// Tenant is the parent tenant ID.
+	Tenant int `json:"tenant,omitempty"`
+	// Timestamp is the record timestamp (Unix epoch).
+	Timestamp uint32 `json:"timestamp,omitempty"`
+
+	// RAM metrics
+	// RAMUsed is the RAM currently used in MB.
+	RAMUsed uint32 `json:"ram_used,omitempty"`
+	// VRAMUsed is the virtual RAM currently used in MB.
+	VRAMUsed uint32 `json:"vram_used,omitempty"`
+	// RAMAllocated is the RAM allocated in MB.
+	RAMAllocated uint32 `json:"ram_allocated,omitempty"`
+	// RAMPct is the RAM usage percentage.
+	RAMPct uint32 `json:"ram_pct,omitempty"`
+
+	// CPU metrics
+	// TotalCPU is the total CPU usage.
+	TotalCPU uint32 `json:"total_cpu,omitempty"`
+	// CoreCount is the number of CPU cores.
+	CoreCount uint32 `json:"core_count,omitempty"`
+
+	// Network metrics
+	// IPCount is the number of IP addresses.
+	IPCount uint32 `json:"ip_count,omitempty"`
+
+	// Storage tier 0 metrics
+	// Tier0Provisioned is the provisioned storage for tier 0 in bytes.
+	Tier0Provisioned uint64 `json:"tier0_provisioned,omitempty"`
+	// Tier0Used is the used storage for tier 0 in bytes.
+	Tier0Used uint64 `json:"tier0_used,omitempty"`
+	// Tier0Pct is the tier 0 usage percentage.
+	Tier0Pct uint32 `json:"tier0_pct,omitempty"`
+	// Tier0Allocated is the allocated storage for tier 0 in bytes.
+	Tier0Allocated uint64 `json:"tier0_allocated,omitempty"`
+
+	// Storage tier 1 metrics
+	// Tier1Provisioned is the provisioned storage for tier 1 in bytes.
+	Tier1Provisioned uint64 `json:"tier1_provisioned,omitempty"`
+	// Tier1Used is the used storage for tier 1 in bytes.
+	Tier1Used uint64 `json:"tier1_used,omitempty"`
+	// Tier1Pct is the tier 1 usage percentage.
+	Tier1Pct uint32 `json:"tier1_pct,omitempty"`
+	// Tier1Allocated is the allocated storage for tier 1 in bytes.
+	Tier1Allocated uint64 `json:"tier1_allocated,omitempty"`
+
+	// Storage tier 2 metrics
+	// Tier2Provisioned is the provisioned storage for tier 2 in bytes.
+	Tier2Provisioned uint64 `json:"tier2_provisioned,omitempty"`
+	// Tier2Used is the used storage for tier 2 in bytes.
+	Tier2Used uint64 `json:"tier2_used,omitempty"`
+	// Tier2Pct is the tier 2 usage percentage.
+	Tier2Pct uint32 `json:"tier2_pct,omitempty"`
+	// Tier2Allocated is the allocated storage for tier 2 in bytes.
+	Tier2Allocated uint64 `json:"tier2_allocated,omitempty"`
+
+	// Storage tier 3 metrics
+	// Tier3Provisioned is the provisioned storage for tier 3 in bytes.
+	Tier3Provisioned uint64 `json:"tier3_provisioned,omitempty"`
+	// Tier3Used is the used storage for tier 3 in bytes.
+	Tier3Used uint64 `json:"tier3_used,omitempty"`
+	// Tier3Pct is the tier 3 usage percentage.
+	Tier3Pct uint32 `json:"tier3_pct,omitempty"`
+	// Tier3Allocated is the allocated storage for tier 3 in bytes.
+	Tier3Allocated uint64 `json:"tier3_allocated,omitempty"`
+
+	// Storage tier 4 metrics
+	// Tier4Provisioned is the provisioned storage for tier 4 in bytes.
+	Tier4Provisioned uint64 `json:"tier4_provisioned,omitempty"`
+	// Tier4Used is the used storage for tier 4 in bytes.
+	Tier4Used uint64 `json:"tier4_used,omitempty"`
+	// Tier4Pct is the tier 4 usage percentage.
+	Tier4Pct uint32 `json:"tier4_pct,omitempty"`
+	// Tier4Allocated is the allocated storage for tier 4 in bytes.
+	Tier4Allocated uint64 `json:"tier4_allocated,omitempty"`
+
+	// Storage tier 5 metrics
+	// Tier5Provisioned is the provisioned storage for tier 5 in bytes.
+	Tier5Provisioned uint64 `json:"tier5_provisioned,omitempty"`
+	// Tier5Used is the used storage for tier 5 in bytes.
+	Tier5Used uint64 `json:"tier5_used,omitempty"`
+	// Tier5Pct is the tier 5 usage percentage.
+	Tier5Pct uint32 `json:"tier5_pct,omitempty"`
+	// Tier5Allocated is the allocated storage for tier 5 in bytes.
+	Tier5Allocated uint64 `json:"tier5_allocated,omitempty"`
+
+	// GPU metrics
+	// VGPUsUsed is the number of vGPUs in use.
+	VGPUsUsed uint16 `json:"vgpus_used,omitempty"`
+	// GPUsUsed is the number of physical GPUs in use.
+	GPUsUsed uint16 `json:"gpus_used,omitempty"`
+	// VGPUsTotal is the total number of vGPUs available.
+	VGPUsTotal uint16 `json:"vgpus_total,omitempty"`
+	// GPUsTotal is the total number of physical GPUs available.
+	GPUsTotal uint16 `json:"gpus_total,omitempty"`
+	// VGPUsPct is the vGPU usage percentage.
+	VGPUsPct uint16 `json:"vgpus_pct,omitempty"`
+	// GPUsPct is the GPU usage percentage.
+	GPUsPct uint16 `json:"gpus_pct,omitempty"`
+}
+
+// tenantStatsHistoryShortFields lists all fields for tenant stats history short queries.
+const tenantStatsHistoryShortFields = "$key,tenant,timestamp,ram_used,vram_used,total_cpu,core_count,ip_count,ram_allocated,ram_pct,tier0_provisioned,tier0_used,tier0_pct,tier0_allocated,tier1_provisioned,tier1_used,tier1_pct,tier1_allocated,tier2_provisioned,tier2_used,tier2_pct,tier2_allocated,tier3_provisioned,tier3_used,tier3_pct,tier3_allocated,tier4_provisioned,tier4_used,tier4_pct,tier4_allocated,tier5_provisioned,tier5_used,tier5_pct,tier5_allocated,vgpus_used,gpus_used,vgpus_total,gpus_total,vgpus_pct,gpus_pct"

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,102 @@
+package vergeos
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFlexFK_UnmarshalJSON_Int(t *testing.T) {
+	var f FlexFK
+	if err := json.Unmarshal([]byte(`42`), &f); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Int() != 42 {
+		t.Errorf("expected 42, got %d", f.Int())
+	}
+}
+
+func TestFlexFK_UnmarshalJSON_String(t *testing.T) {
+	var f FlexFK
+	if err := json.Unmarshal([]byte(`"99"`), &f); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Int() != 99 {
+		t.Errorf("expected 99, got %d", f.Int())
+	}
+}
+
+func TestFlexFK_UnmarshalJSON_EmptyString(t *testing.T) {
+	var f FlexFK
+	if err := json.Unmarshal([]byte(`""`), &f); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Int() != 0 {
+		t.Errorf("expected 0, got %d", f.Int())
+	}
+}
+
+func TestFlexFK_UnmarshalJSON_ObjectWithKey(t *testing.T) {
+	var f FlexFK
+	if err := json.Unmarshal([]byte(`{"$key": 5, "name": "Prod"}`), &f); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Int() != 5 {
+		t.Errorf("expected 5, got %d", f.Int())
+	}
+}
+
+func TestFlexFK_UnmarshalJSON_ObjectWithID(t *testing.T) {
+	var f FlexFK
+	if err := json.Unmarshal([]byte(`{"id": 7, "name": "node1"}`), &f); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Int() != 7 {
+		t.Errorf("expected 7, got %d", f.Int())
+	}
+}
+
+func TestFlexFK_UnmarshalJSON_Null(t *testing.T) {
+	var f FlexFK
+	if err := json.Unmarshal([]byte(`null`), &f); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Int() != 0 {
+		t.Errorf("expected 0, got %d", f.Int())
+	}
+}
+
+func TestFlexFK_MarshalJSON(t *testing.T) {
+	f := FlexFK(42)
+	data, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != "42" {
+		t.Errorf("expected \"42\", got %s", string(data))
+	}
+}
+
+func TestFlexFK_InStruct(t *testing.T) {
+	type row struct {
+		Key     FlexInt `json:"$key"`
+		Cluster FlexFK  `json:"cluster"`
+	}
+
+	// Scalar FK
+	var r1 row
+	if err := json.Unmarshal([]byte(`{"$key": 1, "cluster": 3}`), &r1); err != nil {
+		t.Fatalf("scalar: %v", err)
+	}
+	if r1.Cluster.Int() != 3 {
+		t.Errorf("scalar: expected 3, got %d", r1.Cluster.Int())
+	}
+
+	// Expanded FK
+	var r2 row
+	if err := json.Unmarshal([]byte(`{"$key": 1, "cluster": {"$key": 3, "name": "Prod"}}`), &r2); err != nil {
+		t.Fatalf("expanded: %v", err)
+	}
+	if r2.Cluster.Int() != 3 {
+		t.Errorf("expanded: expected 3, got %d", r2.Cluster.Int())
+	}
+}

--- a/types_vsan.go
+++ b/types_vsan.go
@@ -53,8 +53,9 @@ type StorageTierStats struct {
 type ClusterTier struct {
 	// Key is the unique identifier for the cluster tier record.
 	Key FlexInt `json:"$key,omitempty"`
-	// Cluster is the parent cluster ID.
-	Cluster int `json:"cluster,omitempty"`
+	// Cluster is the parent cluster ID. Uses FlexFK to handle FK expansion
+	// when callers request fields that cause the API to return an object.
+	Cluster FlexFK `json:"cluster,omitempty"`
 	// Tier is the tier number (0-5).
 	Tier int `json:"tier,omitempty"`
 	// Description is the tier description.
@@ -68,12 +69,10 @@ type ClusterTier struct {
 	// Stats contains the tier statistics.
 	Stats *ClusterTierStats `json:"stats,omitempty"`
 	// NodesOnline contains the list of node states for this tier.
-	// Only populated when the API returns these nested objects (e.g., fields=all).
-	// Note: fields=all also expands FK fields like Cluster to objects, which may
-	// require custom deserialization. Not included in default field list.
+	// Populated by default via computed field expression.
 	NodesOnline *ClusterTierNodesOnline `json:"nodes_online,omitempty"`
 	// DrivesOnline contains the list of drive states for this tier.
-	// Only populated when the API returns these nested objects (e.g., fields=all).
+	// Populated by default via computed field expression.
 	DrivesOnline []ClusterTierDriveState `json:"drives_online,omitempty"`
 }
 
@@ -371,7 +370,8 @@ const (
 	storageTierListFields = "$key,tier,description,capacity,used,allocated,used_inflated,dedupe_ratio,used_pct,modified,stats[reads,writes,read_bytes,write_bytes,rops,wops,rbps,wbps]"
 
 	// clusterTierListFields lists all fields for cluster tier queries.
-	clusterTierListFields = "$key,cluster,tier,description,cost_per_gb,price_per_gb,status[tier,status,state,capacity,used,used_pct,allocated,redundant,encrypted,working,last_walk_time_ms,last_fullwalk_time_ms,transaction,repairs,bad_drives,fullwalk,progress,index_unique,state_timestamp,cur_space_throttle_ms,transaction_start_stamp],stats[reads,writes,read_bytes,write_bytes,rops,wops,rbps,wbps]"
+	// Includes computed field expressions for online node/drive counts.
+	clusterTierListFields = "$key,cluster,tier,description,cost_per_gb,price_per_gb,status[tier,status,state,capacity,used,used_pct,allocated,redundant,encrypted,working,last_walk_time_ms,last_fullwalk_time_ms,transaction,repairs,bad_drives,fullwalk,progress,index_unique,state_timestamp,cur_space_throttle_ms,transaction_start_stamp],stats[reads,writes,read_bytes,write_bytes,rops,wops,rbps,wbps],vsan_drives[parent_drive#status#state as state] ? state eq 'online' as drives_online,cluster[nodes[machine#status#state as state] ? state eq 'online'] as nodes_online"
 
 	// machineDrivePhysListFields lists all fields for machine drive physical status queries.
 	machineDrivePhysListFields = "$key,parent_drive,path,all_paths,modified,size,model,fw,serial,temp,temp_warn,encrypted,realloc_sectors,realloc_sectors_warn,wear_level,wear_level_warn,hours,hours_warn,current_pending_sector,current_pending_sector_warn,offline_uncorrectable,offline_uncorrectable_warn,smart,vsan_driveid,vsan_tier,vsan_used,vsan_max,vsan_read_errors,vsan_write_errors,vsan_avg_latency,vsan_max_latency,vsan_repairing,vsan_repair_estimate,vsan_last_error,vsan_throttle,vsan_path,vsan_online_since,spare,swap,swap_size,boot,boot_size,ybpart,ybpart_size,encryption_key,enclosure_slot,locate_status,location,bus,parent_drive#machine#name as node_display,parent_drive#status#status as statuslist"

--- a/types_vsan_test.go
+++ b/types_vsan_test.go
@@ -1,0 +1,111 @@
+package vergeos
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestClusterTier_UnmarshalWithOnlineFields(t *testing.T) {
+	data := `{
+		"$key": 1,
+		"cluster": 1,
+		"tier": 0,
+		"drives_online": [
+			{"state": "online"},
+			{"state": "online"},
+			{"state": "online"}
+		],
+		"nodes_online": {
+			"nodes": [
+				{"state": "online"},
+				{"state": "online"}
+			]
+		}
+	}`
+
+	var ct ClusterTier
+	if err := json.Unmarshal([]byte(data), &ct); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if ct.Key.Int() != 1 {
+		t.Errorf("Key: expected 1, got %d", ct.Key.Int())
+	}
+	if ct.Cluster.Int() != 1 {
+		t.Errorf("Cluster: expected 1, got %d", ct.Cluster.Int())
+	}
+	if ct.CountOnlineDrives() != 3 {
+		t.Errorf("CountOnlineDrives: expected 3, got %d", ct.CountOnlineDrives())
+	}
+	if ct.CountOnlineNodes() != 2 {
+		t.Errorf("CountOnlineNodes: expected 2, got %d", ct.CountOnlineNodes())
+	}
+}
+
+func TestClusterTier_UnmarshalWithExpandedClusterFK(t *testing.T) {
+	data := `{
+		"$key": 1,
+		"cluster": {"$key": 3, "name": "Prod"},
+		"tier": 0,
+		"drives_online": [{"state": "online"}],
+		"nodes_online": {"nodes": [{"state": "online"}]}
+	}`
+
+	var ct ClusterTier
+	if err := json.Unmarshal([]byte(data), &ct); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if ct.Cluster.Int() != 3 {
+		t.Errorf("Cluster: expected 3, got %d", ct.Cluster.Int())
+	}
+}
+
+func TestClusterTier_EmptyOnlineFields(t *testing.T) {
+	data := `{"$key": 1, "cluster": 1, "tier": 0}`
+
+	var ct ClusterTier
+	if err := json.Unmarshal([]byte(data), &ct); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if ct.CountOnlineNodes() != 0 {
+		t.Errorf("CountOnlineNodes: expected 0, got %d", ct.CountOnlineNodes())
+	}
+	if ct.CountOnlineDrives() != 0 {
+		t.Errorf("CountOnlineDrives: expected 0, got %d", ct.CountOnlineDrives())
+	}
+}
+
+func TestClusterTier_MixedDriveStates(t *testing.T) {
+	data := `{
+		"$key": 1,
+		"cluster": 1,
+		"tier": 0,
+		"drives_online": [
+			{"state": "online"},
+			{"state": "offline"},
+			{"state": "online"},
+			{"state": "repairing"}
+		]
+	}`
+
+	var ct ClusterTier
+	if err := json.Unmarshal([]byte(data), &ct); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if ct.CountOnlineDrives() != 2 {
+		t.Errorf("CountOnlineDrives: expected 2, got %d", ct.CountOnlineDrives())
+	}
+}
+
+func TestClusterTierListFields_ContainsOnlineExpressions(t *testing.T) {
+	if !strings.Contains(clusterTierListFields, "drives_online") {
+		t.Error("clusterTierListFields missing drives_online expression")
+	}
+	if !strings.Contains(clusterTierListFields, "nodes_online") {
+		t.Error("clusterTierListFields missing nodes_online expression")
+	}
+}

--- a/update_test.go
+++ b/update_test.go
@@ -1,0 +1,178 @@
+package vergeos
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// UpdateSettings tests
+
+func TestUpdateSettingsService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/update_settings/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, UpdateSettings{
+				Key:        1,
+				Source:     1,
+				Branch:     2,
+				BranchName: "stable-4.13",
+				AutoUpdate: true,
+			})
+		},
+	}))
+
+	settings, err := client.UpdateSettings.Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if settings.BranchName != "stable-4.13" {
+		t.Errorf("expected branch name 'stable-4.13', got %q", settings.BranchName)
+	}
+	if !settings.AutoUpdate {
+		t.Error("expected auto_update to be true")
+	}
+	if settings.Branch != 2 {
+		t.Errorf("expected branch 2, got %d", settings.Branch)
+	}
+}
+
+// UpdateBranch tests
+
+func TestUpdateBranchService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/update_branches": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []UpdateBranch{
+				{Key: 1, Name: "stable-4.13", Description: "Stable release"},
+				{Key: 2, Name: "beta-4.14", Description: "Beta release"},
+			})
+		},
+	}))
+
+	branches, err := client.UpdateBranches.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(branches) != 2 {
+		t.Fatalf("expected 2 branches, got %d", len(branches))
+	}
+	if branches[0].Name != "stable-4.13" {
+		t.Errorf("expected name 'stable-4.13', got %q", branches[0].Name)
+	}
+}
+
+func TestUpdateBranchService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/update_branches/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, UpdateBranch{Key: 1, Name: "stable-4.13", Description: "Stable release"})
+		},
+	}))
+
+	branch, err := client.UpdateBranches.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if branch.Name != "stable-4.13" {
+		t.Errorf("expected name 'stable-4.13', got %q", branch.Name)
+	}
+	if branch.Description != "Stable release" {
+		t.Errorf("expected description 'Stable release', got %q", branch.Description)
+	}
+}
+
+func TestUpdateBranchService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/update_branches/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.UpdateBranches.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// UpdateSourcePackage tests
+
+func TestUpdateSourcePackageService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/update_source_packages": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []UpdateSourcePackage{
+				{Key: 1, Name: "ybos", Version: "4.13.1", Branch: 1, Source: 1, Downloaded: true},
+				{Key: 2, Name: "ybos-ui", Version: "4.13.1", Branch: 1, Source: 1, Downloaded: false},
+			})
+		},
+	}))
+
+	packages, err := client.UpdateSourcePackages.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(packages) != 2 {
+		t.Fatalf("expected 2 packages, got %d", len(packages))
+	}
+	if packages[0].Name != "ybos" {
+		t.Errorf("expected name 'ybos', got %q", packages[0].Name)
+	}
+	if !packages[0].Downloaded {
+		t.Error("expected first package to be downloaded")
+	}
+}
+
+func TestUpdateSourcePackageService_ListByBranchAndSource(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/update_source_packages": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "branch eq 1 and source eq 2" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []UpdateSourcePackage{{Key: 1, Name: "ybos", Branch: 1, Source: 2}})
+		},
+	}))
+
+	packages, err := client.UpdateSourcePackages.ListByBranchAndSource(context.Background(), 1, 2)
+	if err != nil {
+		t.Fatalf("ListByBranchAndSource failed: %v", err)
+	}
+	if len(packages) != 1 {
+		t.Fatalf("expected 1 package, got %d", len(packages))
+	}
+}
+
+func TestUpdateSourcePackageService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/update_source_packages/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, UpdateSourcePackage{Key: 1, Name: "ybos", Version: "4.13.1", Downloaded: true})
+		},
+	}))
+
+	pkg, err := client.UpdateSourcePackages.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if pkg.Name != "ybos" {
+		t.Errorf("expected name 'ybos', got %q", pkg.Name)
+	}
+	if pkg.Version != "4.13.1" {
+		t.Errorf("expected version '4.13.1', got %q", pkg.Version)
+	}
+}
+
+func TestUpdateSourcePackageService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/update_source_packages/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.UpdateSourcePackages.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/user.go
+++ b/user.go
@@ -62,7 +62,7 @@ func (s *UserService) Get(ctx context.Context, id int) (*User, error) {
 
 // GetByName returns a user by username.
 func (s *UserService) GetByName(ctx context.Context, name string) (*User, error) {
-	users, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	users, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/user.go
+++ b/user.go
@@ -127,7 +127,7 @@ func (s *UserService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/users/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "User", ID: id}
 		}
 		return err
 	}

--- a/user.go
+++ b/user.go
@@ -16,7 +16,7 @@ const (
 type userAction struct {
 	User   int         `json:"user"`
 	Action string      `json:"action"`
-	Params interface{} `json:"params"`
+	Params any `json:"params"`
 }
 
 // UserService handles user operations.

--- a/user_test.go
+++ b/user_test.go
@@ -1,0 +1,300 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestUserService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/users": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []User{
+				{Key: 1, Name: "admin", Enabled: true},
+				{Key: 2, Name: "operator", Enabled: true},
+			})
+		},
+	}))
+
+	users, err := client.Users.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(users))
+	}
+	if users[0].Name != "admin" {
+		t.Errorf("expected name 'admin', got %q", users[0].Name)
+	}
+}
+
+func TestUserService_List_WithFilter(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/users": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter parameter")
+			}
+			jsonResponse(w, 200, []User{{Key: 1, Name: "admin", Enabled: true}})
+		},
+	}))
+
+	users, err := client.Users.List(context.Background(), WithFilter("enabled eq true"))
+	if err != nil {
+		t.Fatalf("List with filter failed: %v", err)
+	}
+	if len(users) != 1 {
+		t.Fatalf("expected 1 user, got %d", len(users))
+	}
+}
+
+func TestUserService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/users/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, User{Key: 1, Name: "admin", Email: "admin@example.com", Enabled: true})
+		},
+	}))
+
+	user, err := client.Users.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if user.Name != "admin" {
+		t.Errorf("expected name 'admin', got %q", user.Name)
+	}
+	if user.Email != "admin@example.com" {
+		t.Errorf("expected email 'admin@example.com', got %q", user.Email)
+	}
+}
+
+func TestUserService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/users/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Users.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestUserService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/users": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "name eq 'admin'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []User{{Key: 1, Name: "admin"}})
+		},
+	}))
+
+	user, err := client.Users.GetByName(context.Background(), "admin")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if user.Name != "admin" {
+		t.Errorf("expected name 'admin', got %q", user.Name)
+	}
+}
+
+func TestUserService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/users": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []User{})
+		},
+	}))
+
+	_, err := client.Users.GetByName(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestUserService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/users": func(w http.ResponseWriter, r *http.Request) {
+			var req UserCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "newuser" {
+				t.Errorf("expected name 'newuser', got %q", req.Name)
+			}
+			if req.Enabled == nil || !*req.Enabled {
+				t.Error("expected enabled to default to true")
+			}
+			jsonResponse(w, 200, apiResponse{Key: float64(3)})
+		},
+		"GET /api/v4/users/3": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, User{Key: 3, Name: "newuser", Enabled: true})
+		},
+	}))
+
+	user, err := client.Users.Create(context.Background(), &UserCreateRequest{
+		Name: "newuser",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if user.Name != "newuser" {
+		t.Errorf("expected name 'newuser', got %q", user.Name)
+	}
+	if int(user.Key) != 3 {
+		t.Errorf("expected key 3, got %d", int(user.Key))
+	}
+}
+
+func TestUserService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Users.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestUserService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Users.Create(context.Background(), &UserCreateRequest{})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestUserService_Update(t *testing.T) {
+	newEmail := "updated@example.com"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/users/1": func(w http.ResponseWriter, r *http.Request) {
+			var req UserUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Email == nil || *req.Email != newEmail {
+				t.Errorf("expected email %q, got %v", newEmail, req.Email)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/users/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, User{Key: 1, Name: "admin", Email: newEmail})
+		},
+	}))
+
+	user, err := client.Users.Update(context.Background(), 1, &UserUpdateRequest{Email: &newEmail})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if user.Email != newEmail {
+		t.Errorf("expected email %q, got %q", newEmail, user.Email)
+	}
+}
+
+func TestUserService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Users.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestUserService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/users/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	name := "updated"
+	_, err := client.Users.Update(context.Background(), 999, &UserUpdateRequest{Name: &name})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestUserService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/users/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Users.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestUserService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/users/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	// Delete of already-deleted resource returns nil
+	err := client.Users.Delete(context.Background(), 999)
+	if err != nil {
+		t.Fatalf("expected nil for already-deleted user, got %v", err)
+	}
+}
+
+func TestUserService_Enable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/user_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body userAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.User != 1 {
+				t.Errorf("expected user 1, got %d", body.User)
+			}
+			if body.Action != "enable" {
+				t.Errorf("expected action 'enable', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Users.Enable(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Enable failed: %v", err)
+	}
+}
+
+func TestUserService_Disable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/user_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body userAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.User != 2 {
+				t.Errorf("expected user 2, got %d", body.User)
+			}
+			if body.Action != "disable" {
+				t.Errorf("expected action 'disable', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Users.Disable(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("Disable failed: %v", err)
+	}
+}

--- a/user_test.go
+++ b/user_test.go
@@ -250,10 +250,13 @@ func TestUserService_Delete_NotFound(t *testing.T) {
 		},
 	}))
 
-	// Delete of already-deleted resource returns nil
+	// Delete of non-existent resource returns NotFoundError
 	err := client.Users.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("expected nil for already-deleted user, got %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted user")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }
 

--- a/version.go
+++ b/version.go
@@ -35,17 +35,21 @@ type versionResponse struct {
 
 // parseVersion extracts major version from version string.
 // Handles formats: "26.0.0", "v26.0.0", "26.0.0-beta1"
-func parseVersion(v string) (major int) {
+func parseVersion(v string) (int, error) {
 	v = strings.TrimPrefix(v, "v")
 	// Handle dash-suffixed versions like "26.0.0-beta1"
 	if idx := strings.Index(v, "-"); idx != -1 {
 		v = v[:idx]
 	}
 	parts := strings.Split(v, ".")
-	if len(parts) >= 1 {
-		major, _ = strconv.Atoi(parts[0])
+	if len(parts) == 0 || parts[0] == "" {
+		return 0, fmt.Errorf("empty version string")
 	}
-	return
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, fmt.Errorf("invalid major version %q: %w", parts[0], err)
+	}
+	return major, nil
 }
 
 // checkServerVersion fetches /version.json and validates the server is v26.
@@ -56,7 +60,10 @@ func (c *Client) checkServerVersion(ctx context.Context) error {
 		return fmt.Errorf("failed to check server version: %w", err)
 	}
 
-	major := parseVersion(resp.Version)
+	major, err := parseVersion(resp.Version)
+	if err != nil {
+		return fmt.Errorf("failed to parse server version %q: %w", resp.Version, err)
+	}
 	if major != RequiredMajorVersion {
 		return &UnsupportedVersionError{
 			ServerVersion: resp.Version,

--- a/version_test.go
+++ b/version_test.go
@@ -7,23 +7,33 @@ import (
 
 func TestParseVersion(t *testing.T) {
 	tests := []struct {
-		input string
-		major int
+		input   string
+		major   int
+		wantErr bool
 	}{
-		{"26.0.0", 26},
-		{"v26.1.2", 26},
-		{"26.0.0-beta1", 26},
-		{"4.2.0", 4},
-		{"4", 4},
-		{"", 0},
-		{"v4.2.0", 4},
-		{"26.1.3-rc1", 26},
-		{"v", 0},
-		{"abc", 0},
+		{"26.0.0", 26, false},
+		{"v26.1.2", 26, false},
+		{"26.0.0-beta1", 26, false},
+		{"4.2.0", 4, false},
+		{"4", 4, false},
+		{"v4.2.0", 4, false},
+		{"26.1.3-rc1", 26, false},
+		{"", 0, true},
+		{"v", 0, true},
+		{"abc", 0, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			major := parseVersion(tt.input)
+			major, err := parseVersion(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseVersion(%q) expected error, got %d", tt.input, major)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseVersion(%q) unexpected error: %v", tt.input, err)
+			}
 			if major != tt.major {
 				t.Errorf("parseVersion(%q) = %d, want %d", tt.input, major, tt.major)
 			}

--- a/vm.go
+++ b/vm.go
@@ -193,12 +193,6 @@ func (s *VMService) waitForPowerState(ctx context.Context, id int, desiredState 
 	}
 
 	for i := 0; i < powerStateMaxRetries; i++ {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(powerStatePollInterval):
-		}
-
 		vm, err := s.Get(ctx, id)
 		if err != nil {
 			return err
@@ -206,6 +200,12 @@ func (s *VMService) waitForPowerState(ctx context.Context, id int, desiredState 
 
 		if vm.PowerState == desiredState {
 			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(powerStatePollInterval):
 		}
 	}
 

--- a/vm.go
+++ b/vm.go
@@ -264,7 +264,7 @@ type VMCloneOptions struct {
 
 // Clone creates a copy of a VM.
 func (s *VMService) Clone(ctx context.Context, id int, opts *VMCloneOptions) error {
-	params := map[string]interface{}{}
+	params := map[string]any{}
 	if opts != nil {
 		if opts.Name != "" {
 			params["name"] = opts.Name
@@ -275,7 +275,7 @@ func (s *VMService) Clone(ctx context.Context, id int, opts *VMCloneOptions) err
 	action := struct {
 		VM     int                    `json:"vm"`
 		Action string                 `json:"action"`
-		Params map[string]interface{} `json:"params"`
+		Params map[string]any `json:"params"`
 	}{
 		VM:     id,
 		Action: vmActionClone,
@@ -298,7 +298,7 @@ type VMSnapshotOptions struct {
 
 // Snapshot takes a snapshot of a VM.
 func (s *VMService) Snapshot(ctx context.Context, id int, opts *VMSnapshotOptions) error {
-	params := map[string]interface{}{}
+	params := map[string]any{}
 	if opts != nil {
 		if opts.Retention > 0 {
 			params["retention"] = opts.Retention
@@ -309,7 +309,7 @@ func (s *VMService) Snapshot(ctx context.Context, id int, opts *VMSnapshotOption
 	action := struct {
 		VM     int                    `json:"vm"`
 		Action string                 `json:"action"`
-		Params map[string]interface{} `json:"params"`
+		Params map[string]any `json:"params"`
 	}{
 		VM:     id,
 		Action: vmActionSnapshot,
@@ -340,7 +340,7 @@ func (s *VMService) Migrate(ctx context.Context, id int, opts *VMMigrateOptions)
 		return &ValidationError{Field: "target_node", Message: "target_node is required"}
 	}
 
-	params := map[string]interface{}{
+	params := map[string]any{
 		"node": opts.TargetNode,
 	}
 
@@ -354,7 +354,7 @@ func (s *VMService) Migrate(ctx context.Context, id int, opts *VMMigrateOptions)
 	action := struct {
 		VM     int                    `json:"vm"`
 		Action string                 `json:"action"`
-		Params map[string]interface{} `json:"params"`
+		Params map[string]any `json:"params"`
 	}{
 		VM:     id,
 		Action: "migrate",

--- a/vm.go
+++ b/vm.go
@@ -209,7 +209,7 @@ func (s *VMService) waitForPowerState(ctx context.Context, id int, desiredState 
 		}
 	}
 
-	return fmt.Errorf("vergeos: timeout waiting for VM %d to become %s", id, stateStr)
+	return &TimeoutError{Resource: "VM", ID: id, Action: "become " + stateStr}
 }
 
 // Reset sends a reset signal to a running VM (equivalent to pressing the reset button).

--- a/vm_device.go
+++ b/vm_device.go
@@ -24,8 +24,9 @@ func (s *VMDeviceService) List(ctx context.Context, vmID int) ([]VMDevice, error
 
 	// Load settings for each device
 	for i := range devices {
-		// Non-fatal: continue without settings if load fails
-		_ = s.loadSettings(ctx, &devices[i])
+		if err := s.loadSettings(ctx, &devices[i]); err != nil {
+			return nil, err
+		}
 	}
 
 	return devices, nil
@@ -45,8 +46,10 @@ func (s *VMDeviceService) Get(ctx context.Context, deviceID int) (*VMDevice, err
 		return nil, err
 	}
 
-	// Load settings based on device type (non-fatal: return device without settings if load fails)
-	_ = s.loadSettings(ctx, &device)
+	// Load settings based on device type
+	if err := s.loadSettings(ctx, &device); err != nil {
+		return nil, err
+	}
 
 	return &device, nil
 }
@@ -171,8 +174,10 @@ func (s *VMDeviceService) Create(ctx context.Context, vmID int, req *VMDeviceCre
 		return nil, err
 	}
 
-	// Update device settings if provided (non-fatal: device was created but settings update may fail)
-	_ = s.updateSettings(ctx, device, req.USBSettings, req.TPMSettings, req.VGPUSettings)
+	// Update device settings if provided
+	if err := s.updateSettings(ctx, device, req.USBSettings, req.TPMSettings, req.VGPUSettings); err != nil {
+		return nil, err
+	}
 
 	// Read back with settings
 	return s.Get(ctx, id)
@@ -198,8 +203,10 @@ func (s *VMDeviceService) Update(ctx context.Context, deviceID int, req *VMDevic
 		return nil, err
 	}
 
-	// Update device settings if provided (non-fatal: device was updated but settings update may fail)
-	_ = s.updateSettings(ctx, device, req.USBSettings, req.TPMSettings, req.VGPUSettings)
+	// Update device settings if provided
+	if err := s.updateSettings(ctx, device, req.USBSettings, req.TPMSettings, req.VGPUSettings); err != nil {
+		return nil, err
+	}
 
 	// Read back with settings
 	return s.Get(ctx, deviceID)

--- a/vm_device.go
+++ b/vm_device.go
@@ -264,7 +264,7 @@ func (s *VMDeviceService) Delete(ctx context.Context, deviceID int) error {
 	endpoint := fmt.Sprintf("/machine_devices/%d", deviceID)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "VMDevice", ID: deviceID}
 		}
 		return err
 	}

--- a/vm_device.go
+++ b/vm_device.go
@@ -12,10 +12,10 @@ type VMDeviceService struct {
 }
 
 // List returns all devices for a VM.
-func (s *VMDeviceService) List(ctx context.Context, vmID int) ([]VMDevice, error) {
+func (s *VMDeviceService) List(ctx context.Context, machineID int) ([]VMDevice, error) {
 	params := url.Values{}
 	params.Set("fields", deviceListFields)
-	params.Set("filter", fmt.Sprintf("machine eq %d", vmID))
+	params.Set("filter", fmt.Sprintf("machine eq %d", machineID))
 
 	var devices []VMDevice
 	if err := s.client.get(ctx, "/machine_devices", params, &devices); err != nil {

--- a/vm_device_test.go
+++ b/vm_device_test.go
@@ -1,0 +1,319 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestVMDeviceService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_devices": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "machine eq 42" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VMDevice{
+				{ID: FlexInt(1), Machine: 42, Name: "tpm0", Type: DeviceTypeTPM},
+				{ID: FlexInt(2), Machine: 42, Name: "usb0", Type: DeviceTypeUSB},
+			})
+		},
+		// Settings endpoints return empty arrays (no settings configured)
+		"GET /api/v4/machine_device_settings_tpm": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TPMDeviceSettings{})
+		},
+		"GET /api/v4/machine_device_settings_usb": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []USBDeviceSettings{})
+		},
+	}))
+
+	devices, err := client.VMDevices.List(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(devices) != 2 {
+		t.Fatalf("expected 2 devices, got %d", len(devices))
+	}
+	if devices[0].Type != DeviceTypeTPM {
+		t.Errorf("expected type %q, got %q", DeviceTypeTPM, devices[0].Type)
+	}
+}
+
+func TestVMDeviceService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_devices/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMDevice{
+				ID:      FlexInt(1),
+				Machine: 42,
+				Name:    "tpm0",
+				Type:    DeviceTypeTPM,
+				Enabled: true,
+			})
+		},
+		"GET /api/v4/machine_device_settings_tpm": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TPMDeviceSettings{
+				{ID: 10, MachineDevice: 1, Model: "tpm-crb", Version: "2.0"},
+			})
+		},
+	}))
+
+	device, err := client.VMDevices.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if device.Name != "tpm0" {
+		t.Errorf("expected name 'tpm0', got %q", device.Name)
+	}
+	if device.TPMSettings == nil {
+		t.Fatal("expected TPMSettings to be loaded")
+	}
+	if device.TPMSettings.Version != "2.0" {
+		t.Errorf("expected TPM version '2.0', got %q", device.TPMSettings.Version)
+	}
+}
+
+func TestVMDeviceService_Get_USBSettings(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_devices/2": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMDevice{
+				ID:   FlexInt(2),
+				Name: "usb0",
+				Type: DeviceTypeUSB,
+			})
+		},
+		"GET /api/v4/machine_device_settings_usb": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []USBDeviceSettings{
+				{ID: 20, MachineDevice: 2, GuestReset: true},
+			})
+		},
+	}))
+
+	device, err := client.VMDevices.Get(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if device.USBSettings == nil {
+		t.Fatal("expected USBSettings to be loaded")
+	}
+	if !device.USBSettings.GuestReset {
+		t.Error("expected GuestReset to be true")
+	}
+}
+
+func TestVMDeviceService_Get_VGPUSettings(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_devices/3": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMDevice{
+				ID:   FlexInt(3),
+				Name: "vgpu0",
+				Type: DeviceTypeVGPU,
+			})
+		},
+		"GET /api/v4/machine_device_settings_nvidia_vgpu": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VGPUDeviceSettings{
+				{ID: 30, MachineDevice: 3, ProfileType: "nvidia-123"},
+			})
+		},
+	}))
+
+	device, err := client.VMDevices.Get(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if device.VGPUSettings == nil {
+		t.Fatal("expected VGPUSettings to be loaded")
+	}
+	if device.VGPUSettings.ProfileType != "nvidia-123" {
+		t.Errorf("expected ProfileType 'nvidia-123', got %q", device.VGPUSettings.ProfileType)
+	}
+}
+
+func TestVMDeviceService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_devices/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VMDevices.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVMDeviceService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/machine_devices": func(w http.ResponseWriter, r *http.Request) {
+			var req VMDeviceCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Machine != 10 {
+				t.Errorf("expected machine 10, got %d", req.Machine)
+			}
+			if req.Name != "tpm0" {
+				t.Errorf("expected name 'tpm0', got %q", req.Name)
+			}
+			if req.Type != DeviceTypeTPM {
+				t.Errorf("expected type %q, got %q", DeviceTypeTPM, req.Type)
+			}
+			if req.Enabled == nil || !*req.Enabled {
+				t.Error("expected enabled to default to true")
+			}
+			jsonResponse(w, 200, apiResponse{Key: float64(5)})
+		},
+		"GET /api/v4/machine_devices/5": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMDevice{
+				ID:      FlexInt(5),
+				Machine: 10,
+				Name:    "tpm0",
+				Type:    DeviceTypeTPM,
+				Enabled: true,
+			})
+		},
+		"GET /api/v4/machine_device_settings_tpm": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TPMDeviceSettings{})
+		},
+	}))
+
+	device, err := client.VMDevices.Create(context.Background(), 10, &VMDeviceCreateRequest{
+		Name: "tpm0",
+		Type: DeviceTypeTPM,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if device.ID.Int() != 5 {
+		t.Errorf("expected ID 5, got %d", device.ID.Int())
+	}
+}
+
+func TestVMDeviceService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMDevices.Create(context.Background(), 10, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMDeviceService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMDevices.Create(context.Background(), 10, &VMDeviceCreateRequest{
+		Type: DeviceTypeTPM,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMDeviceService_Create_MissingType(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMDevices.Create(context.Background(), 10, &VMDeviceCreateRequest{
+		Name: "tpm0",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing type")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMDeviceService_Update(t *testing.T) {
+	newName := "device-updated"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/machine_devices/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VMDeviceUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/machine_devices/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMDevice{
+				ID:   FlexInt(1),
+				Name: newName,
+				Type: DeviceTypeTPM,
+			})
+		},
+		"GET /api/v4/machine_device_settings_tpm": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []TPMDeviceSettings{})
+		},
+	}))
+
+	device, err := client.VMDevices.Update(context.Background(), 1, &VMDeviceUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if device.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, device.Name)
+	}
+}
+
+func TestVMDeviceService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMDevices.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMDeviceService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/machine_devices/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newName := "x"
+	_, err := client.VMDevices.Update(context.Background(), 999, &VMDeviceUpdateRequest{Name: &newName})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVMDeviceService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/machine_devices/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMDevices.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVMDeviceService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/machine_devices/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	// Delete of already-gone device should succeed (idempotent)
+	err := client.VMDevices.Delete(context.Background(), 999)
+	if err != nil {
+		t.Fatalf("Delete of missing device should be nil, got: %v", err)
+	}
+}

--- a/vm_device_test.go
+++ b/vm_device_test.go
@@ -313,7 +313,10 @@ func TestVMDeviceService_Delete_NotFound(t *testing.T) {
 
 	// Delete of already-gone device should succeed (idempotent)
 	err := client.VMDevices.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("Delete of missing device should be nil, got: %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted device")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }

--- a/vm_drive.go
+++ b/vm_drive.go
@@ -118,8 +118,12 @@ func (s *VMDriveService) Create(ctx context.Context, vmID int, req *VMDriveCreat
 
 // waitForImport waits for a drive import to complete and handles resizing if needed.
 func (s *VMDriveService) waitForImport(ctx context.Context, driveID int, targetSizeGB int64) (*VMDrive, error) {
-	// Initial wait
-	time.Sleep(5 * time.Second)
+	// Initial wait before first poll
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(5 * time.Second):
+	}
 
 	for i := 0; i < importMaxRetries; i++ {
 		drive, err := s.Get(ctx, driveID)

--- a/vm_drive.go
+++ b/vm_drive.go
@@ -44,6 +44,27 @@ func (s *VMDriveService) List(ctx context.Context, vmID int) ([]VMDrive, error) 
 	return drives, nil
 }
 
+// ListAll returns all machine drives across all VMs.
+func (s *VMDriveService) ListAll(ctx context.Context, opts ...ListOption) ([]VMDrive, error) {
+	options := applyListOptions(opts)
+	if options.Fields == "most" {
+		options.Fields = driveListFields
+	}
+	params := options.toQueryParams()
+
+	var drives []VMDrive
+	if err := s.client.get(ctx, "/machine_drives", params, &drives); err != nil {
+		return nil, err
+	}
+
+	// Convert bytes to GB
+	for i := range drives {
+		drives[i].SizeGB = drives[i].SizeBytes / bytesPerGB
+	}
+
+	return drives, nil
+}
+
 // Get returns a single drive by ID.
 func (s *VMDriveService) Get(ctx context.Context, driveID int) (*VMDrive, error) {
 	params := url.Values{}

--- a/vm_drive.go
+++ b/vm_drive.go
@@ -206,7 +206,7 @@ func (s *VMDriveService) Delete(ctx context.Context, driveID int) error {
 	drive, err := s.Get(ctx, driveID)
 	if err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "VMDrive", ID: driveID}
 		}
 		return err
 	}
@@ -221,7 +221,7 @@ func (s *VMDriveService) Delete(ctx context.Context, driveID int) error {
 	endpoint := fmt.Sprintf("/machine_drives/%d", driveID)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "VMDrive", ID: driveID}
 		}
 		return err
 	}

--- a/vm_drive.go
+++ b/vm_drive.go
@@ -25,11 +25,11 @@ type VMDriveService struct {
 	client *Client
 }
 
-// List returns all drives for a VM.
-func (s *VMDriveService) List(ctx context.Context, vmID int) ([]VMDrive, error) {
+// List returns all drives for a machine.
+func (s *VMDriveService) List(ctx context.Context, machineID int) ([]VMDrive, error) {
 	params := url.Values{}
 	params.Set("fields", driveListFields)
-	params.Set("filter", fmt.Sprintf("machine eq %d", vmID))
+	params.Set("filter", fmt.Sprintf("machine eq %d", machineID))
 
 	var drives []VMDrive
 	if err := s.client.get(ctx, "/machine_drives", params, &drives); err != nil {

--- a/vm_drive.go
+++ b/vm_drive.go
@@ -172,7 +172,7 @@ func (s *VMDriveService) waitForImport(ctx context.Context, driveID int, targetS
 		}
 	}
 
-	return nil, fmt.Errorf("vergeos: timeout waiting for drive %d import to complete", driveID)
+	return nil, &TimeoutError{Resource: "VMDrive", ID: driveID, Action: "complete import"}
 }
 
 // Update updates a drive and returns the updated drive.
@@ -263,7 +263,7 @@ func (s *VMDriveService) HotplugDrive(ctx context.Context, vmID, driveID int) er
 		}
 	}
 
-	return fmt.Errorf("vergeos: timeout waiting for drive %d to hotplug", driveID)
+	return &TimeoutError{Resource: "VMDrive", ID: driveID, Action: "hotplug"}
 }
 
 // HotUnplugDrive hot-unplugs a drive from a running VM.
@@ -303,7 +303,7 @@ func (s *VMDriveService) HotUnplugDrive(ctx context.Context, vmID, driveID int) 
 		}
 	}
 
-	return fmt.Errorf("vergeos: timeout waiting for drive %d to unplug", driveID)
+	return &TimeoutError{Resource: "VMDrive", ID: driveID, Action: "unplug"}
 }
 
 // hotUnplug is the internal wrapper used by Delete.

--- a/vm_drive_test.go
+++ b/vm_drive_test.go
@@ -296,7 +296,7 @@ func TestVMDriveService_Delete_HotUnplug(t *testing.T) {
 			jsonResponse(w, 200, VMDrive{ID: FlexInt(1), Machine: 10, PowerState: state})
 		},
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "hotplugdrive" {
 				t.Errorf("expected action 'hotplugdrive', got %v", body["action"])
@@ -318,12 +318,12 @@ func TestVMDriveService_HotplugDrive(t *testing.T) {
 	getCalls := 0
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "hotplugdrive" {
 				t.Errorf("expected action 'hotplugdrive', got %v", body["action"])
 			}
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if params["device"] != "5" {
 				t.Errorf("expected device '5', got %v", params["device"])
 			}
@@ -349,12 +349,12 @@ func TestVMDriveService_HotUnplugDrive(t *testing.T) {
 	getCalls := 0
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "hotplugdrive" {
 				t.Errorf("expected action 'hotplugdrive', got %v", body["action"])
 			}
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if params["unplug"] != true {
 				t.Error("expected unplug to be true for hot-unplug")
 			}

--- a/vm_drive_test.go
+++ b/vm_drive_test.go
@@ -36,6 +36,53 @@ func TestVMDriveService_List(t *testing.T) {
 	}
 }
 
+func TestVMDriveService_ListAll(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drives": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "" {
+				t.Errorf("expected no filter for ListAll, got %q", filter)
+			}
+			jsonResponse(w, 200, []VMDrive{
+				{ID: FlexInt(1), Machine: 42, Name: "disk0", SizeBytes: 10 * bytesPerGB},
+				{ID: FlexInt(2), Machine: 99, Name: "disk1", SizeBytes: 20 * bytesPerGB},
+			})
+		},
+	}))
+
+	drives, err := client.VMDrives.ListAll(context.Background())
+	if err != nil {
+		t.Fatalf("ListAll failed: %v", err)
+	}
+	if len(drives) != 2 {
+		t.Fatalf("expected 2 drives, got %d", len(drives))
+	}
+	// Verify drives span multiple VMs
+	if drives[0].Machine == drives[1].Machine {
+		t.Error("expected drives from different VMs")
+	}
+	if drives[0].SizeGB != 10 {
+		t.Errorf("expected SizeGB 10, got %d", drives[0].SizeGB)
+	}
+}
+
+func TestVMDriveService_ListAll_WithFilter(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drives": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "status eq 'online'" {
+				t.Errorf("expected status filter, got %q", filter)
+			}
+			jsonResponse(w, 200, []VMDrive{})
+		},
+	}))
+
+	_, err := client.VMDrives.ListAll(context.Background(), WithFilter("status eq 'online'"))
+	if err != nil {
+		t.Fatalf("ListAll with filter failed: %v", err)
+	}
+}
+
 func TestVMDriveService_Get(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"GET /api/v4/machine_drives/1": func(w http.ResponseWriter, r *http.Request) {

--- a/vm_drive_test.go
+++ b/vm_drive_test.go
@@ -1,0 +1,323 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestVMDriveService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drives": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "machine eq 42" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VMDrive{
+				{ID: FlexInt(1), Machine: 42, Name: "disk0", SizeBytes: 10 * bytesPerGB},
+				{ID: FlexInt(2), Machine: 42, Name: "disk1", SizeBytes: 20 * bytesPerGB},
+			})
+		},
+	}))
+
+	drives, err := client.VMDrives.List(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(drives) != 2 {
+		t.Fatalf("expected 2 drives, got %d", len(drives))
+	}
+	if drives[0].SizeGB != 10 {
+		t.Errorf("expected SizeGB 10, got %d", drives[0].SizeGB)
+	}
+	if drives[1].SizeGB != 20 {
+		t.Errorf("expected SizeGB 20, got %d", drives[1].SizeGB)
+	}
+}
+
+func TestVMDriveService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drives/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMDrive{
+				ID:        FlexInt(1),
+				Machine:   42,
+				Name:      "disk0",
+				SizeBytes: 50 * bytesPerGB,
+				Interface: "virtio-scsi",
+			})
+		},
+	}))
+
+	drive, err := client.VMDrives.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if drive.SizeGB != 50 {
+		t.Errorf("expected SizeGB 50, got %d", drive.SizeGB)
+	}
+	if drive.Interface != "virtio-scsi" {
+		t.Errorf("expected interface 'virtio-scsi', got %q", drive.Interface)
+	}
+}
+
+func TestVMDriveService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drives/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VMDrives.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVMDriveService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/machine_drives": func(w http.ResponseWriter, r *http.Request) {
+			var req VMDriveCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Machine != 10 {
+				t.Errorf("expected machine 10, got %d", req.Machine)
+			}
+			if req.Name != "disk0" {
+				t.Errorf("expected name 'disk0', got %q", req.Name)
+			}
+			if req.SizeBytes != 25*bytesPerGB {
+				t.Errorf("expected SizeBytes %d, got %d", 25*bytesPerGB, req.SizeBytes)
+			}
+			if req.Enabled == nil || !*req.Enabled {
+				t.Error("expected enabled to default to true")
+			}
+			jsonResponse(w, 200, apiResponse{Key: float64(7)})
+		},
+		"GET /api/v4/machine_drives/7": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMDrive{
+				ID:        FlexInt(7),
+				Machine:   10,
+				Name:      "disk0",
+				SizeBytes: 25 * bytesPerGB,
+				Enabled:   true,
+			})
+		},
+	}))
+
+	drive, err := client.VMDrives.Create(context.Background(), 10, &VMDriveCreateRequest{
+		Name:   "disk0",
+		SizeGB: 25,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if drive.ID.Int() != 7 {
+		t.Errorf("expected ID 7, got %d", drive.ID.Int())
+	}
+	if drive.SizeGB != 25 {
+		t.Errorf("expected SizeGB 25, got %d", drive.SizeGB)
+	}
+}
+
+func TestVMDriveService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMDrives.Create(context.Background(), 10, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMDriveService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMDrives.Create(context.Background(), 10, &VMDriveCreateRequest{})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMDriveService_Update(t *testing.T) {
+	newName := "disk-updated"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/machine_drives/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VMDriveUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/machine_drives/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMDrive{
+				ID:        FlexInt(1),
+				Name:      newName,
+				SizeBytes: 10 * bytesPerGB,
+			})
+		},
+	}))
+
+	drive, err := client.VMDrives.Update(context.Background(), 1, &VMDriveUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if drive.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, drive.Name)
+	}
+}
+
+func TestVMDriveService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMDrives.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMDriveService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/machine_drives/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newName := "x"
+	_, err := client.VMDrives.Update(context.Background(), 999, &VMDriveUpdateRequest{Name: &newName})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVMDriveService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drives/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMDrive{ID: FlexInt(1), Machine: 10, PowerState: "offline"})
+		},
+		"DELETE /api/v4/machine_drives/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMDrives.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVMDriveService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drives/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	// Delete of already-gone drive should succeed (idempotent)
+	err := client.VMDrives.Delete(context.Background(), 999)
+	if err != nil {
+		t.Fatalf("Delete of missing drive should be nil, got: %v", err)
+	}
+}
+
+func TestVMDriveService_Delete_HotUnplug(t *testing.T) {
+	getCalls := 0
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drives/1": func(w http.ResponseWriter, r *http.Request) {
+			getCalls++
+			state := "online"
+			if getCalls > 1 {
+				state = "offline"
+			}
+			jsonResponse(w, 200, VMDrive{ID: FlexInt(1), Machine: 10, PowerState: state})
+		},
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "hotplugdrive" {
+				t.Errorf("expected action 'hotplugdrive', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+		"DELETE /api/v4/machine_drives/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMDrives.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete with hot-unplug failed: %v", err)
+	}
+}
+
+func TestVMDriveService_HotplugDrive(t *testing.T) {
+	getCalls := 0
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "hotplugdrive" {
+				t.Errorf("expected action 'hotplugdrive', got %v", body["action"])
+			}
+			params := body["params"].(map[string]interface{})
+			if params["device"] != "5" {
+				t.Errorf("expected device '5', got %v", params["device"])
+			}
+			// Unplug should NOT be set for hotplug
+			if unplug, ok := params["unplug"]; ok && unplug == true {
+				t.Error("expected unplug to be false for hotplug")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/machine_drives/5": func(w http.ResponseWriter, r *http.Request) {
+			getCalls++
+			jsonResponse(w, 200, VMDrive{ID: FlexInt(5), Machine: 10, PowerState: "online"})
+		},
+	}))
+
+	err := client.VMDrives.HotplugDrive(context.Background(), 10, 5)
+	if err != nil {
+		t.Fatalf("HotplugDrive failed: %v", err)
+	}
+}
+
+func TestVMDriveService_HotUnplugDrive(t *testing.T) {
+	getCalls := 0
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "hotplugdrive" {
+				t.Errorf("expected action 'hotplugdrive', got %v", body["action"])
+			}
+			params := body["params"].(map[string]interface{})
+			if params["unplug"] != true {
+				t.Error("expected unplug to be true for hot-unplug")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/machine_drives/5": func(w http.ResponseWriter, r *http.Request) {
+			getCalls++
+			jsonResponse(w, 200, VMDrive{ID: FlexInt(5), Machine: 10, PowerState: "offline"})
+		},
+	}))
+
+	err := client.VMDrives.HotUnplugDrive(context.Background(), 10, 5)
+	if err != nil {
+		t.Fatalf("HotUnplugDrive failed: %v", err)
+	}
+}

--- a/vm_drive_test.go
+++ b/vm_drive_test.go
@@ -274,10 +274,13 @@ func TestVMDriveService_Delete_NotFound(t *testing.T) {
 		},
 	}))
 
-	// Delete of already-gone drive should succeed (idempotent)
+	// Delete of already-gone drive returns NotFoundError
 	err := client.VMDrives.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("Delete of missing drive should be nil, got: %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted drive")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }
 

--- a/vm_nic.go
+++ b/vm_nic.go
@@ -129,7 +129,7 @@ func (s *VMNICService) Delete(ctx context.Context, nicID int) error {
 	nic, err := s.Get(ctx, nicID)
 	if err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "VMNIC", ID: nicID}
 		}
 		return err
 	}
@@ -144,7 +144,7 @@ func (s *VMNICService) Delete(ctx context.Context, nicID int) error {
 	endpoint := fmt.Sprintf("/machine_nics/%d", nicID)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return nil // Already deleted
+			return &NotFoundError{Resource: "VMNIC", ID: nicID}
 		}
 		return err
 	}

--- a/vm_nic.go
+++ b/vm_nic.go
@@ -89,14 +89,16 @@ func (s *VMNICService) Create(ctx context.Context, vmID int, req *VMNICCreateReq
 		return nil, err
 	}
 
-	// Assign IP address if requested (non-fatal: NIC was created but IP assignment may fail)
+	// Assign IP address if requested
 	if req.AssignIPAddress && req.VNET > 0 && nic.MAC != "" {
 		addrReq := vnetAddressRequest{
 			VNET: req.VNET,
 			MAC:  nic.MAC,
 			Type: "static",
 		}
-		_ = s.client.post(ctx, "/vnet_addresses", addrReq, nil)
+		if err := s.client.post(ctx, "/vnet_addresses", addrReq, nil); err != nil {
+			return nil, fmt.Errorf("vergeos: NIC created (ID %d) but IP assignment failed: %w", id, err)
+		}
 	}
 
 	return nic, nil

--- a/vm_nic.go
+++ b/vm_nic.go
@@ -188,5 +188,5 @@ func (s *VMNICService) hotUnplug(ctx context.Context, vmID, nicID int) error {
 		}
 	}
 
-	return fmt.Errorf("vergeos: timeout waiting for NIC %d to unplug", nicID)
+	return &TimeoutError{Resource: "VMNIC", ID: nicID, Action: "unplug"}
 }

--- a/vm_nic_test.go
+++ b/vm_nic_test.go
@@ -231,7 +231,7 @@ func TestVMNICService_Delete_HotUnplug(t *testing.T) {
 			jsonResponse(w, 200, VMNIC{ID: FlexInt(1), Machine: 10, PowerState: state})
 		},
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "hotplugnic" {
 				t.Errorf("expected action 'hotplugnic', got %v", body["action"])

--- a/vm_nic_test.go
+++ b/vm_nic_test.go
@@ -1,0 +1,247 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestVMNICService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_nics": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "machine eq 42" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VMNIC{
+				{ID: FlexInt(1), Machine: 42, Name: "nic0"},
+				{ID: FlexInt(2), Machine: 42, Name: "nic1"},
+			})
+		},
+	}))
+
+	nics, err := client.VMNICs.List(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(nics) != 2 {
+		t.Fatalf("expected 2 NICs, got %d", len(nics))
+	}
+	if nics[0].Name != "nic0" {
+		t.Errorf("expected name 'nic0', got %q", nics[0].Name)
+	}
+}
+
+func TestVMNICService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_nics/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMNIC{
+				ID:      FlexInt(1),
+				Machine: 42,
+				Name:    "nic0",
+				MAC:     "00:11:22:33:44:55",
+			})
+		},
+	}))
+
+	nic, err := client.VMNICs.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if nic.MAC != "00:11:22:33:44:55" {
+		t.Errorf("expected MAC '00:11:22:33:44:55', got %q", nic.MAC)
+	}
+}
+
+func TestVMNICService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_nics/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VMNICs.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVMNICService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/machine_nics": func(w http.ResponseWriter, r *http.Request) {
+			var req VMNICCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Machine != 10 {
+				t.Errorf("expected machine 10, got %d", req.Machine)
+			}
+			if req.Name != "nic0" {
+				t.Errorf("expected name 'nic0', got %q", req.Name)
+			}
+			if req.Enabled == nil || !*req.Enabled {
+				t.Error("expected enabled to default to true")
+			}
+			jsonResponse(w, 200, apiResponse{Key: float64(5)})
+		},
+		"GET /api/v4/machine_nics/5": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMNIC{
+				ID:      FlexInt(5),
+				Machine: 10,
+				Name:    "nic0",
+				Enabled: true,
+			})
+		},
+	}))
+
+	nic, err := client.VMNICs.Create(context.Background(), 10, &VMNICCreateRequest{
+		Name: "nic0",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if nic.ID.Int() != 5 {
+		t.Errorf("expected ID 5, got %d", nic.ID.Int())
+	}
+}
+
+func TestVMNICService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMNICs.Create(context.Background(), 10, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMNICService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMNICs.Create(context.Background(), 10, &VMNICCreateRequest{})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMNICService_Update(t *testing.T) {
+	newName := "nic-updated"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/machine_nics/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VMNICUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/machine_nics/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMNIC{ID: FlexInt(1), Name: newName})
+		},
+	}))
+
+	nic, err := client.VMNICs.Update(context.Background(), 1, &VMNICUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if nic.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, nic.Name)
+	}
+}
+
+func TestVMNICService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMNICs.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMNICService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/machine_nics/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newName := "x"
+	_, err := client.VMNICs.Update(context.Background(), 999, &VMNICUpdateRequest{Name: &newName})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVMNICService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_nics/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMNIC{ID: FlexInt(1), Machine: 10, PowerState: "down"})
+		},
+		"DELETE /api/v4/machine_nics/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMNICs.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVMNICService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_nics/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	// Delete of already-gone NIC should succeed (idempotent)
+	err := client.VMNICs.Delete(context.Background(), 999)
+	if err != nil {
+		t.Fatalf("Delete of missing NIC should be nil, got: %v", err)
+	}
+}
+
+func TestVMNICService_Delete_HotUnplug(t *testing.T) {
+	getCalls := 0
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_nics/1": func(w http.ResponseWriter, r *http.Request) {
+			getCalls++
+			// First call: NIC is up. After unplug action: NIC is down.
+			state := "up"
+			if getCalls > 1 {
+				state = "down"
+			}
+			jsonResponse(w, 200, VMNIC{ID: FlexInt(1), Machine: 10, PowerState: state})
+		},
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "hotplugnic" {
+				t.Errorf("expected action 'hotplugnic', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+		"DELETE /api/v4/machine_nics/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMNICs.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete with hot-unplug failed: %v", err)
+	}
+}

--- a/vm_nic_test.go
+++ b/vm_nic_test.go
@@ -208,10 +208,13 @@ func TestVMNICService_Delete_NotFound(t *testing.T) {
 		},
 	}))
 
-	// Delete of already-gone NIC should succeed (idempotent)
+	// Delete of already-gone NIC returns NotFoundError
 	err := client.VMNICs.Delete(context.Background(), 999)
-	if err != nil {
-		t.Fatalf("Delete of missing NIC should be nil, got: %v", err)
+	if err == nil {
+		t.Fatal("expected NotFoundError for deleted NIC")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }
 

--- a/vm_snapshot.go
+++ b/vm_snapshot.go
@@ -182,7 +182,7 @@ func (s *VMSnapshotService) Restore(ctx context.Context, id int, opts *VMSnapsho
 		return err
 	}
 
-	params := map[string]interface{}{}
+	params := map[string]any{}
 	if opts != nil {
 		params["poweron"] = opts.PowerOn
 	}
@@ -190,7 +190,7 @@ func (s *VMSnapshotService) Restore(ctx context.Context, id int, opts *VMSnapsho
 	action := struct {
 		VM     int                    `json:"vm"`
 		Action string                 `json:"action"`
-		Params map[string]interface{} `json:"params"`
+		Params map[string]any `json:"params"`
 	}{
 		VM:     int(snapshot.Machine),
 		Action: "restore",

--- a/vm_snapshot.go
+++ b/vm_snapshot.go
@@ -99,7 +99,7 @@ func (s *VMSnapshotService) Get(ctx context.Context, id int) (*VMSnapshot, error
 
 // GetByName returns a VM snapshot by name within a specific VM.
 func (s *VMSnapshotService) GetByName(ctx context.Context, vmID int, name string) (*VMSnapshot, error) {
-	snapshots, err := s.ListByVM(ctx, vmID, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	snapshots, err := s.ListByVM(ctx, vmID, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/vm_snapshot_test.go
+++ b/vm_snapshot_test.go
@@ -1,0 +1,437 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestVMSnapshotService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VMSnapshot{
+				{Key: FlexInt(1), Name: "snap1", Machine: FlexInt(10)},
+				{Key: FlexInt(2), Name: "snap2", Machine: FlexInt(20)},
+			})
+		},
+	}))
+
+	snaps, err := client.VMSnapshots.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(snaps) != 2 {
+		t.Fatalf("expected 2 snapshots, got %d", len(snaps))
+	}
+	if snaps[0].Name != "snap1" {
+		t.Errorf("expected name 'snap1', got %q", snaps[0].Name)
+	}
+}
+
+func TestVMSnapshotService_ListByVM(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "machine eq 42" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VMSnapshot{
+				{Key: FlexInt(1), Name: "snap1", Machine: FlexInt(42)},
+			})
+		},
+	}))
+
+	snaps, err := client.VMSnapshots.ListByVM(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ListByVM failed: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(snaps))
+	}
+}
+
+func TestVMSnapshotService_ListByVM_WithFilter(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			// Should combine user filter with machine filter
+			expected := "(name eq 'daily') and machine eq 42"
+			if filter != expected {
+				t.Errorf("expected filter %q, got %q", expected, filter)
+			}
+			jsonResponse(w, 200, []VMSnapshot{})
+		},
+	}))
+
+	_, err := client.VMSnapshots.ListByVM(context.Background(), 42, WithFilter("name eq 'daily'"))
+	if err != nil {
+		t.Fatalf("ListByVM with filter failed: %v", err)
+	}
+}
+
+func TestVMSnapshotService_ListExpiring(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			// 7 days = 7*86400 = 604800
+			expected := "expires lt {$add({$now},604800)} and expires gt 0"
+			if filter != expected {
+				t.Errorf("expected filter %q, got %q", expected, filter)
+			}
+			jsonResponse(w, 200, []VMSnapshot{
+				{Key: FlexInt(1), Name: "expiring-snap", Expires: 1234567890},
+			})
+		},
+	}))
+
+	snaps, err := client.VMSnapshots.ListExpiring(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("ListExpiring failed: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(snaps))
+	}
+}
+
+func TestVMSnapshotService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMSnapshot{
+				Key:         FlexInt(1),
+				Machine:     FlexInt(42),
+				Name:        "snap1",
+				ExpiresType: "never",
+			})
+		},
+	}))
+
+	snap, err := client.VMSnapshots.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if snap.Name != "snap1" {
+		t.Errorf("expected name 'snap1', got %q", snap.Name)
+	}
+	if snap.ExpiresType != "never" {
+		t.Errorf("expected expires_type 'never', got %q", snap.ExpiresType)
+	}
+}
+
+func TestVMSnapshotService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_snapshots/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VMSnapshots.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVMSnapshotService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			expected := "(name eq 'daily-backup') and machine eq 42"
+			if filter != expected {
+				t.Errorf("expected filter %q, got %q", expected, filter)
+			}
+			jsonResponse(w, 200, []VMSnapshot{
+				{Key: FlexInt(1), Machine: FlexInt(42), Name: "daily-backup"},
+			})
+		},
+	}))
+
+	snap, err := client.VMSnapshots.GetByName(context.Background(), 42, "daily-backup")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if snap.Name != "daily-backup" {
+		t.Errorf("expected name 'daily-backup', got %q", snap.Name)
+	}
+}
+
+func TestVMSnapshotService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VMSnapshot{})
+		},
+	}))
+
+	_, err := client.VMSnapshots.GetByName(context.Background(), 42, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVMSnapshotService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/machine_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			var req VMSnapshotCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Machine != 42 {
+				t.Errorf("expected machine 42, got %d", req.Machine)
+			}
+			if req.Name != "test-snap" {
+				t.Errorf("expected name 'test-snap', got %q", req.Name)
+			}
+			if req.ExpiresType != "date" {
+				t.Errorf("expected default expires_type 'date', got %q", req.ExpiresType)
+			}
+			jsonResponse(w, 200, apiResponse{Key: float64(5)})
+		},
+		"GET /api/v4/machine_snapshots/5": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMSnapshot{
+				Key:         FlexInt(5),
+				Machine:     FlexInt(42),
+				Name:        "test-snap",
+				ExpiresType: "date",
+			})
+		},
+	}))
+
+	snap, err := client.VMSnapshots.Create(context.Background(), &VMSnapshotCreateRequest{
+		Machine: 42,
+		Name:    "test-snap",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if snap.Key.Int() != 5 {
+		t.Errorf("expected key 5, got %d", snap.Key.Int())
+	}
+}
+
+func TestVMSnapshotService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMSnapshots.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMSnapshotService_Create_MissingMachine(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMSnapshots.Create(context.Background(), &VMSnapshotCreateRequest{
+		Name: "snap1",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing machine")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMSnapshotService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMSnapshots.Create(context.Background(), &VMSnapshotCreateRequest{
+		Machine: 42,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMSnapshotService_Update(t *testing.T) {
+	newName := "snap-updated"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/machine_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VMSnapshotUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/machine_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMSnapshot{Key: FlexInt(1), Name: newName})
+		},
+	}))
+
+	snap, err := client.VMSnapshots.Update(context.Background(), 1, &VMSnapshotUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if snap.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, snap.Name)
+	}
+}
+
+func TestVMSnapshotService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMSnapshots.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMSnapshotService_Update_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/machine_snapshots/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	newName := "x"
+	_, err := client.VMSnapshots.Update(context.Background(), 999, &VMSnapshotUpdateRequest{Name: &newName})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVMSnapshotService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/machine_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMSnapshots.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVMSnapshotService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/machine_snapshots/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VMSnapshots.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVMSnapshotService_Restore(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMSnapshot{Key: FlexInt(1), Machine: FlexInt(42), Name: "snap1"})
+		},
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "restore" {
+				t.Errorf("expected action 'restore', got %v", body["action"])
+			}
+			if int(body["vm"].(float64)) != 42 {
+				t.Errorf("expected vm 42, got %v", body["vm"])
+			}
+			params := body["params"].(map[string]interface{})
+			if int(params["snapshot"].(float64)) != 1 {
+				t.Errorf("expected snapshot param 1, got %v", params["snapshot"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMSnapshots.Restore(context.Background(), 1, nil)
+	if err != nil {
+		t.Fatalf("Restore failed: %v", err)
+	}
+}
+
+func TestVMSnapshotService_Restore_WithPowerOn(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMSnapshot{Key: FlexInt(1), Machine: FlexInt(42)})
+		},
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			params := body["params"].(map[string]interface{})
+			if params["poweron"] != true {
+				t.Errorf("expected poweron true, got %v", params["poweron"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMSnapshots.Restore(context.Background(), 1, &VMSnapshotRestoreOptions{PowerOn: true})
+	if err != nil {
+		t.Fatalf("Restore with PowerOn failed: %v", err)
+	}
+}
+
+func TestVMSnapshotService_SetNeverExpires(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/machine_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VMSnapshotUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.ExpiresType == nil || *req.ExpiresType != "never" {
+				t.Errorf("expected expires_type 'never', got %v", req.ExpiresType)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/machine_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMSnapshot{Key: FlexInt(1), ExpiresType: "never"})
+		},
+	}))
+
+	snap, err := client.VMSnapshots.SetNeverExpires(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("SetNeverExpires failed: %v", err)
+	}
+	if snap.ExpiresType != "never" {
+		t.Errorf("expected expires_type 'never', got %q", snap.ExpiresType)
+	}
+}
+
+func TestVMSnapshotService_SetExpires(t *testing.T) {
+	var expireTS int64 = 1700000000
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/machine_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VMSnapshotUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.ExpiresType == nil || *req.ExpiresType != "date" {
+				t.Errorf("expected expires_type 'date', got %v", req.ExpiresType)
+			}
+			if req.Expires == nil || *req.Expires != expireTS {
+				t.Errorf("expected expires %d, got %v", expireTS, req.Expires)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/machine_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMSnapshot{Key: FlexInt(1), ExpiresType: "date", Expires: expireTS})
+		},
+	}))
+
+	snap, err := client.VMSnapshots.SetExpires(context.Background(), 1, expireTS)
+	if err != nil {
+		t.Fatalf("SetExpires failed: %v", err)
+	}
+	if snap.Expires != expireTS {
+		t.Errorf("expected expires %d, got %d", expireTS, snap.Expires)
+	}
+}

--- a/vm_snapshot_test.go
+++ b/vm_snapshot_test.go
@@ -340,7 +340,7 @@ func TestVMSnapshotService_Restore(t *testing.T) {
 			jsonResponse(w, 200, VMSnapshot{Key: FlexInt(1), Machine: FlexInt(42), Name: "snap1"})
 		},
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "restore" {
 				t.Errorf("expected action 'restore', got %v", body["action"])
@@ -348,7 +348,7 @@ func TestVMSnapshotService_Restore(t *testing.T) {
 			if int(body["vm"].(float64)) != 42 {
 				t.Errorf("expected vm 42, got %v", body["vm"])
 			}
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if int(params["snapshot"].(float64)) != 1 {
 				t.Errorf("expected snapshot param 1, got %v", params["snapshot"])
 			}
@@ -368,9 +368,9 @@ func TestVMSnapshotService_Restore_WithPowerOn(t *testing.T) {
 			jsonResponse(w, 200, VMSnapshot{Key: FlexInt(1), Machine: FlexInt(42)})
 		},
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if params["poweron"] != true {
 				t.Errorf("expected poweron true, got %v", params["poweron"])
 			}

--- a/vm_test.go
+++ b/vm_test.go
@@ -1,0 +1,852 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+func TestVMService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VM{
+				{ID: 1, Name: "vm-alpha", CPUCores: 2, RAM: 4096},
+				{ID: 2, Name: "vm-beta", CPUCores: 4, RAM: 8192},
+			})
+		},
+	}))
+
+	vms, err := client.VMs.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(vms) != 2 {
+		t.Fatalf("expected 2 VMs, got %d", len(vms))
+	}
+	if vms[0].Name != "vm-alpha" {
+		t.Errorf("expected name 'vm-alpha', got %q", vms[0].Name)
+	}
+}
+
+func TestVMService_List_Empty(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VM{})
+		},
+	}))
+
+	vms, err := client.VMs.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(vms) != 0 {
+		t.Fatalf("expected 0 VMs, got %d", len(vms))
+	}
+}
+
+func TestVMService_List_WithFilter(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter query param")
+			}
+			jsonResponse(w, 200, []VM{{ID: 1, Name: "vm-alpha"}})
+		},
+	}))
+
+	vms, err := client.VMs.List(context.Background(), WithFilter("name eq 'vm-alpha'"))
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(vms) != 1 {
+		t.Fatalf("expected 1 VM, got %d", len(vms))
+	}
+}
+
+func TestVMService_List_ServerError(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 500, map[string]string{"err": "internal error"})
+		},
+	}))
+
+	_, err := client.VMs.List(context.Background())
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Get
+// ---------------------------------------------------------------------------
+
+func TestVMService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VM{ID: 1, Name: "vm-alpha", CPUCores: 2, RAM: 4096})
+		},
+	}))
+
+	vm, err := client.VMs.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if vm.Name != "vm-alpha" {
+		t.Errorf("expected name 'vm-alpha', got %q", vm.Name)
+	}
+	if vm.CPUCores != 2 {
+		t.Errorf("expected 2 cores, got %d", vm.CPUCores)
+	}
+}
+
+func TestVMService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VMs.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+func TestVMService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vms": func(w http.ResponseWriter, r *http.Request) {
+			var req VMCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "new-vm" {
+				t.Errorf("expected name 'new-vm', got %q", req.Name)
+			}
+			if req.CPUCores != 4 {
+				t.Errorf("expected 4 cores, got %d", req.CPUCores)
+			}
+			if req.RAM != 8192 {
+				t.Errorf("expected 8192 RAM, got %d", req.RAM)
+			}
+			jsonResponse(w, 200, apiResponse{Key: float64(42)})
+		},
+		"GET /api/v4/vms/42": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VM{ID: 42, Name: "new-vm", CPUCores: 4, RAM: 8192})
+		},
+	}))
+
+	vm, err := client.VMs.Create(context.Background(), &VMCreateRequest{
+		Name:     "new-vm",
+		CPUCores: 4,
+		RAM:      8192,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if vm.ID.Int() != 42 {
+		t.Errorf("expected ID 42, got %d", vm.ID.Int())
+	}
+	if vm.Name != "new-vm" {
+		t.Errorf("expected name 'new-vm', got %q", vm.Name)
+	}
+}
+
+func TestVMService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMs.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMs.Create(context.Background(), &VMCreateRequest{
+		CPUCores: 2,
+		RAM:      4096,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMService_Create_ZeroCPUCores(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMs.Create(context.Background(), &VMCreateRequest{
+		Name: "bad-vm",
+		RAM:  4096,
+	})
+	if err == nil {
+		t.Fatal("expected error for zero cpu_cores")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMService_Create_ZeroRAM(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMs.Create(context.Background(), &VMCreateRequest{
+		Name:     "bad-vm",
+		CPUCores: 2,
+	})
+	if err == nil {
+		t.Fatal("expected error for zero ram")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMService_Create_DefaultsEnabled(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vms": func(w http.ResponseWriter, r *http.Request) {
+			var req VMCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Enabled == nil || !*req.Enabled {
+				t.Error("expected Enabled to default to true")
+			}
+			jsonResponse(w, 200, apiResponse{Key: float64(1)})
+		},
+		"GET /api/v4/vms/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VM{ID: 1, Name: "vm", CPUCores: 1, RAM: 1024, Enabled: true})
+		},
+	}))
+
+	_, err := client.VMs.Create(context.Background(), &VMCreateRequest{
+		Name:     "vm",
+		CPUCores: 1,
+		RAM:      1024,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Update
+// ---------------------------------------------------------------------------
+
+func TestVMService_Update(t *testing.T) {
+	newName := "renamed-vm"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vms/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VMUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vms/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VM{ID: 1, Name: newName, CPUCores: 2, RAM: 4096})
+		},
+	}))
+
+	vm, err := client.VMs.Update(context.Background(), 1, &VMUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if vm.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, vm.Name)
+	}
+}
+
+func TestVMService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VMs.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMService_Update_NotFound(t *testing.T) {
+	newName := "ghost"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vms/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VMs.Update(context.Background(), 999, &VMUpdateRequest{Name: &newName})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+func TestVMService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vms/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMs.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVMService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vms/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VMs.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PowerOn
+// ---------------------------------------------------------------------------
+
+func TestVMService_PowerOn_AlreadyRunning(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VM{ID: 1, Name: "vm", PowerState: true})
+		},
+	}))
+
+	err := client.VMs.PowerOn(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("PowerOn (already running) failed: %v", err)
+	}
+}
+
+func TestVMService_PowerOn(t *testing.T) {
+	getCalls := 0
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/1": func(w http.ResponseWriter, r *http.Request) {
+			getCalls++
+			// First call: stopped. Subsequent calls: running.
+			running := getCalls > 1
+			jsonResponse(w, 200, VM{ID: 1, Name: "vm", PowerState: running})
+		},
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "poweron" {
+				t.Errorf("expected action 'poweron', got %v", body["action"])
+			}
+			if int(body["vm"].(float64)) != 1 {
+				t.Errorf("expected vm 1, got %v", body["vm"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMs.PowerOn(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("PowerOn failed: %v", err)
+	}
+}
+
+func TestVMService_PowerOn_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VMs.PowerOn(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PowerOff
+// ---------------------------------------------------------------------------
+
+func TestVMService_PowerOff_AlreadyStopped(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VM{ID: 1, Name: "vm", PowerState: false})
+		},
+	}))
+
+	err := client.VMs.PowerOff(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("PowerOff (already stopped) failed: %v", err)
+	}
+}
+
+func TestVMService_PowerOff(t *testing.T) {
+	getCalls := 0
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/1": func(w http.ResponseWriter, r *http.Request) {
+			getCalls++
+			// First call: running. Subsequent calls: stopped.
+			running := getCalls <= 1
+			jsonResponse(w, 200, VM{ID: 1, Name: "vm", PowerState: running})
+		},
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "kill" {
+				t.Errorf("expected action 'kill', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMs.PowerOff(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("PowerOff failed: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reset
+// ---------------------------------------------------------------------------
+
+func TestVMService_Reset(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "reset" {
+				t.Errorf("expected action 'reset', got %v", body["action"])
+			}
+			if int(body["vm"].(float64)) != 1 {
+				t.Errorf("expected vm 1, got %v", body["vm"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMs.Reset(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Reset failed: %v", err)
+	}
+}
+
+func TestVMService_Reset_ServerError(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 500, map[string]string{"err": "internal error"})
+		},
+	}))
+
+	err := client.VMs.Reset(context.Background(), 1)
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GuestReboot
+// ---------------------------------------------------------------------------
+
+func TestVMService_GuestReboot(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "guestreboot" {
+				t.Errorf("expected action 'guestreboot', got %v", body["action"])
+			}
+			if int(body["vm"].(float64)) != 5 {
+				t.Errorf("expected vm 5, got %v", body["vm"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMs.GuestReboot(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("GuestReboot failed: %v", err)
+	}
+}
+
+func TestVMService_GuestReboot_ServerError(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 500, map[string]string{"err": "internal error"})
+		},
+	}))
+
+	err := client.VMs.GuestReboot(context.Background(), 5)
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GuestShutdown
+// ---------------------------------------------------------------------------
+
+func TestVMService_GuestShutdown(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "poweroff" {
+				t.Errorf("expected action 'poweroff', got %v", body["action"])
+			}
+			if int(body["vm"].(float64)) != 3 {
+				t.Errorf("expected vm 3, got %v", body["vm"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMs.GuestShutdown(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("GuestShutdown failed: %v", err)
+	}
+}
+
+func TestVMService_GuestShutdown_ServerError(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 500, map[string]string{"err": "internal error"})
+		},
+	}))
+
+	err := client.VMs.GuestShutdown(context.Background(), 3)
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Clone
+// ---------------------------------------------------------------------------
+
+func TestVMService_Clone(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "clone" {
+				t.Errorf("expected action 'clone', got %v", body["action"])
+			}
+			if int(body["vm"].(float64)) != 1 {
+				t.Errorf("expected vm 1, got %v", body["vm"])
+			}
+			params := body["params"].(map[string]interface{})
+			if params["name"] != "cloned-vm" {
+				t.Errorf("expected clone name 'cloned-vm', got %v", params["name"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMs.Clone(context.Background(), 1, &VMCloneOptions{Name: "cloned-vm"})
+	if err != nil {
+		t.Fatalf("Clone failed: %v", err)
+	}
+}
+
+func TestVMService_Clone_NilOpts(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "clone" {
+				t.Errorf("expected action 'clone', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMs.Clone(context.Background(), 1, nil)
+	if err != nil {
+		t.Fatalf("Clone with nil opts failed: %v", err)
+	}
+}
+
+func TestVMService_Clone_PreserveMACs(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			params := body["params"].(map[string]interface{})
+			if params["preserve_macs"] != true {
+				t.Errorf("expected preserve_macs true, got %v", params["preserve_macs"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMs.Clone(context.Background(), 1, &VMCloneOptions{PreserveMACs: true})
+	if err != nil {
+		t.Fatalf("Clone with PreserveMACs failed: %v", err)
+	}
+}
+
+func TestVMService_Clone_ServerError(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 500, map[string]string{"err": "internal error"})
+		},
+	}))
+
+	err := client.VMs.Clone(context.Background(), 1, &VMCloneOptions{Name: "fail"})
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot
+// ---------------------------------------------------------------------------
+
+func TestVMService_Snapshot(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "quiesce_snapshot" {
+				t.Errorf("expected action 'quiesce_snapshot', got %v", body["action"])
+			}
+			if int(body["vm"].(float64)) != 2 {
+				t.Errorf("expected vm 2, got %v", body["vm"])
+			}
+			params := body["params"].(map[string]interface{})
+			if int(params["retention"].(float64)) != 3600 {
+				t.Errorf("expected retention 3600, got %v", params["retention"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMs.Snapshot(context.Background(), 2, &VMSnapshotOptions{Retention: 3600})
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+}
+
+func TestVMService_Snapshot_NilOpts(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "quiesce_snapshot" {
+				t.Errorf("expected action 'quiesce_snapshot', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMs.Snapshot(context.Background(), 2, nil)
+	if err != nil {
+		t.Fatalf("Snapshot with nil opts failed: %v", err)
+	}
+}
+
+func TestVMService_Snapshot_WithQuiesce(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			params := body["params"].(map[string]interface{})
+			if params["quiesce"] != true {
+				t.Errorf("expected quiesce true, got %v", params["quiesce"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMs.Snapshot(context.Background(), 2, &VMSnapshotOptions{Quiesce: true})
+	if err != nil {
+		t.Fatalf("Snapshot with quiesce failed: %v", err)
+	}
+}
+
+func TestVMService_Snapshot_ServerError(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 500, map[string]string{"err": "internal error"})
+		},
+	}))
+
+	err := client.VMs.Snapshot(context.Background(), 2, nil)
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Migrate
+// ---------------------------------------------------------------------------
+
+func TestVMService_Migrate(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "migrate" {
+				t.Errorf("expected action 'migrate', got %v", body["action"])
+			}
+			if int(body["vm"].(float64)) != 1 {
+				t.Errorf("expected vm 1, got %v", body["vm"])
+			}
+			params := body["params"].(map[string]interface{})
+			if int(params["node"].(float64)) != 3 {
+				t.Errorf("expected node 3, got %v", params["node"])
+			}
+			if params["method"] != "live" {
+				t.Errorf("expected method 'live', got %v", params["method"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VMs.Migrate(context.Background(), 1, &VMMigrateOptions{TargetNode: 3})
+	if err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+}
+
+func TestVMService_Migrate_NonLive(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			params := body["params"].(map[string]interface{})
+			if params["method"] != "auto" {
+				t.Errorf("expected method 'auto', got %v", params["method"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	live := false
+	err := client.VMs.Migrate(context.Background(), 1, &VMMigrateOptions{
+		TargetNode: 3,
+		Live:       &live,
+	})
+	if err != nil {
+		t.Fatalf("Migrate non-live failed: %v", err)
+	}
+}
+
+func TestVMService_Migrate_NilOpts(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	err := client.VMs.Migrate(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil opts")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMService_Migrate_ZeroTargetNode(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	err := client.VMs.Migrate(context.Background(), 1, &VMMigrateOptions{TargetNode: 0})
+	if err == nil {
+		t.Fatal("expected error for zero target_node")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVMService_Migrate_ServerError(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 500, map[string]string{"err": "internal error"})
+		},
+	}))
+
+	err := client.VMs.Migrate(context.Background(), 1, &VMMigrateOptions{TargetNode: 3})
+	if err == nil {
+		t.Fatal("expected error for server error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetConsoleURL
+// ---------------------------------------------------------------------------
+
+func TestVMService_GetConsoleURL(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VM{ID: 1, Name: "vm", PowerState: true})
+		},
+	}))
+
+	url, err := client.VMs.GetConsoleURL(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetConsoleURL failed: %v", err)
+	}
+	if url == "" {
+		t.Error("expected non-empty console URL")
+	}
+}
+
+func TestVMService_GetConsoleURL_VMStopped(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VM{ID: 1, Name: "vm", PowerState: false})
+		},
+	}))
+
+	_, err := client.VMs.GetConsoleURL(context.Background(), 1)
+	if err == nil {
+		t.Fatal("expected error for stopped VM")
+	}
+}
+
+func TestVMService_GetConsoleURL_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VMs.GetConsoleURL(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/vm_test.go
+++ b/vm_test.go
@@ -362,7 +362,7 @@ func TestVMService_PowerOn(t *testing.T) {
 			jsonResponse(w, 200, VM{ID: 1, Name: "vm", PowerState: running})
 		},
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "poweron" {
 				t.Errorf("expected action 'poweron', got %v", body["action"])
@@ -423,7 +423,7 @@ func TestVMService_PowerOff(t *testing.T) {
 			jsonResponse(w, 200, VM{ID: 1, Name: "vm", PowerState: running})
 		},
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "kill" {
 				t.Errorf("expected action 'kill', got %v", body["action"])
@@ -445,7 +445,7 @@ func TestVMService_PowerOff(t *testing.T) {
 func TestVMService_Reset(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "reset" {
 				t.Errorf("expected action 'reset', got %v", body["action"])
@@ -483,7 +483,7 @@ func TestVMService_Reset_ServerError(t *testing.T) {
 func TestVMService_GuestReboot(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "guestreboot" {
 				t.Errorf("expected action 'guestreboot', got %v", body["action"])
@@ -521,7 +521,7 @@ func TestVMService_GuestReboot_ServerError(t *testing.T) {
 func TestVMService_GuestShutdown(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "poweroff" {
 				t.Errorf("expected action 'poweroff', got %v", body["action"])
@@ -559,7 +559,7 @@ func TestVMService_GuestShutdown_ServerError(t *testing.T) {
 func TestVMService_Clone(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "clone" {
 				t.Errorf("expected action 'clone', got %v", body["action"])
@@ -567,7 +567,7 @@ func TestVMService_Clone(t *testing.T) {
 			if int(body["vm"].(float64)) != 1 {
 				t.Errorf("expected vm 1, got %v", body["vm"])
 			}
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if params["name"] != "cloned-vm" {
 				t.Errorf("expected clone name 'cloned-vm', got %v", params["name"])
 			}
@@ -584,7 +584,7 @@ func TestVMService_Clone(t *testing.T) {
 func TestVMService_Clone_NilOpts(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "clone" {
 				t.Errorf("expected action 'clone', got %v", body["action"])
@@ -602,9 +602,9 @@ func TestVMService_Clone_NilOpts(t *testing.T) {
 func TestVMService_Clone_PreserveMACs(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if params["preserve_macs"] != true {
 				t.Errorf("expected preserve_macs true, got %v", params["preserve_macs"])
 			}
@@ -638,7 +638,7 @@ func TestVMService_Clone_ServerError(t *testing.T) {
 func TestVMService_Snapshot(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "quiesce_snapshot" {
 				t.Errorf("expected action 'quiesce_snapshot', got %v", body["action"])
@@ -646,7 +646,7 @@ func TestVMService_Snapshot(t *testing.T) {
 			if int(body["vm"].(float64)) != 2 {
 				t.Errorf("expected vm 2, got %v", body["vm"])
 			}
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if int(params["retention"].(float64)) != 3600 {
 				t.Errorf("expected retention 3600, got %v", params["retention"])
 			}
@@ -663,7 +663,7 @@ func TestVMService_Snapshot(t *testing.T) {
 func TestVMService_Snapshot_NilOpts(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "quiesce_snapshot" {
 				t.Errorf("expected action 'quiesce_snapshot', got %v", body["action"])
@@ -681,9 +681,9 @@ func TestVMService_Snapshot_NilOpts(t *testing.T) {
 func TestVMService_Snapshot_WithQuiesce(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if params["quiesce"] != true {
 				t.Errorf("expected quiesce true, got %v", params["quiesce"])
 			}
@@ -717,7 +717,7 @@ func TestVMService_Snapshot_ServerError(t *testing.T) {
 func TestVMService_Migrate(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "migrate" {
 				t.Errorf("expected action 'migrate', got %v", body["action"])
@@ -725,7 +725,7 @@ func TestVMService_Migrate(t *testing.T) {
 			if int(body["vm"].(float64)) != 1 {
 				t.Errorf("expected vm 1, got %v", body["vm"])
 			}
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if int(params["node"].(float64)) != 3 {
 				t.Errorf("expected node 3, got %v", params["node"])
 			}
@@ -745,9 +745,9 @@ func TestVMService_Migrate(t *testing.T) {
 func TestVMService_Migrate_NonLive(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vm_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
-			params := body["params"].(map[string]interface{})
+			params := body["params"].(map[string]any)
 			if params["method"] != "auto" {
 				t.Errorf("expected method 'auto', got %v", params["method"])
 			}

--- a/vnet_address.go
+++ b/vnet_address.go
@@ -38,7 +38,7 @@ func (s *VNetAddressService) ListByNetwork(ctx context.Context, vnetID int, opts
 
 // ListByType returns all addresses of a specific type within a network.
 func (s *VNetAddressService) ListByType(ctx context.Context, vnetID int, addrType string, opts ...ListOption) ([]VNetAddress, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("vnet eq %d and type eq '%s'", vnetID, addrType))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("vnet eq %d and type eq '%s'", vnetID, escapeFilterValue(addrType)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }
@@ -62,7 +62,7 @@ func (s *VNetAddressService) Get(ctx context.Context, id int) (*VNetAddress, err
 
 // GetByIP returns an address by IP within a specific network.
 func (s *VNetAddressService) GetByIP(ctx context.Context, vnetID int, ip string) (*VNetAddress, error) {
-	addresses, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and ip eq '%s'", vnetID, ip)))
+	addresses, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and ip eq '%s'", vnetID, escapeFilterValue(ip))))
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (s *VNetAddressService) GetByIP(ctx context.Context, vnetID int, ip string)
 
 // GetByMAC returns an address by MAC address within a specific network.
 func (s *VNetAddressService) GetByMAC(ctx context.Context, vnetID int, mac string) (*VNetAddress, error) {
-	addresses, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and mac eq '%s'", vnetID, mac)))
+	addresses, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and mac eq '%s'", vnetID, escapeFilterValue(mac))))
 	if err != nil {
 		return nil, err
 	}

--- a/vnet_address.go
+++ b/vnet_address.go
@@ -52,7 +52,7 @@ func (s *VNetAddressService) Get(ctx context.Context, id int) (*VNetAddress, err
 	endpoint := fmt.Sprintf("/vnet_addresses/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &address); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetAddress", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetAddress", ID: id}
 		}
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (s *VNetAddressService) Update(ctx context.Context, id int, req *VNetAddres
 	endpoint := fmt.Sprintf("/vnet_addresses/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetAddress", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetAddress", ID: id}
 		}
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (s *VNetAddressService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_addresses/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetAddress", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetAddress", ID: id}
 		}
 		return err
 	}

--- a/vnet_address_test.go
+++ b/vnet_address_test.go
@@ -1,0 +1,308 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestVNetAddressService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_addresses": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetAddress{
+				{Key: 1, VNet: 10, IP: "192.168.1.100", Type: "static"},
+				{Key: 2, VNet: 10, IP: "192.168.1.101", Type: "dynamic"},
+			})
+		},
+	}))
+
+	addresses, err := client.VNetAddresses.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(addresses) != 2 {
+		t.Fatalf("expected 2 addresses, got %d", len(addresses))
+	}
+	if addresses[0].IP != "192.168.1.100" {
+		t.Errorf("expected IP '192.168.1.100', got %q", addresses[0].IP)
+	}
+}
+
+func TestVNetAddressService_ListByNetwork(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_addresses": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "vnet eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VNetAddress{{Key: 1, VNet: 10, IP: "192.168.1.100"}})
+		},
+	}))
+
+	addresses, err := client.VNetAddresses.ListByNetwork(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListByNetwork failed: %v", err)
+	}
+	if len(addresses) != 1 {
+		t.Fatalf("expected 1 address, got %d", len(addresses))
+	}
+}
+
+func TestVNetAddressService_ListByType(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_addresses": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "vnet eq 10 and type eq 'static'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VNetAddress{{Key: 1, VNet: 10, Type: "static"}})
+		},
+	}))
+
+	addresses, err := client.VNetAddresses.ListByType(context.Background(), 10, "static")
+	if err != nil {
+		t.Fatalf("ListByType failed: %v", err)
+	}
+	if len(addresses) != 1 {
+		t.Fatalf("expected 1 address, got %d", len(addresses))
+	}
+}
+
+func TestVNetAddressService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_addresses/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetAddress{Key: 1, VNet: 10, IP: "192.168.1.100", MAC: "aa:bb:cc:dd:ee:ff", Type: "static"})
+		},
+	}))
+
+	addr, err := client.VNetAddresses.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if addr.IP != "192.168.1.100" {
+		t.Errorf("expected IP '192.168.1.100', got %q", addr.IP)
+	}
+	if addr.MAC != "aa:bb:cc:dd:ee:ff" {
+		t.Errorf("expected MAC 'aa:bb:cc:dd:ee:ff', got %q", addr.MAC)
+	}
+}
+
+func TestVNetAddressService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_addresses/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VNetAddresses.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetAddressService_GetByIP(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_addresses": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetAddress{{Key: 1, VNet: 10, IP: "192.168.1.100"}})
+		},
+		"GET /api/v4/vnet_addresses/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetAddress{Key: 1, VNet: 10, IP: "192.168.1.100", Type: "static"})
+		},
+	}))
+
+	addr, err := client.VNetAddresses.GetByIP(context.Background(), 10, "192.168.1.100")
+	if err != nil {
+		t.Fatalf("GetByIP failed: %v", err)
+	}
+	if addr.Type != "static" {
+		t.Errorf("expected type 'static', got %q", addr.Type)
+	}
+}
+
+func TestVNetAddressService_GetByIP_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_addresses": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetAddress{})
+		},
+	}))
+
+	_, err := client.VNetAddresses.GetByIP(context.Background(), 10, "10.0.0.99")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetAddressService_GetByMAC(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_addresses": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetAddress{{Key: 1, VNet: 10, MAC: "aa:bb:cc:dd:ee:ff"}})
+		},
+		"GET /api/v4/vnet_addresses/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetAddress{Key: 1, VNet: 10, MAC: "aa:bb:cc:dd:ee:ff", IP: "192.168.1.100"})
+		},
+	}))
+
+	addr, err := client.VNetAddresses.GetByMAC(context.Background(), 10, "aa:bb:cc:dd:ee:ff")
+	if err != nil {
+		t.Fatalf("GetByMAC failed: %v", err)
+	}
+	if addr.IP != "192.168.1.100" {
+		t.Errorf("expected IP '192.168.1.100', got %q", addr.IP)
+	}
+}
+
+func TestVNetAddressService_GetByMAC_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_addresses": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetAddress{})
+		},
+	}))
+
+	_, err := client.VNetAddresses.GetByMAC(context.Background(), 10, "00:00:00:00:00:00")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetAddressService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_addresses": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetAddressCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.VNet != 10 {
+				t.Errorf("expected vnet 10, got %d", req.VNet)
+			}
+			if req.Type != "static" {
+				t.Errorf("expected type 'static', got %q", req.Type)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 5, "status": "ok"})
+		},
+		"GET /api/v4/vnet_addresses/5": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetAddress{Key: 5, VNet: 10, IP: "192.168.1.200", Type: "static"})
+		},
+	}))
+
+	addr, err := client.VNetAddresses.Create(context.Background(), &VNetAddressCreateRequest{
+		VNet: 10,
+		IP:   "192.168.1.200",
+		Type: "static",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if int(addr.Key) != 5 {
+		t.Errorf("expected key 5, got %d", int(addr.Key))
+	}
+}
+
+func TestVNetAddressService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetAddresses.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetAddressService_Create_MissingVNet(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetAddresses.Create(context.Background(), &VNetAddressCreateRequest{Type: "static"})
+	if err == nil {
+		t.Fatal("expected error for missing vnet")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetAddressService_Create_MissingType(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetAddresses.Create(context.Background(), &VNetAddressCreateRequest{VNet: 10})
+	if err == nil {
+		t.Fatal("expected error for missing type")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetAddressService_Update(t *testing.T) {
+	newIP := "192.168.1.201"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnet_addresses/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetAddressUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.IP == nil || *req.IP != newIP {
+				t.Errorf("expected IP %q, got %v", newIP, req.IP)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vnet_addresses/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetAddress{Key: 1, IP: newIP})
+		},
+	}))
+
+	addr, err := client.VNetAddresses.Update(context.Background(), 1, &VNetAddressUpdateRequest{IP: &newIP})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if addr.IP != newIP {
+		t.Errorf("expected IP %q, got %q", newIP, addr.IP)
+	}
+}
+
+func TestVNetAddressService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetAddresses.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetAddressService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_addresses/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VNetAddresses.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVNetAddressService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_addresses/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VNetAddresses.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/vnet_address_test.go
+++ b/vnet_address_test.go
@@ -185,7 +185,7 @@ func TestVNetAddressService_Create(t *testing.T) {
 			if req.Type != "static" {
 				t.Errorf("expected type 'static', got %q", req.Type)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 5, "status": "ok"})
+			jsonResponse(w, 200, map[string]any{"$key": 5, "status": "ok"})
 		},
 		"GET /api/v4/vnet_addresses/5": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetAddress{Key: 5, VNet: 10, IP: "192.168.1.200", Type: "static"})

--- a/vnet_dns.go
+++ b/vnet_dns.go
@@ -55,7 +55,7 @@ func (s *VNetDNSViewService) Get(ctx context.Context, id int) (*VNetDNSView, err
 
 // GetByName returns a DNS view by name within a specific network.
 func (s *VNetDNSViewService) GetByName(ctx context.Context, vnetID int, name string) (*VNetDNSView, error) {
-	views, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and name eq '%s'", vnetID, name)))
+	views, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and name eq '%s'", vnetID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +168,7 @@ func (s *VNetDNSZoneService) Get(ctx context.Context, id int) (*VNetDNSZone, err
 
 // GetByDomain returns a DNS zone by domain name within a specific view.
 func (s *VNetDNSZoneService) GetByDomain(ctx context.Context, viewID int, domain string) (*VNetDNSZone, error) {
-	zones, err := s.List(ctx, WithFilter(fmt.Sprintf("view eq %d and domain eq '%s'", viewID, domain)))
+	zones, err := s.List(ctx, WithFilter(fmt.Sprintf("view eq %d and domain eq '%s'", viewID, escapeFilterValue(domain))))
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +264,7 @@ func (s *VNetDNSRecordService) ListByZone(ctx context.Context, zoneID int, opts 
 
 // ListByType returns all DNS records of a specific type within a zone.
 func (s *VNetDNSRecordService) ListByType(ctx context.Context, zoneID int, recordType string, opts ...ListOption) ([]VNetDNSRecord, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("zone eq %d and type eq '%s'", zoneID, recordType))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("zone eq %d and type eq '%s'", zoneID, escapeFilterValue(recordType)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }
@@ -288,7 +288,7 @@ func (s *VNetDNSRecordService) Get(ctx context.Context, id int) (*VNetDNSRecord,
 
 // GetByHostAndType returns a DNS record by host and type within a zone.
 func (s *VNetDNSRecordService) GetByHostAndType(ctx context.Context, zoneID int, host, recordType string) (*VNetDNSRecord, error) {
-	records, err := s.List(ctx, WithFilter(fmt.Sprintf("zone eq %d and host eq '%s' and type eq '%s'", zoneID, host, recordType)))
+	records, err := s.List(ctx, WithFilter(fmt.Sprintf("zone eq %d and host eq '%s' and type eq '%s'", zoneID, escapeFilterValue(host), escapeFilterValue(recordType))))
 	if err != nil {
 		return nil, err
 	}

--- a/vnet_dns.go
+++ b/vnet_dns.go
@@ -45,7 +45,7 @@ func (s *VNetDNSViewService) Get(ctx context.Context, id int) (*VNetDNSView, err
 	endpoint := fmt.Sprintf("/vnet_dns_views/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &view); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetDNSView", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetDNSView", ID: id}
 		}
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (s *VNetDNSViewService) Update(ctx context.Context, id int, req *VNetDNSVie
 	endpoint := fmt.Sprintf("/vnet_dns_views/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetDNSView", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetDNSView", ID: id}
 		}
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (s *VNetDNSViewService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_dns_views/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetDNSView", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetDNSView", ID: id}
 		}
 		return err
 	}
@@ -158,7 +158,7 @@ func (s *VNetDNSZoneService) Get(ctx context.Context, id int) (*VNetDNSZone, err
 	endpoint := fmt.Sprintf("/vnet_dns_zones/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &zone); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetDNSZone", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetDNSZone", ID: id}
 		}
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func (s *VNetDNSZoneService) Update(ctx context.Context, id int, req *VNetDNSZon
 	endpoint := fmt.Sprintf("/vnet_dns_zones/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetDNSZone", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetDNSZone", ID: id}
 		}
 		return nil, err
 	}
@@ -225,7 +225,7 @@ func (s *VNetDNSZoneService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_dns_zones/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetDNSZone", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetDNSZone", ID: id}
 		}
 		return err
 	}
@@ -278,7 +278,7 @@ func (s *VNetDNSRecordService) Get(ctx context.Context, id int) (*VNetDNSRecord,
 	endpoint := fmt.Sprintf("/vnet_dns_zone_records/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &record); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetDNSRecord", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetDNSRecord", ID: id}
 		}
 		return nil, err
 	}
@@ -335,7 +335,7 @@ func (s *VNetDNSRecordService) Update(ctx context.Context, id int, req *VNetDNSR
 	endpoint := fmt.Sprintf("/vnet_dns_zone_records/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetDNSRecord", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetDNSRecord", ID: id}
 		}
 		return nil, err
 	}
@@ -348,7 +348,7 @@ func (s *VNetDNSRecordService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_dns_zone_records/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetDNSRecord", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetDNSRecord", ID: id}
 		}
 		return err
 	}

--- a/vnet_dns_test.go
+++ b/vnet_dns_test.go
@@ -1,0 +1,783 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// --- VNetDNSViewService tests ---
+
+func TestVNetDNSViewService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_views": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetDNSView{
+				{Key: 1, VNet: 10, Name: "default"},
+				{Key: 2, VNet: 10, Name: "internal"},
+			})
+		},
+	}))
+
+	views, err := client.VNetDNSViews.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(views) != 2 {
+		t.Fatalf("expected 2 views, got %d", len(views))
+	}
+	if views[0].Name != "default" {
+		t.Errorf("expected name 'default', got %q", views[0].Name)
+	}
+}
+
+func TestVNetDNSViewService_ListByNetwork(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_views": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "vnet eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VNetDNSView{{Key: 1, VNet: 10, Name: "default"}})
+		},
+	}))
+
+	views, err := client.VNetDNSViews.ListByNetwork(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListByNetwork failed: %v", err)
+	}
+	if len(views) != 1 {
+		t.Fatalf("expected 1 view, got %d", len(views))
+	}
+}
+
+func TestVNetDNSViewService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_views/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetDNSView{Key: 1, VNet: 10, Name: "default", Recursion: true})
+		},
+	}))
+
+	view, err := client.VNetDNSViews.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if view.Name != "default" {
+		t.Errorf("expected name 'default', got %q", view.Name)
+	}
+	if !view.Recursion {
+		t.Error("expected recursion to be true")
+	}
+}
+
+func TestVNetDNSViewService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_views/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VNetDNSViews.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSViewService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_views": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetDNSView{{Key: 1, VNet: 10, Name: "default"}})
+		},
+		"GET /api/v4/vnet_dns_views/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetDNSView{Key: 1, VNet: 10, Name: "default", Recursion: true})
+		},
+	}))
+
+	view, err := client.VNetDNSViews.GetByName(context.Background(), 10, "default")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if !view.Recursion {
+		t.Error("expected recursion to be true")
+	}
+}
+
+func TestVNetDNSViewService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_views": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetDNSView{})
+		},
+	}))
+
+	_, err := client.VNetDNSViews.GetByName(context.Background(), 10, "nope")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSViewService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_dns_views": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetDNSViewCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "internal" {
+				t.Errorf("expected name 'internal', got %q", req.Name)
+			}
+			if req.VNet != 10 {
+				t.Errorf("expected vnet 10, got %d", req.VNet)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 3, "status": "ok"})
+		},
+		"GET /api/v4/vnet_dns_views/3": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetDNSView{Key: 3, VNet: 10, Name: "internal"})
+		},
+	}))
+
+	view, err := client.VNetDNSViews.Create(context.Background(), &VNetDNSViewCreateRequest{
+		VNet: 10,
+		Name: "internal",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if int(view.Key) != 3 {
+		t.Errorf("expected key 3, got %d", int(view.Key))
+	}
+}
+
+func TestVNetDNSViewService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetDNSViews.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSViewService_Create_MissingVNet(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetDNSViews.Create(context.Background(), &VNetDNSViewCreateRequest{Name: "test"})
+	if err == nil {
+		t.Fatal("expected error for missing vnet")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSViewService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetDNSViews.Create(context.Background(), &VNetDNSViewCreateRequest{VNet: 10})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSViewService_Update(t *testing.T) {
+	newName := "external"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnet_dns_views/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetDNSViewUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vnet_dns_views/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetDNSView{Key: 1, Name: newName})
+		},
+	}))
+
+	view, err := client.VNetDNSViews.Update(context.Background(), 1, &VNetDNSViewUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if view.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, view.Name)
+	}
+}
+
+func TestVNetDNSViewService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetDNSViews.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSViewService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_dns_views/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VNetDNSViews.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVNetDNSViewService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_dns_views/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VNetDNSViews.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// --- VNetDNSZoneService tests ---
+
+func TestVNetDNSZoneService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_zones": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetDNSZone{
+				{Key: 1, View: 1, Domain: "example.com", Type: "master"},
+				{Key: 2, View: 1, Domain: "internal.local", Type: "master"},
+			})
+		},
+	}))
+
+	zones, err := client.VNetDNSZones.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(zones) != 2 {
+		t.Fatalf("expected 2 zones, got %d", len(zones))
+	}
+	if zones[0].Domain != "example.com" {
+		t.Errorf("expected domain 'example.com', got %q", zones[0].Domain)
+	}
+}
+
+func TestVNetDNSZoneService_ListByView(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_zones": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "view eq 1" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VNetDNSZone{{Key: 1, View: 1, Domain: "example.com"}})
+		},
+	}))
+
+	zones, err := client.VNetDNSZones.ListByView(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ListByView failed: %v", err)
+	}
+	if len(zones) != 1 {
+		t.Fatalf("expected 1 zone, got %d", len(zones))
+	}
+}
+
+func TestVNetDNSZoneService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_zones/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetDNSZone{Key: 1, View: 1, Domain: "example.com", Type: "master", Nameserver: "ns1.example.com"})
+		},
+	}))
+
+	zone, err := client.VNetDNSZones.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if zone.Domain != "example.com" {
+		t.Errorf("expected domain 'example.com', got %q", zone.Domain)
+	}
+	if zone.Nameserver != "ns1.example.com" {
+		t.Errorf("expected nameserver 'ns1.example.com', got %q", zone.Nameserver)
+	}
+}
+
+func TestVNetDNSZoneService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_zones/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VNetDNSZones.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSZoneService_GetByDomain(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_zones": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetDNSZone{{Key: 1, View: 1, Domain: "example.com"}})
+		},
+		"GET /api/v4/vnet_dns_zones/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetDNSZone{Key: 1, View: 1, Domain: "example.com", Type: "master"})
+		},
+	}))
+
+	zone, err := client.VNetDNSZones.GetByDomain(context.Background(), 1, "example.com")
+	if err != nil {
+		t.Fatalf("GetByDomain failed: %v", err)
+	}
+	if zone.Type != "master" {
+		t.Errorf("expected type 'master', got %q", zone.Type)
+	}
+}
+
+func TestVNetDNSZoneService_GetByDomain_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_zones": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetDNSZone{})
+		},
+	}))
+
+	_, err := client.VNetDNSZones.GetByDomain(context.Background(), 1, "nope.com")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSZoneService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_dns_zones": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetDNSZoneCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Domain != "test.local" {
+				t.Errorf("expected domain 'test.local', got %q", req.Domain)
+			}
+			if req.View != 1 {
+				t.Errorf("expected view 1, got %d", req.View)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 5, "status": "ok"})
+		},
+		"GET /api/v4/vnet_dns_zones/5": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetDNSZone{Key: 5, View: 1, Domain: "test.local", Type: "master"})
+		},
+	}))
+
+	zone, err := client.VNetDNSZones.Create(context.Background(), &VNetDNSZoneCreateRequest{
+		View:   1,
+		Domain: "test.local",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if int(zone.Key) != 5 {
+		t.Errorf("expected key 5, got %d", int(zone.Key))
+	}
+}
+
+func TestVNetDNSZoneService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetDNSZones.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSZoneService_Create_MissingView(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetDNSZones.Create(context.Background(), &VNetDNSZoneCreateRequest{Domain: "test.local"})
+	if err == nil {
+		t.Fatal("expected error for missing view")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSZoneService_Create_MissingDomain(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetDNSZones.Create(context.Background(), &VNetDNSZoneCreateRequest{View: 1})
+	if err == nil {
+		t.Fatal("expected error for missing domain")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSZoneService_Update(t *testing.T) {
+	newDomain := "updated.local"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnet_dns_zones/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetDNSZoneUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Domain == nil || *req.Domain != newDomain {
+				t.Errorf("expected domain %q, got %v", newDomain, req.Domain)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vnet_dns_zones/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetDNSZone{Key: 1, Domain: newDomain})
+		},
+	}))
+
+	zone, err := client.VNetDNSZones.Update(context.Background(), 1, &VNetDNSZoneUpdateRequest{Domain: &newDomain})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if zone.Domain != newDomain {
+		t.Errorf("expected domain %q, got %q", newDomain, zone.Domain)
+	}
+}
+
+func TestVNetDNSZoneService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetDNSZones.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSZoneService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_dns_zones/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VNetDNSZones.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVNetDNSZoneService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_dns_zones/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VNetDNSZones.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// --- VNetDNSRecordService tests ---
+
+func TestVNetDNSRecordService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_zone_records": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetDNSRecord{
+				{Key: 1, Zone: 1, Host: "www", Type: "A", Value: "192.168.1.10"},
+				{Key: 2, Zone: 1, Host: "mail", Type: "A", Value: "192.168.1.20"},
+			})
+		},
+	}))
+
+	records, err := client.VNetDNSRecords.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+	if records[0].Host != "www" {
+		t.Errorf("expected host 'www', got %q", records[0].Host)
+	}
+}
+
+func TestVNetDNSRecordService_ListByZone(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_zone_records": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "zone eq 1" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VNetDNSRecord{{Key: 1, Zone: 1, Host: "www"}})
+		},
+	}))
+
+	records, err := client.VNetDNSRecords.ListByZone(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("ListByZone failed: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+}
+
+func TestVNetDNSRecordService_ListByType(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_zone_records": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "zone eq 1 and type eq 'MX'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VNetDNSRecord{{Key: 3, Zone: 1, Type: "MX", Value: "mail.example.com"}})
+		},
+	}))
+
+	records, err := client.VNetDNSRecords.ListByType(context.Background(), 1, "MX")
+	if err != nil {
+		t.Fatalf("ListByType failed: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+}
+
+func TestVNetDNSRecordService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_zone_records/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetDNSRecord{Key: 1, Zone: 1, Host: "www", Type: "A", Value: "192.168.1.10"})
+		},
+	}))
+
+	record, err := client.VNetDNSRecords.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if record.Type != "A" {
+		t.Errorf("expected type 'A', got %q", record.Type)
+	}
+	if record.Value != "192.168.1.10" {
+		t.Errorf("expected value '192.168.1.10', got %q", record.Value)
+	}
+}
+
+func TestVNetDNSRecordService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_zone_records/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VNetDNSRecords.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSRecordService_GetByHostAndType(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_zone_records": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetDNSRecord{{Key: 1, Zone: 1, Host: "www", Type: "A"}})
+		},
+		"GET /api/v4/vnet_dns_zone_records/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetDNSRecord{Key: 1, Zone: 1, Host: "www", Type: "A", Value: "192.168.1.10"})
+		},
+	}))
+
+	record, err := client.VNetDNSRecords.GetByHostAndType(context.Background(), 1, "www", "A")
+	if err != nil {
+		t.Fatalf("GetByHostAndType failed: %v", err)
+	}
+	if record.Value != "192.168.1.10" {
+		t.Errorf("expected value '192.168.1.10', got %q", record.Value)
+	}
+}
+
+func TestVNetDNSRecordService_GetByHostAndType_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_dns_zone_records": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetDNSRecord{})
+		},
+	}))
+
+	_, err := client.VNetDNSRecords.GetByHostAndType(context.Background(), 1, "nope", "A")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSRecordService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_dns_zone_records": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetDNSRecordCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Zone != 1 {
+				t.Errorf("expected zone 1, got %d", req.Zone)
+			}
+			if req.Type != "A" {
+				t.Errorf("expected type 'A', got %q", req.Type)
+			}
+			if req.Value != "192.168.1.30" {
+				t.Errorf("expected value '192.168.1.30', got %q", req.Value)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 5, "status": "ok"})
+		},
+		"GET /api/v4/vnet_dns_zone_records/5": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetDNSRecord{Key: 5, Zone: 1, Host: "api", Type: "A", Value: "192.168.1.30"})
+		},
+	}))
+
+	record, err := client.VNetDNSRecords.Create(context.Background(), &VNetDNSRecordCreateRequest{
+		Zone:  1,
+		Host:  "api",
+		Type:  "A",
+		Value: "192.168.1.30",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if int(record.Key) != 5 {
+		t.Errorf("expected key 5, got %d", int(record.Key))
+	}
+}
+
+func TestVNetDNSRecordService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetDNSRecords.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSRecordService_Create_MissingZone(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetDNSRecords.Create(context.Background(), &VNetDNSRecordCreateRequest{Type: "A", Value: "1.2.3.4"})
+	if err == nil {
+		t.Fatal("expected error for missing zone")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSRecordService_Create_MissingType(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetDNSRecords.Create(context.Background(), &VNetDNSRecordCreateRequest{Zone: 1, Value: "1.2.3.4"})
+	if err == nil {
+		t.Fatal("expected error for missing type")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSRecordService_Create_MissingValue(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetDNSRecords.Create(context.Background(), &VNetDNSRecordCreateRequest{Zone: 1, Type: "A"})
+	if err == nil {
+		t.Fatal("expected error for missing value")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSRecordService_Update(t *testing.T) {
+	newValue := "192.168.1.99"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnet_dns_zone_records/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetDNSRecordUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Value == nil || *req.Value != newValue {
+				t.Errorf("expected value %q, got %v", newValue, req.Value)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vnet_dns_zone_records/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetDNSRecord{Key: 1, Value: newValue})
+		},
+	}))
+
+	record, err := client.VNetDNSRecords.Update(context.Background(), 1, &VNetDNSRecordUpdateRequest{Value: &newValue})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if record.Value != newValue {
+		t.Errorf("expected value %q, got %q", newValue, record.Value)
+	}
+}
+
+func TestVNetDNSRecordService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetDNSRecords.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetDNSRecordService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_dns_zone_records/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VNetDNSRecords.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVNetDNSRecordService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_dns_zone_records/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VNetDNSRecords.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/vnet_dns_test.go
+++ b/vnet_dns_test.go
@@ -132,7 +132,7 @@ func TestVNetDNSViewService_Create(t *testing.T) {
 			if req.VNet != 10 {
 				t.Errorf("expected vnet 10, got %d", req.VNet)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 3, "status": "ok"})
+			jsonResponse(w, 200, map[string]any{"$key": 3, "status": "ok"})
 		},
 		"GET /api/v4/vnet_dns_views/3": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetDNSView{Key: 3, VNet: 10, Name: "internal"})
@@ -378,7 +378,7 @@ func TestVNetDNSZoneService_Create(t *testing.T) {
 			if req.View != 1 {
 				t.Errorf("expected view 1, got %d", req.View)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 5, "status": "ok"})
+			jsonResponse(w, 200, map[string]any{"$key": 5, "status": "ok"})
 		},
 		"GET /api/v4/vnet_dns_zones/5": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetDNSZone{Key: 5, View: 1, Domain: "test.local", Type: "master"})
@@ -647,7 +647,7 @@ func TestVNetDNSRecordService_Create(t *testing.T) {
 			if req.Value != "192.168.1.30" {
 				t.Errorf("expected value '192.168.1.30', got %q", req.Value)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 5, "status": "ok"})
+			jsonResponse(w, 200, map[string]any{"$key": 5, "status": "ok"})
 		},
 		"GET /api/v4/vnet_dns_zone_records/5": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetDNSRecord{Key: 5, Zone: 1, Host: "api", Type: "A", Value: "192.168.1.30"})

--- a/vnet_host.go
+++ b/vnet_host.go
@@ -46,7 +46,7 @@ func (s *VNetHostService) Get(ctx context.Context, id int) (*VNetHost, error) {
 	endpoint := fmt.Sprintf("/vnet_hosts/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &host); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetHost", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetHost", ID: id}
 		}
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (s *VNetHostService) Update(ctx context.Context, id int, req *VNetHostUpdat
 	endpoint := fmt.Sprintf("/vnet_hosts/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetHost", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetHost", ID: id}
 		}
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (s *VNetHostService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_hosts/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetHost", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetHost", ID: id}
 		}
 		return err
 	}

--- a/vnet_host.go
+++ b/vnet_host.go
@@ -56,7 +56,7 @@ func (s *VNetHostService) Get(ctx context.Context, id int) (*VNetHost, error) {
 
 // GetByHost returns a host override by hostname within a specific network.
 func (s *VNetHostService) GetByHost(ctx context.Context, vnetID int, hostname string) (*VNetHost, error) {
-	hosts, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and host eq '%s'", vnetID, hostname)))
+	hosts, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and host eq '%s'", vnetID, escapeFilterValue(hostname))))
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (s *VNetHostService) GetByHost(ctx context.Context, vnetID int, hostname st
 
 // GetByIP returns a host override by IP address within a specific network.
 func (s *VNetHostService) GetByIP(ctx context.Context, vnetID int, ip string) (*VNetHost, error) {
-	hosts, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and ip eq '%s'", vnetID, ip)))
+	hosts, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and ip eq '%s'", vnetID, escapeFilterValue(ip))))
 	if err != nil {
 		return nil, err
 	}

--- a/vnet_host_test.go
+++ b/vnet_host_test.go
@@ -168,7 +168,7 @@ func TestVNetHostService_Create(t *testing.T) {
 			if req.IP != "192.168.1.50" {
 				t.Errorf("expected IP '192.168.1.50', got %q", req.IP)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 5, "status": "ok"})
+			jsonResponse(w, 200, map[string]any{"$key": 5, "status": "ok"})
 		},
 		"GET /api/v4/vnet_hosts/5": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetHost{Key: 5, VNet: 10, Host: "db-server", IP: "192.168.1.50", Type: "host"})

--- a/vnet_host_test.go
+++ b/vnet_host_test.go
@@ -1,0 +1,303 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestVNetHostService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_hosts": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetHost{
+				{Key: 1, VNet: 10, Host: "server1", IP: "192.168.1.10"},
+				{Key: 2, VNet: 10, Host: "server2", IP: "192.168.1.11"},
+			})
+		},
+	}))
+
+	hosts, err := client.VNetHosts.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(hosts) != 2 {
+		t.Fatalf("expected 2 hosts, got %d", len(hosts))
+	}
+	if hosts[0].Host != "server1" {
+		t.Errorf("expected host 'server1', got %q", hosts[0].Host)
+	}
+}
+
+func TestVNetHostService_ListByNetwork(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_hosts": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "vnet eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VNetHost{{Key: 1, VNet: 10, Host: "server1"}})
+		},
+	}))
+
+	hosts, err := client.VNetHosts.ListByNetwork(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListByNetwork failed: %v", err)
+	}
+	if len(hosts) != 1 {
+		t.Fatalf("expected 1 host, got %d", len(hosts))
+	}
+}
+
+func TestVNetHostService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_hosts/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetHost{Key: 1, VNet: 10, Host: "server1", IP: "192.168.1.10", Type: "host"})
+		},
+	}))
+
+	host, err := client.VNetHosts.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if host.Host != "server1" {
+		t.Errorf("expected host 'server1', got %q", host.Host)
+	}
+	if host.IP != "192.168.1.10" {
+		t.Errorf("expected IP '192.168.1.10', got %q", host.IP)
+	}
+}
+
+func TestVNetHostService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_hosts/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VNetHosts.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetHostService_GetByHost(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_hosts": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetHost{{Key: 1, VNet: 10, Host: "server1"}})
+		},
+		"GET /api/v4/vnet_hosts/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetHost{Key: 1, VNet: 10, Host: "server1", IP: "192.168.1.10"})
+		},
+	}))
+
+	host, err := client.VNetHosts.GetByHost(context.Background(), 10, "server1")
+	if err != nil {
+		t.Fatalf("GetByHost failed: %v", err)
+	}
+	if host.IP != "192.168.1.10" {
+		t.Errorf("expected IP '192.168.1.10', got %q", host.IP)
+	}
+}
+
+func TestVNetHostService_GetByHost_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_hosts": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetHost{})
+		},
+	}))
+
+	_, err := client.VNetHosts.GetByHost(context.Background(), 10, "nope")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetHostService_GetByIP(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_hosts": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetHost{{Key: 1, VNet: 10, IP: "192.168.1.10"}})
+		},
+		"GET /api/v4/vnet_hosts/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetHost{Key: 1, VNet: 10, Host: "server1", IP: "192.168.1.10"})
+		},
+	}))
+
+	host, err := client.VNetHosts.GetByIP(context.Background(), 10, "192.168.1.10")
+	if err != nil {
+		t.Fatalf("GetByIP failed: %v", err)
+	}
+	if host.Host != "server1" {
+		t.Errorf("expected host 'server1', got %q", host.Host)
+	}
+}
+
+func TestVNetHostService_GetByIP_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_hosts": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetHost{})
+		},
+	}))
+
+	_, err := client.VNetHosts.GetByIP(context.Background(), 10, "10.0.0.99")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetHostService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_hosts": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetHostCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.VNet != 10 {
+				t.Errorf("expected vnet 10, got %d", req.VNet)
+			}
+			if req.Host != "db-server" {
+				t.Errorf("expected host 'db-server', got %q", req.Host)
+			}
+			if req.IP != "192.168.1.50" {
+				t.Errorf("expected IP '192.168.1.50', got %q", req.IP)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 5, "status": "ok"})
+		},
+		"GET /api/v4/vnet_hosts/5": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetHost{Key: 5, VNet: 10, Host: "db-server", IP: "192.168.1.50", Type: "host"})
+		},
+	}))
+
+	host, err := client.VNetHosts.Create(context.Background(), &VNetHostCreateRequest{
+		VNet: 10,
+		Host: "db-server",
+		IP:   "192.168.1.50",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if int(host.Key) != 5 {
+		t.Errorf("expected key 5, got %d", int(host.Key))
+	}
+}
+
+func TestVNetHostService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetHosts.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetHostService_Create_MissingVNet(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetHosts.Create(context.Background(), &VNetHostCreateRequest{Host: "test", IP: "1.2.3.4"})
+	if err == nil {
+		t.Fatal("expected error for missing vnet")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetHostService_Create_MissingHost(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetHosts.Create(context.Background(), &VNetHostCreateRequest{VNet: 10, IP: "1.2.3.4"})
+	if err == nil {
+		t.Fatal("expected error for missing host")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetHostService_Create_MissingIP(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetHosts.Create(context.Background(), &VNetHostCreateRequest{VNet: 10, Host: "test"})
+	if err == nil {
+		t.Fatal("expected error for missing ip")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetHostService_Update(t *testing.T) {
+	newIP := "192.168.1.99"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnet_hosts/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetHostUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.IP == nil || *req.IP != newIP {
+				t.Errorf("expected IP %q, got %v", newIP, req.IP)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vnet_hosts/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetHost{Key: 1, Host: "server1", IP: newIP})
+		},
+	}))
+
+	host, err := client.VNetHosts.Update(context.Background(), 1, &VNetHostUpdateRequest{IP: &newIP})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if host.IP != newIP {
+		t.Errorf("expected IP %q, got %q", newIP, host.IP)
+	}
+}
+
+func TestVNetHostService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetHosts.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetHostService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_hosts/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VNetHosts.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVNetHostService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_hosts/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VNetHosts.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/vnet_ipsec.go
+++ b/vnet_ipsec.go
@@ -158,7 +158,7 @@ func (s *VNetIPSecPhase1Service) Get(ctx context.Context, id int) (*VNetIPSecPha
 
 // GetByName returns a Phase 1 configuration by name within an IPSec configuration.
 func (s *VNetIPSecPhase1Service) GetByName(ctx context.Context, ipsecID int, name string) (*VNetIPSecPhase1, error) {
-	phase1s, err := s.List(ctx, WithFilter(fmt.Sprintf("ipsec eq %d and name eq '%s'", ipsecID, name)))
+	phase1s, err := s.List(ctx, WithFilter(fmt.Sprintf("ipsec eq %d and name eq '%s'", ipsecID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +274,7 @@ func (s *VNetIPSecPhase2Service) Get(ctx context.Context, id int) (*VNetIPSecPha
 
 // GetByName returns a Phase 2 configuration by name within a Phase 1.
 func (s *VNetIPSecPhase2Service) GetByName(ctx context.Context, phase1ID int, name string) (*VNetIPSecPhase2, error) {
-	phase2s, err := s.List(ctx, WithFilter(fmt.Sprintf("phase1 eq %d and name eq '%s'", phase1ID, name)))
+	phase2s, err := s.List(ctx, WithFilter(fmt.Sprintf("phase1 eq %d and name eq '%s'", phase1ID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/vnet_ipsec.go
+++ b/vnet_ipsec.go
@@ -38,7 +38,7 @@ func (s *VNetIPSecService) Get(ctx context.Context, id int) (*VNetIPSec, error) 
 	endpoint := fmt.Sprintf("/vnet_ipsecs/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &ipsec); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetIPSec", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetIPSec", ID: id}
 		}
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (s *VNetIPSecService) Update(ctx context.Context, id int, req *VNetIPSecUpd
 	endpoint := fmt.Sprintf("/vnet_ipsecs/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetIPSec", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetIPSec", ID: id}
 		}
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (s *VNetIPSecService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_ipsecs/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetIPSec", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetIPSec", ID: id}
 		}
 		return err
 	}
@@ -148,7 +148,7 @@ func (s *VNetIPSecPhase1Service) Get(ctx context.Context, id int) (*VNetIPSecPha
 	endpoint := fmt.Sprintf("/vnet_ipsec_phase1s/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &phase1); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetIPSecPhase1", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetIPSecPhase1", ID: id}
 		}
 		return nil, err
 	}
@@ -205,7 +205,7 @@ func (s *VNetIPSecPhase1Service) Update(ctx context.Context, id int, req *VNetIP
 	endpoint := fmt.Sprintf("/vnet_ipsec_phase1s/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetIPSecPhase1", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetIPSecPhase1", ID: id}
 		}
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func (s *VNetIPSecPhase1Service) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_ipsec_phase1s/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetIPSecPhase1", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetIPSecPhase1", ID: id}
 		}
 		return err
 	}
@@ -264,7 +264,7 @@ func (s *VNetIPSecPhase2Service) Get(ctx context.Context, id int) (*VNetIPSecPha
 	endpoint := fmt.Sprintf("/vnet_ipsec_phase2s/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &phase2); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetIPSecPhase2", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetIPSecPhase2", ID: id}
 		}
 		return nil, err
 	}
@@ -321,7 +321,7 @@ func (s *VNetIPSecPhase2Service) Update(ctx context.Context, id int, req *VNetIP
 	endpoint := fmt.Sprintf("/vnet_ipsec_phase2s/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetIPSecPhase2", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetIPSecPhase2", ID: id}
 		}
 		return nil, err
 	}
@@ -334,7 +334,7 @@ func (s *VNetIPSecPhase2Service) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_ipsec_phase2s/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetIPSecPhase2", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetIPSecPhase2", ID: id}
 		}
 		return err
 	}
@@ -387,7 +387,7 @@ func (s *VNetIPSecConnectionService) Get(ctx context.Context, id int) (*VNetIPSe
 	endpoint := fmt.Sprintf("/vnet_ipsec_connections/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &conn); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetIPSecConnection", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetIPSecConnection", ID: id}
 		}
 		return nil, err
 	}

--- a/vnet_ipsec_test.go
+++ b/vnet_ipsec_test.go
@@ -1,0 +1,821 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// VNetIPSecService tests
+// ---------------------------------------------------------------------------
+
+func TestVNetIPSecService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsecs": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetIPSec{
+				{Key: 1, VNet: 10, Enabled: true},
+				{Key: 2, VNet: 20, Enabled: false},
+			})
+		},
+	}))
+
+	ipsecs, err := client.VNetIPSecs.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(ipsecs) != 2 {
+		t.Fatalf("expected 2 ipsecs, got %d", len(ipsecs))
+	}
+	if !ipsecs[0].Enabled {
+		t.Error("expected first ipsec to be enabled")
+	}
+}
+
+func TestVNetIPSecService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsecs/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetIPSec{Key: 1, VNet: 10, Enabled: true, Mode: "normal"})
+		},
+	}))
+
+	ipsec, err := client.VNetIPSecs.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if ipsec.Mode != "normal" {
+		t.Errorf("expected mode 'normal', got %q", ipsec.Mode)
+	}
+}
+
+func TestVNetIPSecService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsecs/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VNetIPSecs.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecService_GetByNetwork(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsecs": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "vnet eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VNetIPSec{{Key: 1, VNet: 10}})
+		},
+		"GET /api/v4/vnet_ipsecs/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetIPSec{Key: 1, VNet: 10, Enabled: true})
+		},
+	}))
+
+	ipsec, err := client.VNetIPSecs.GetByNetwork(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("GetByNetwork failed: %v", err)
+	}
+	if int(ipsec.VNet) != 10 {
+		t.Errorf("expected vnet 10, got %d", ipsec.VNet)
+	}
+}
+
+func TestVNetIPSecService_GetByNetwork_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsecs": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetIPSec{})
+		},
+	}))
+
+	_, err := client.VNetIPSecs.GetByNetwork(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_ipsecs": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetIPSecCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.VNet != 10 {
+				t.Errorf("expected vnet 10, got %d", req.VNet)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+		},
+		"GET /api/v4/vnet_ipsecs/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetIPSec{Key: 1, VNet: 10, Enabled: true, Mode: "normal"})
+		},
+	}))
+
+	ipsec, err := client.VNetIPSecs.Create(context.Background(), &VNetIPSecCreateRequest{VNet: 10})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if int(ipsec.VNet) != 10 {
+		t.Errorf("expected vnet 10, got %d", ipsec.VNet)
+	}
+}
+
+func TestVNetIPSecService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetIPSecs.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecService_Create_MissingVNet(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetIPSecs.Create(context.Background(), &VNetIPSecCreateRequest{})
+	if err == nil {
+		t.Fatal("expected error for missing vnet")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecService_Update(t *testing.T) {
+	enabled := false
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnet_ipsecs/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vnet_ipsecs/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetIPSec{Key: 1, VNet: 10, Enabled: false})
+		},
+	}))
+
+	ipsec, err := client.VNetIPSecs.Update(context.Background(), 1, &VNetIPSecUpdateRequest{Enabled: &enabled})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if ipsec.Enabled {
+		t.Error("expected ipsec to be disabled")
+	}
+}
+
+func TestVNetIPSecService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetIPSecs.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_ipsecs/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VNetIPSecs.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVNetIPSecService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_ipsecs/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VNetIPSecs.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VNetIPSecPhase1Service tests
+// ---------------------------------------------------------------------------
+
+func TestVNetIPSecPhase1Service_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_phase1s": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetIPSecPhase1{
+				{Key: 1, Name: "phase1-a", RemoteGateway: "1.2.3.4"},
+				{Key: 2, Name: "phase1-b", RemoteGateway: "5.6.7.8"},
+			})
+		},
+	}))
+
+	phase1s, err := client.VNetIPSecPhase1s.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(phase1s) != 2 {
+		t.Fatalf("expected 2 phase1s, got %d", len(phase1s))
+	}
+}
+
+func TestVNetIPSecPhase1Service_ListByIPSec(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_phase1s": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "ipsec eq 5" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VNetIPSecPhase1{{Key: 1, IPSec: 5, Name: "phase1-a"}})
+		},
+	}))
+
+	phase1s, err := client.VNetIPSecPhase1s.ListByIPSec(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("ListByIPSec failed: %v", err)
+	}
+	if len(phase1s) != 1 {
+		t.Fatalf("expected 1 phase1, got %d", len(phase1s))
+	}
+}
+
+func TestVNetIPSecPhase1Service_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_phase1s/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetIPSecPhase1{Key: 1, Name: "phase1-a", RemoteGateway: "1.2.3.4", Auth: "psk"})
+		},
+	}))
+
+	p1, err := client.VNetIPSecPhase1s.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if p1.RemoteGateway != "1.2.3.4" {
+		t.Errorf("expected remote_gateway '1.2.3.4', got %q", p1.RemoteGateway)
+	}
+}
+
+func TestVNetIPSecPhase1Service_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_phase1s/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VNetIPSecPhase1s.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecPhase1Service_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_phase1s": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetIPSecPhase1{{Key: 1, IPSec: 5, Name: "phase1-a"}})
+		},
+		"GET /api/v4/vnet_ipsec_phase1s/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetIPSecPhase1{Key: 1, IPSec: 5, Name: "phase1-a", RemoteGateway: "1.2.3.4"})
+		},
+	}))
+
+	p1, err := client.VNetIPSecPhase1s.GetByName(context.Background(), 5, "phase1-a")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if p1.Name != "phase1-a" {
+		t.Errorf("expected name 'phase1-a', got %q", p1.Name)
+	}
+}
+
+func TestVNetIPSecPhase1Service_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_phase1s": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetIPSecPhase1{})
+		},
+	}))
+
+	_, err := client.VNetIPSecPhase1s.GetByName(context.Background(), 5, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecPhase1Service_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_ipsec_phase1s": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetIPSecPhase1CreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "phase1-a" {
+				t.Errorf("expected name 'phase1-a', got %q", req.Name)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+		},
+		"GET /api/v4/vnet_ipsec_phase1s/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetIPSecPhase1{Key: 1, IPSec: 5, Name: "phase1-a", RemoteGateway: "1.2.3.4"})
+		},
+	}))
+
+	p1, err := client.VNetIPSecPhase1s.Create(context.Background(), &VNetIPSecPhase1CreateRequest{
+		IPSec:         5,
+		Name:          "phase1-a",
+		RemoteGateway: "1.2.3.4",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if p1.Name != "phase1-a" {
+		t.Errorf("expected name 'phase1-a', got %q", p1.Name)
+	}
+}
+
+func TestVNetIPSecPhase1Service_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetIPSecPhase1s.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecPhase1Service_Create_MissingIPSec(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetIPSecPhase1s.Create(context.Background(), &VNetIPSecPhase1CreateRequest{
+		Name:          "phase1-a",
+		RemoteGateway: "1.2.3.4",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing ipsec")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecPhase1Service_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetIPSecPhase1s.Create(context.Background(), &VNetIPSecPhase1CreateRequest{
+		IPSec:         5,
+		RemoteGateway: "1.2.3.4",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecPhase1Service_Create_MissingRemoteGateway(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetIPSecPhase1s.Create(context.Background(), &VNetIPSecPhase1CreateRequest{
+		IPSec: 5,
+		Name:  "phase1-a",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing remote_gateway")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecPhase1Service_Update(t *testing.T) {
+	newName := "phase1-updated"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnet_ipsec_phase1s/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vnet_ipsec_phase1s/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetIPSecPhase1{Key: 1, Name: newName})
+		},
+	}))
+
+	p1, err := client.VNetIPSecPhase1s.Update(context.Background(), 1, &VNetIPSecPhase1UpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if p1.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, p1.Name)
+	}
+}
+
+func TestVNetIPSecPhase1Service_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetIPSecPhase1s.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecPhase1Service_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_ipsec_phase1s/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VNetIPSecPhase1s.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVNetIPSecPhase1Service_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_ipsec_phase1s/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VNetIPSecPhase1s.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VNetIPSecPhase2Service tests
+// ---------------------------------------------------------------------------
+
+func TestVNetIPSecPhase2Service_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_phase2s": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetIPSecPhase2{
+				{Key: 1, Name: "phase2-a", Local: "10.0.0.0/24"},
+				{Key: 2, Name: "phase2-b", Local: "10.0.1.0/24"},
+			})
+		},
+	}))
+
+	phase2s, err := client.VNetIPSecPhase2s.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(phase2s) != 2 {
+		t.Fatalf("expected 2 phase2s, got %d", len(phase2s))
+	}
+}
+
+func TestVNetIPSecPhase2Service_ListByPhase1(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_phase2s": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "phase1 eq 3" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VNetIPSecPhase2{{Key: 1, Phase1: 3, Name: "phase2-a"}})
+		},
+	}))
+
+	phase2s, err := client.VNetIPSecPhase2s.ListByPhase1(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("ListByPhase1 failed: %v", err)
+	}
+	if len(phase2s) != 1 {
+		t.Fatalf("expected 1 phase2, got %d", len(phase2s))
+	}
+}
+
+func TestVNetIPSecPhase2Service_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_phase2s/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetIPSecPhase2{Key: 1, Name: "phase2-a", Local: "10.0.0.0/24", Remote: "10.0.1.0/24", Mode: "tunnel"})
+		},
+	}))
+
+	p2, err := client.VNetIPSecPhase2s.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if p2.Mode != "tunnel" {
+		t.Errorf("expected mode 'tunnel', got %q", p2.Mode)
+	}
+}
+
+func TestVNetIPSecPhase2Service_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_phase2s/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VNetIPSecPhase2s.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecPhase2Service_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_phase2s": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetIPSecPhase2{{Key: 1, Phase1: 3, Name: "phase2-a"}})
+		},
+		"GET /api/v4/vnet_ipsec_phase2s/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetIPSecPhase2{Key: 1, Phase1: 3, Name: "phase2-a", Local: "10.0.0.0/24"})
+		},
+	}))
+
+	p2, err := client.VNetIPSecPhase2s.GetByName(context.Background(), 3, "phase2-a")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if p2.Name != "phase2-a" {
+		t.Errorf("expected name 'phase2-a', got %q", p2.Name)
+	}
+}
+
+func TestVNetIPSecPhase2Service_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_phase2s": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetIPSecPhase2{})
+		},
+	}))
+
+	_, err := client.VNetIPSecPhase2s.GetByName(context.Background(), 3, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecPhase2Service_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_ipsec_phase2s": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetIPSecPhase2CreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "phase2-a" {
+				t.Errorf("expected name 'phase2-a', got %q", req.Name)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+		},
+		"GET /api/v4/vnet_ipsec_phase2s/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetIPSecPhase2{Key: 1, Phase1: 3, Name: "phase2-a", Local: "10.0.0.0/24"})
+		},
+	}))
+
+	p2, err := client.VNetIPSecPhase2s.Create(context.Background(), &VNetIPSecPhase2CreateRequest{
+		Phase1: 3,
+		Name:   "phase2-a",
+		Local:  "10.0.0.0/24",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if p2.Name != "phase2-a" {
+		t.Errorf("expected name 'phase2-a', got %q", p2.Name)
+	}
+}
+
+func TestVNetIPSecPhase2Service_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetIPSecPhase2s.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecPhase2Service_Create_MissingPhase1(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetIPSecPhase2s.Create(context.Background(), &VNetIPSecPhase2CreateRequest{
+		Name:  "phase2-a",
+		Local: "10.0.0.0/24",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing phase1")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecPhase2Service_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetIPSecPhase2s.Create(context.Background(), &VNetIPSecPhase2CreateRequest{
+		Phase1: 3,
+		Local:  "10.0.0.0/24",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecPhase2Service_Create_MissingLocal(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetIPSecPhase2s.Create(context.Background(), &VNetIPSecPhase2CreateRequest{
+		Phase1: 3,
+		Name:   "phase2-a",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing local")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecPhase2Service_Update(t *testing.T) {
+	newName := "phase2-updated"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnet_ipsec_phase2s/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vnet_ipsec_phase2s/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetIPSecPhase2{Key: 1, Name: newName})
+		},
+	}))
+
+	p2, err := client.VNetIPSecPhase2s.Update(context.Background(), 1, &VNetIPSecPhase2UpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if p2.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, p2.Name)
+	}
+}
+
+func TestVNetIPSecPhase2Service_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetIPSecPhase2s.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetIPSecPhase2Service_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_ipsec_phase2s/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VNetIPSecPhase2s.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVNetIPSecPhase2Service_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_ipsec_phase2s/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VNetIPSecPhase2s.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VNetIPSecConnectionService tests (read-only)
+// ---------------------------------------------------------------------------
+
+func TestVNetIPSecConnectionService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_connections": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetIPSecConnection{
+				{Key: 1, VNet: 10, Local: "10.0.0.1", Remote: "10.0.1.1"},
+				{Key: 2, VNet: 10, Local: "10.0.0.1", Remote: "10.0.2.1"},
+			})
+		},
+	}))
+
+	conns, err := client.VNetIPSecConnections.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(conns) != 2 {
+		t.Fatalf("expected 2 connections, got %d", len(conns))
+	}
+}
+
+func TestVNetIPSecConnectionService_ListByNetwork(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_connections": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "vnet eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VNetIPSecConnection{{Key: 1, VNet: 10}})
+		},
+	}))
+
+	conns, err := client.VNetIPSecConnections.ListByNetwork(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListByNetwork failed: %v", err)
+	}
+	if len(conns) != 1 {
+		t.Fatalf("expected 1 connection, got %d", len(conns))
+	}
+}
+
+func TestVNetIPSecConnectionService_ListByPhase1(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_connections": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "phase1 eq 3" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VNetIPSecConnection{{Key: 1, Phase1: 3}})
+		},
+	}))
+
+	conns, err := client.VNetIPSecConnections.ListByPhase1(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("ListByPhase1 failed: %v", err)
+	}
+	if len(conns) != 1 {
+		t.Fatalf("expected 1 connection, got %d", len(conns))
+	}
+}
+
+func TestVNetIPSecConnectionService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_connections/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetIPSecConnection{Key: 1, VNet: 10, Local: "10.0.0.1", Remote: "10.0.1.1", Protocol: "esp"})
+		},
+	}))
+
+	conn, err := client.VNetIPSecConnections.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if conn.Protocol != "esp" {
+		t.Errorf("expected protocol 'esp', got %q", conn.Protocol)
+	}
+}
+
+func TestVNetIPSecConnectionService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_ipsec_connections/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VNetIPSecConnections.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/vnet_ipsec_test.go
+++ b/vnet_ipsec_test.go
@@ -112,7 +112,7 @@ func TestVNetIPSecService_Create(t *testing.T) {
 			if req.VNet != 10 {
 				t.Errorf("expected vnet 10, got %d", req.VNet)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/vnet_ipsecs/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetIPSec{Key: 1, VNet: 10, Enabled: true, Mode: "normal"})
@@ -331,7 +331,7 @@ func TestVNetIPSecPhase1Service_Create(t *testing.T) {
 			if req.Name != "phase1-a" {
 				t.Errorf("expected name 'phase1-a', got %q", req.Name)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/vnet_ipsec_phase1s/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetIPSecPhase1{Key: 1, IPSec: 5, Name: "phase1-a", RemoteGateway: "1.2.3.4"})
@@ -587,7 +587,7 @@ func TestVNetIPSecPhase2Service_Create(t *testing.T) {
 			if req.Name != "phase2-a" {
 				t.Errorf("expected name 'phase2-a', got %q", req.Name)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/vnet_ipsec_phase2s/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetIPSecPhase2{Key: 1, Phase1: 3, Name: "phase2-a", Local: "10.0.0.0/24"})

--- a/vnet_rule.go
+++ b/vnet_rule.go
@@ -57,7 +57,7 @@ func (s *VNetRuleService) Get(ctx context.Context, id int) (*VNetRule, error) {
 
 // GetByName returns a firewall rule by name within a specific network.
 func (s *VNetRuleService) GetByName(ctx context.Context, vnetID int, name string) (*VNetRule, error) {
-	rules, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and name eq '%s'", vnetID, name)))
+	rules, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and name eq '%s'", vnetID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func (s *VNetRuleAliasService) Get(ctx context.Context, id int) (*VNetRuleAlias,
 
 // GetByName returns a rule alias by name.
 func (s *VNetRuleAliasService) GetByName(ctx context.Context, name string) (*VNetRuleAlias, error) {
-	aliases, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	aliases, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/vnet_rule.go
+++ b/vnet_rule.go
@@ -47,7 +47,7 @@ func (s *VNetRuleService) Get(ctx context.Context, id int) (*VNetRule, error) {
 	endpoint := fmt.Sprintf("/vnet_rules/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &rule); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetRule", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetRule", ID: id}
 		}
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (s *VNetRuleService) Update(ctx context.Context, id int, req *VNetRuleUpdat
 	endpoint := fmt.Sprintf("/vnet_rules/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetRule", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetRule", ID: id}
 		}
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (s *VNetRuleService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_rules/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetRule", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetRule", ID: id}
 		}
 		return err
 	}
@@ -208,7 +208,7 @@ func (s *VNetRuleAliasService) Get(ctx context.Context, id int) (*VNetRuleAlias,
 	endpoint := fmt.Sprintf("/vnet_rule_aliases/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &alias); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetRuleAlias", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetRuleAlias", ID: id}
 		}
 		return nil, err
 	}
@@ -265,7 +265,7 @@ func (s *VNetRuleAliasService) Update(ctx context.Context, id int, req *VNetRule
 	endpoint := fmt.Sprintf("/vnet_rule_aliases/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetRuleAlias", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetRuleAlias", ID: id}
 		}
 		return nil, err
 	}
@@ -279,7 +279,7 @@ func (s *VNetRuleAliasService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_rule_aliases/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetRuleAlias", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetRuleAlias", ID: id}
 		}
 		return err
 	}

--- a/vnet_rule_test.go
+++ b/vnet_rule_test.go
@@ -132,7 +132,7 @@ func TestVNetRuleService_Create(t *testing.T) {
 			if req.VNet != 10 {
 				t.Errorf("expected vnet 10, got %d", req.VNet)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 5, "status": "ok"})
+			jsonResponse(w, 200, map[string]any{"$key": 5, "status": "ok"})
 		},
 		"GET /api/v4/vnet_rules/5": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetRule{Key: 5, VNet: 10, Name: "allow-http", Action: "accept", Enabled: true})
@@ -418,7 +418,7 @@ func TestVNetRuleAliasService_Create(t *testing.T) {
 			if req.Name != "web-servers" {
 				t.Errorf("expected name 'web-servers', got %q", req.Name)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 3, "status": "ok"})
+			jsonResponse(w, 200, map[string]any{"$key": 3, "status": "ok"})
 		},
 		"GET /api/v4/vnet_rule_aliases/3": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetRuleAlias{Key: 3, Name: "web-servers", Value: "192.168.1.10,192.168.1.11"})

--- a/vnet_rule_test.go
+++ b/vnet_rule_test.go
@@ -1,0 +1,540 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// --- VNetRuleService tests ---
+
+func TestVNetRuleService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_rules": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetRule{
+				{Key: 1, Name: "allow-ssh", VNet: 10, Action: "accept"},
+				{Key: 2, Name: "block-all", VNet: 10, Action: "drop"},
+			})
+		},
+	}))
+
+	rules, err := client.VNetRules.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("expected 2 rules, got %d", len(rules))
+	}
+	if rules[0].Name != "allow-ssh" {
+		t.Errorf("expected name 'allow-ssh', got %q", rules[0].Name)
+	}
+}
+
+func TestVNetRuleService_ListByNetwork(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_rules": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "vnet eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VNetRule{{Key: 1, VNet: 10, Name: "allow-ssh"}})
+		},
+	}))
+
+	rules, err := client.VNetRules.ListByNetwork(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListByNetwork failed: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rules))
+	}
+}
+
+func TestVNetRuleService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_rules/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetRule{Key: 1, Name: "allow-ssh", Action: "accept", Enabled: true})
+		},
+	}))
+
+	rule, err := client.VNetRules.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if rule.Name != "allow-ssh" {
+		t.Errorf("expected name 'allow-ssh', got %q", rule.Name)
+	}
+	if !rule.Enabled {
+		t.Error("expected rule to be enabled")
+	}
+}
+
+func TestVNetRuleService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_rules/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VNetRules.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetRuleService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_rules": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetRule{{Key: 1, VNet: 10, Name: "allow-ssh"}})
+		},
+		"GET /api/v4/vnet_rules/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetRule{Key: 1, VNet: 10, Name: "allow-ssh", Action: "accept"})
+		},
+	}))
+
+	rule, err := client.VNetRules.GetByName(context.Background(), 10, "allow-ssh")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if rule.Action != "accept" {
+		t.Errorf("expected action 'accept', got %q", rule.Action)
+	}
+}
+
+func TestVNetRuleService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_rules": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetRule{})
+		},
+	}))
+
+	_, err := client.VNetRules.GetByName(context.Background(), 10, "nope")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetRuleService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_rules": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetRuleCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "allow-http" {
+				t.Errorf("expected name 'allow-http', got %q", req.Name)
+			}
+			if req.VNet != 10 {
+				t.Errorf("expected vnet 10, got %d", req.VNet)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 5, "status": "ok"})
+		},
+		"GET /api/v4/vnet_rules/5": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetRule{Key: 5, VNet: 10, Name: "allow-http", Action: "accept", Enabled: true})
+		},
+	}))
+
+	rule, err := client.VNetRules.Create(context.Background(), &VNetRuleCreateRequest{
+		Name: "allow-http",
+		VNet: 10,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if int(rule.Key) != 5 {
+		t.Errorf("expected key 5, got %d", int(rule.Key))
+	}
+}
+
+func TestVNetRuleService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetRules.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetRuleService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetRules.Create(context.Background(), &VNetRuleCreateRequest{VNet: 10})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetRuleService_Create_MissingVNet(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetRules.Create(context.Background(), &VNetRuleCreateRequest{Name: "test"})
+	if err == nil {
+		t.Fatal("expected error for missing vnet")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetRuleService_Update(t *testing.T) {
+	newName := "allow-https"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnet_rules/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetRuleUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vnet_rules/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetRule{Key: 1, Name: newName})
+		},
+	}))
+
+	rule, err := client.VNetRules.Update(context.Background(), 1, &VNetRuleUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if rule.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, rule.Name)
+	}
+}
+
+func TestVNetRuleService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetRules.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetRuleService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_rules/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VNetRules.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVNetRuleService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_rules/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VNetRules.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetRuleService_Enable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnet_rules/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetRuleUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Enabled == nil || !*req.Enabled {
+				t.Error("expected enabled to be true")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vnet_rules/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetRule{Key: 1, VNet: 10, Enabled: true})
+		},
+	}))
+
+	err := client.VNetRules.Enable(context.Background(), 1, false)
+	if err != nil {
+		t.Fatalf("Enable failed: %v", err)
+	}
+}
+
+func TestVNetRuleService_Enable_WithApply(t *testing.T) {
+	applyCalled := false
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnet_rules/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vnet_rules/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetRule{Key: 1, VNet: 10, Enabled: true})
+		},
+		"POST /api/v4/vnet_actions": func(w http.ResponseWriter, r *http.Request) {
+			applyCalled = true
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VNetRules.Enable(context.Background(), 1, true)
+	if err != nil {
+		t.Fatalf("Enable with apply failed: %v", err)
+	}
+	if !applyCalled {
+		t.Error("expected ApplyRules to be called")
+	}
+}
+
+func TestVNetRuleService_Disable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnet_rules/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetRuleUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Enabled == nil || *req.Enabled {
+				t.Error("expected enabled to be false")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vnet_rules/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetRule{Key: 1, VNet: 10, Enabled: false})
+		},
+	}))
+
+	err := client.VNetRules.Disable(context.Background(), 1, false)
+	if err != nil {
+		t.Fatalf("Disable failed: %v", err)
+	}
+}
+
+// --- VNetRuleAliasService tests ---
+
+func TestVNetRuleAliasService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_rule_aliases": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetRuleAlias{
+				{Key: 1, Name: "internal-nets", Value: "10.0.0.0/8,172.16.0.0/12"},
+				{Key: 2, Name: "dns-servers", Value: "8.8.8.8,8.8.4.4"},
+			})
+		},
+	}))
+
+	aliases, err := client.VNetRuleAliases.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(aliases) != 2 {
+		t.Fatalf("expected 2 aliases, got %d", len(aliases))
+	}
+	if aliases[0].Name != "internal-nets" {
+		t.Errorf("expected name 'internal-nets', got %q", aliases[0].Name)
+	}
+}
+
+func TestVNetRuleAliasService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_rule_aliases/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetRuleAlias{Key: 1, Name: "internal-nets", Value: "10.0.0.0/8"})
+		},
+	}))
+
+	alias, err := client.VNetRuleAliases.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if alias.Name != "internal-nets" {
+		t.Errorf("expected name 'internal-nets', got %q", alias.Name)
+	}
+}
+
+func TestVNetRuleAliasService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_rule_aliases/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VNetRuleAliases.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetRuleAliasService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_rule_aliases": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetRuleAlias{{Key: 1, Name: "internal-nets"}})
+		},
+		"GET /api/v4/vnet_rule_aliases/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetRuleAlias{Key: 1, Name: "internal-nets", Value: "10.0.0.0/8"})
+		},
+	}))
+
+	alias, err := client.VNetRuleAliases.GetByName(context.Background(), "internal-nets")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if alias.Value != "10.0.0.0/8" {
+		t.Errorf("expected value '10.0.0.0/8', got %q", alias.Value)
+	}
+}
+
+func TestVNetRuleAliasService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_rule_aliases": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetRuleAlias{})
+		},
+	}))
+
+	_, err := client.VNetRuleAliases.GetByName(context.Background(), "nope")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetRuleAliasService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_rule_aliases": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetRuleAliasCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "web-servers" {
+				t.Errorf("expected name 'web-servers', got %q", req.Name)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 3, "status": "ok"})
+		},
+		"GET /api/v4/vnet_rule_aliases/3": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetRuleAlias{Key: 3, Name: "web-servers", Value: "192.168.1.10,192.168.1.11"})
+		},
+	}))
+
+	alias, err := client.VNetRuleAliases.Create(context.Background(), &VNetRuleAliasCreateRequest{
+		Name:  "web-servers",
+		Value: "192.168.1.10,192.168.1.11",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if int(alias.Key) != 3 {
+		t.Errorf("expected key 3, got %d", int(alias.Key))
+	}
+}
+
+func TestVNetRuleAliasService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetRuleAliases.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetRuleAliasService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetRuleAliases.Create(context.Background(), &VNetRuleAliasCreateRequest{Value: "10.0.0.0/8"})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetRuleAliasService_Create_MissingValue(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetRuleAliases.Create(context.Background(), &VNetRuleAliasCreateRequest{Name: "test"})
+	if err == nil {
+		t.Fatal("expected error for missing value")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetRuleAliasService_Update(t *testing.T) {
+	newValue := "10.0.0.0/8,172.16.0.0/12"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnet_rule_aliases/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetRuleAliasUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Value == nil || *req.Value != newValue {
+				t.Errorf("expected value %q, got %v", newValue, req.Value)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vnet_rule_aliases/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetRuleAlias{Key: 1, Name: "internal-nets", Value: newValue})
+		},
+	}))
+
+	alias, err := client.VNetRuleAliases.Update(context.Background(), 1, &VNetRuleAliasUpdateRequest{Value: &newValue})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if alias.Value != newValue {
+		t.Errorf("expected value %q, got %q", newValue, alias.Value)
+	}
+}
+
+func TestVNetRuleAliasService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetRuleAliases.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetRuleAliasService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_rule_aliases/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VNetRuleAliases.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVNetRuleAliasService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_rule_aliases/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VNetRuleAliases.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/vnet_wireguard.go
+++ b/vnet_wireguard.go
@@ -55,7 +55,7 @@ func (s *VNetWireGuardService) Get(ctx context.Context, id int) (*VNetWireGuard,
 
 // GetByName returns a WireGuard interface by name within a specific network.
 func (s *VNetWireGuardService) GetByName(ctx context.Context, vnetID int, name string) (*VNetWireGuard, error) {
-	wgs, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and name eq '%s'", vnetID, name)))
+	wgs, err := s.List(ctx, WithFilter(fmt.Sprintf("vnet eq %d and name eq '%s'", vnetID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +171,7 @@ func (s *VNetWireGuardPeerService) Get(ctx context.Context, id int) (*VNetWireGu
 
 // GetByName returns a WireGuard peer by name within a specific WireGuard interface.
 func (s *VNetWireGuardPeerService) GetByName(ctx context.Context, wireguardID int, name string) (*VNetWireGuardPeer, error) {
-	peers, err := s.List(ctx, WithFilter(fmt.Sprintf("wireguard eq %d and name eq '%s'", wireguardID, name)))
+	peers, err := s.List(ctx, WithFilter(fmt.Sprintf("wireguard eq %d and name eq '%s'", wireguardID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/vnet_wireguard.go
+++ b/vnet_wireguard.go
@@ -45,7 +45,7 @@ func (s *VNetWireGuardService) Get(ctx context.Context, id int) (*VNetWireGuard,
 	endpoint := fmt.Sprintf("/vnet_wireguards/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &wg); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetWireGuard", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetWireGuard", ID: id}
 		}
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (s *VNetWireGuardService) Update(ctx context.Context, id int, req *VNetWire
 	endpoint := fmt.Sprintf("/vnet_wireguards/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetWireGuard", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetWireGuard", ID: id}
 		}
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (s *VNetWireGuardService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_wireguards/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetWireGuard", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetWireGuard", ID: id}
 		}
 		return err
 	}
@@ -161,7 +161,7 @@ func (s *VNetWireGuardPeerService) Get(ctx context.Context, id int) (*VNetWireGu
 	endpoint := fmt.Sprintf("/vnet_wireguard_peers/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &peer); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetWireGuardPeer", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetWireGuardPeer", ID: id}
 		}
 		return nil, err
 	}
@@ -224,7 +224,7 @@ func (s *VNetWireGuardPeerService) Update(ctx context.Context, id int, req *VNet
 	endpoint := fmt.Sprintf("/vnet_wireguard_peers/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetWireGuardPeer", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetWireGuardPeer", ID: id}
 		}
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (s *VNetWireGuardPeerService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/vnet_wireguard_peers/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "VNetWireGuardPeer", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "VNetWireGuardPeer", ID: id}
 		}
 		return err
 	}
@@ -256,7 +256,7 @@ func (s *VNetWireGuardPeerService) GetConfig(ctx context.Context, id int) (strin
 	endpoint := fmt.Sprintf("/vnet_wireguard_peers/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &result); err != nil {
 		if IsNotFoundError(err) {
-			return "", &NotFoundError{Resource: "VNetWireGuardPeer", ID: fmt.Sprintf("%d", id)}
+			return "", &NotFoundError{Resource: "VNetWireGuardPeer", ID: id}
 		}
 		return "", err
 	}
@@ -296,7 +296,7 @@ func (s *VNetWireGuardPeerStatusService) Get(ctx context.Context, id int) (*VNet
 	endpoint := fmt.Sprintf("/vnet_wireguard_peer_status/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &status); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "VNetWireGuardPeerStatus", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "VNetWireGuardPeerStatus", ID: id}
 		}
 		return nil, err
 	}

--- a/vnet_wireguard_test.go
+++ b/vnet_wireguard_test.go
@@ -134,7 +134,7 @@ func TestVNetWireGuardService_Create(t *testing.T) {
 			if req.VNet != 10 {
 				t.Errorf("expected vnet 10, got %d", req.VNet)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/vnet_wireguards/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetWireGuard{Key: 1, VNet: 10, Name: "wg0", IP: "10.0.0.1/24"})
@@ -395,7 +395,7 @@ func TestVNetWireGuardPeerService_Create(t *testing.T) {
 			if req.Name != "peer-a" {
 				t.Errorf("expected name 'peer-a', got %q", req.Name)
 			}
-			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+			jsonResponse(w, 200, map[string]any{"$key": 1, "status": "OK"})
 		},
 		"GET /api/v4/vnet_wireguard_peers/1": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, VNetWireGuardPeer{Key: 1, WireGuard: 5, Name: "peer-a", PeerIP: "10.0.0.2", PublicKey: "abc123", AllowedIPs: "10.0.0.0/24"})

--- a/vnet_wireguard_test.go
+++ b/vnet_wireguard_test.go
@@ -1,0 +1,702 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// VNetWireGuardService tests
+// ---------------------------------------------------------------------------
+
+func TestVNetWireGuardService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguards": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetWireGuard{
+				{Key: 1, Name: "wg0", IP: "10.0.0.1/24"},
+				{Key: 2, Name: "wg1", IP: "10.0.1.1/24"},
+			})
+		},
+	}))
+
+	wgs, err := client.VNetWireGuards.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(wgs) != 2 {
+		t.Fatalf("expected 2 wireguards, got %d", len(wgs))
+	}
+	if wgs[0].Name != "wg0" {
+		t.Errorf("expected name 'wg0', got %q", wgs[0].Name)
+	}
+}
+
+func TestVNetWireGuardService_ListByNetwork(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguards": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "vnet eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VNetWireGuard{{Key: 1, VNet: 10, Name: "wg0"}})
+		},
+	}))
+
+	wgs, err := client.VNetWireGuards.ListByNetwork(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListByNetwork failed: %v", err)
+	}
+	if len(wgs) != 1 {
+		t.Fatalf("expected 1 wireguard, got %d", len(wgs))
+	}
+}
+
+func TestVNetWireGuardService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguards/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetWireGuard{Key: 1, Name: "wg0", IP: "10.0.0.1/24", ListenPort: 51820})
+		},
+	}))
+
+	wg, err := client.VNetWireGuards.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if wg.Name != "wg0" {
+		t.Errorf("expected name 'wg0', got %q", wg.Name)
+	}
+	if wg.ListenPort != 51820 {
+		t.Errorf("expected port 51820, got %d", wg.ListenPort)
+	}
+}
+
+func TestVNetWireGuardService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguards/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VNetWireGuards.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguards": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetWireGuard{{Key: 1, VNet: 10, Name: "wg0"}})
+		},
+		"GET /api/v4/vnet_wireguards/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetWireGuard{Key: 1, VNet: 10, Name: "wg0", IP: "10.0.0.1/24"})
+		},
+	}))
+
+	wg, err := client.VNetWireGuards.GetByName(context.Background(), 10, "wg0")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if wg.Name != "wg0" {
+		t.Errorf("expected name 'wg0', got %q", wg.Name)
+	}
+}
+
+func TestVNetWireGuardService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguards": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetWireGuard{})
+		},
+	}))
+
+	_, err := client.VNetWireGuards.GetByName(context.Background(), 10, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_wireguards": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetWireGuardCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "wg0" {
+				t.Errorf("expected name 'wg0', got %q", req.Name)
+			}
+			if req.VNet != 10 {
+				t.Errorf("expected vnet 10, got %d", req.VNet)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+		},
+		"GET /api/v4/vnet_wireguards/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetWireGuard{Key: 1, VNet: 10, Name: "wg0", IP: "10.0.0.1/24"})
+		},
+	}))
+
+	wg, err := client.VNetWireGuards.Create(context.Background(), &VNetWireGuardCreateRequest{
+		VNet: 10,
+		Name: "wg0",
+		IP:   "10.0.0.1/24",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if wg.Name != "wg0" {
+		t.Errorf("expected name 'wg0', got %q", wg.Name)
+	}
+}
+
+func TestVNetWireGuardService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetWireGuards.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardService_Create_MissingVNet(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetWireGuards.Create(context.Background(), &VNetWireGuardCreateRequest{
+		Name: "wg0",
+		IP:   "10.0.0.1/24",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing vnet")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetWireGuards.Create(context.Background(), &VNetWireGuardCreateRequest{
+		VNet: 10,
+		IP:   "10.0.0.1/24",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardService_Create_MissingIP(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetWireGuards.Create(context.Background(), &VNetWireGuardCreateRequest{
+		VNet: 10,
+		Name: "wg0",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing ip")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardService_Update(t *testing.T) {
+	newName := "wg0-updated"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnet_wireguards/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetWireGuardUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name == nil || *req.Name != newName {
+				t.Errorf("expected name %q, got %v", newName, req.Name)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vnet_wireguards/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetWireGuard{Key: 1, Name: newName})
+		},
+	}))
+
+	wg, err := client.VNetWireGuards.Update(context.Background(), 1, &VNetWireGuardUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if wg.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, wg.Name)
+	}
+}
+
+func TestVNetWireGuardService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetWireGuards.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_wireguards/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VNetWireGuards.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVNetWireGuardService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_wireguards/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VNetWireGuards.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VNetWireGuardPeerService tests
+// ---------------------------------------------------------------------------
+
+func TestVNetWireGuardPeerService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguard_peers": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetWireGuardPeer{
+				{Key: 1, Name: "peer-a", PublicKey: "abc123"},
+				{Key: 2, Name: "peer-b", PublicKey: "def456"},
+			})
+		},
+	}))
+
+	peers, err := client.VNetWireGuardPeers.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(peers) != 2 {
+		t.Fatalf("expected 2 peers, got %d", len(peers))
+	}
+}
+
+func TestVNetWireGuardPeerService_ListByWireGuard(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguard_peers": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "wireguard eq 5" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VNetWireGuardPeer{{Key: 1, WireGuard: 5, Name: "peer-a"}})
+		},
+	}))
+
+	peers, err := client.VNetWireGuardPeers.ListByWireGuard(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("ListByWireGuard failed: %v", err)
+	}
+	if len(peers) != 1 {
+		t.Fatalf("expected 1 peer, got %d", len(peers))
+	}
+}
+
+func TestVNetWireGuardPeerService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguard_peers/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetWireGuardPeer{Key: 1, Name: "peer-a", PeerIP: "10.0.0.2", PublicKey: "abc123"})
+		},
+	}))
+
+	peer, err := client.VNetWireGuardPeers.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if peer.Name != "peer-a" {
+		t.Errorf("expected name 'peer-a', got %q", peer.Name)
+	}
+}
+
+func TestVNetWireGuardPeerService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguard_peers/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VNetWireGuardPeers.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardPeerService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguard_peers": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetWireGuardPeer{{Key: 1, WireGuard: 5, Name: "peer-a"}})
+		},
+		"GET /api/v4/vnet_wireguard_peers/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetWireGuardPeer{Key: 1, WireGuard: 5, Name: "peer-a", PeerIP: "10.0.0.2"})
+		},
+	}))
+
+	peer, err := client.VNetWireGuardPeers.GetByName(context.Background(), 5, "peer-a")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if peer.Name != "peer-a" {
+		t.Errorf("expected name 'peer-a', got %q", peer.Name)
+	}
+}
+
+func TestVNetWireGuardPeerService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguard_peers": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetWireGuardPeer{})
+		},
+	}))
+
+	_, err := client.VNetWireGuardPeers.GetByName(context.Background(), 5, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardPeerService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/vnet_wireguard_peers": func(w http.ResponseWriter, r *http.Request) {
+			var req VNetWireGuardPeerCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "peer-a" {
+				t.Errorf("expected name 'peer-a', got %q", req.Name)
+			}
+			jsonResponse(w, 200, map[string]interface{}{"$key": 1, "status": "OK"})
+		},
+		"GET /api/v4/vnet_wireguard_peers/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetWireGuardPeer{Key: 1, WireGuard: 5, Name: "peer-a", PeerIP: "10.0.0.2", PublicKey: "abc123", AllowedIPs: "10.0.0.0/24"})
+		},
+	}))
+
+	peer, err := client.VNetWireGuardPeers.Create(context.Background(), &VNetWireGuardPeerCreateRequest{
+		WireGuard:  5,
+		Name:       "peer-a",
+		PeerIP:     "10.0.0.2",
+		PublicKey:  "abc123",
+		AllowedIPs: "10.0.0.0/24",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if peer.Name != "peer-a" {
+		t.Errorf("expected name 'peer-a', got %q", peer.Name)
+	}
+}
+
+func TestVNetWireGuardPeerService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetWireGuardPeers.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardPeerService_Create_MissingWireGuard(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetWireGuardPeers.Create(context.Background(), &VNetWireGuardPeerCreateRequest{
+		Name:       "peer-a",
+		PeerIP:     "10.0.0.2",
+		PublicKey:  "abc123",
+		AllowedIPs: "10.0.0.0/24",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing wireguard")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardPeerService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetWireGuardPeers.Create(context.Background(), &VNetWireGuardPeerCreateRequest{
+		WireGuard:  5,
+		PeerIP:     "10.0.0.2",
+		PublicKey:  "abc123",
+		AllowedIPs: "10.0.0.0/24",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardPeerService_Create_MissingPeerIP(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetWireGuardPeers.Create(context.Background(), &VNetWireGuardPeerCreateRequest{
+		WireGuard:  5,
+		Name:       "peer-a",
+		PublicKey:  "abc123",
+		AllowedIPs: "10.0.0.0/24",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing peer_ip")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardPeerService_Create_MissingPublicKey(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetWireGuardPeers.Create(context.Background(), &VNetWireGuardPeerCreateRequest{
+		WireGuard:  5,
+		Name:       "peer-a",
+		PeerIP:     "10.0.0.2",
+		AllowedIPs: "10.0.0.0/24",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing public_key")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardPeerService_Create_MissingAllowedIPs(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetWireGuardPeers.Create(context.Background(), &VNetWireGuardPeerCreateRequest{
+		WireGuard: 5,
+		Name:      "peer-a",
+		PeerIP:    "10.0.0.2",
+		PublicKey: "abc123",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing allowed_ips")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardPeerService_Update(t *testing.T) {
+	newName := "peer-updated"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/vnet_wireguard_peers/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/vnet_wireguard_peers/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetWireGuardPeer{Key: 1, Name: newName})
+		},
+	}))
+
+	peer, err := client.VNetWireGuardPeers.Update(context.Background(), 1, &VNetWireGuardPeerUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if peer.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, peer.Name)
+	}
+}
+
+func TestVNetWireGuardPeerService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VNetWireGuardPeers.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardPeerService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_wireguard_peers/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VNetWireGuardPeers.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVNetWireGuardPeerService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/vnet_wireguard_peers/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VNetWireGuardPeers.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardPeerService_GetConfig(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguard_peers/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, map[string]string{"wg_config": "[Interface]\nPrivateKey = abc\nAddress = 10.0.0.2/24"})
+		},
+	}))
+
+	config, err := client.VNetWireGuardPeers.GetConfig(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetConfig failed: %v", err)
+	}
+	if config == "" {
+		t.Error("expected non-empty config")
+	}
+}
+
+func TestVNetWireGuardPeerService_GetConfig_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguard_peers/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VNetWireGuardPeers.GetConfig(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VNetWireGuardPeerStatusService tests
+// ---------------------------------------------------------------------------
+
+func TestVNetWireGuardPeerStatusService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguard_peer_status": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetWireGuardPeerStatus{
+				{Key: 1, Peer: 10, TXBytes: 1024, RXBytes: 2048},
+				{Key: 2, Peer: 11, TXBytes: 512, RXBytes: 4096},
+			})
+		},
+	}))
+
+	statuses, err := client.VNetWireGuardPeerStatus.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(statuses) != 2 {
+		t.Fatalf("expected 2 statuses, got %d", len(statuses))
+	}
+	if statuses[0].TXBytes != 1024 {
+		t.Errorf("expected tx_bytes 1024, got %d", statuses[0].TXBytes)
+	}
+}
+
+func TestVNetWireGuardPeerStatusService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguard_peer_status/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VNetWireGuardPeerStatus{Key: 1, Peer: 10, TXBytes: 1024, RXBytes: 2048})
+		},
+	}))
+
+	status, err := client.VNetWireGuardPeerStatus.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if status.RXBytes != 2048 {
+		t.Errorf("expected rx_bytes 2048, got %d", status.RXBytes)
+	}
+}
+
+func TestVNetWireGuardPeerStatusService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguard_peer_status/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VNetWireGuardPeerStatus.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVNetWireGuardPeerStatusService_GetByPeer(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguard_peer_status": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "peer eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VNetWireGuardPeerStatus{{Key: 1, Peer: 10, TXBytes: 1024}})
+		},
+	}))
+
+	status, err := client.VNetWireGuardPeerStatus.GetByPeer(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("GetByPeer failed: %v", err)
+	}
+	if int(status.Peer) != 10 {
+		t.Errorf("expected peer 10, got %d", status.Peer)
+	}
+}
+
+func TestVNetWireGuardPeerStatusService_GetByPeer_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnet_wireguard_peer_status": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VNetWireGuardPeerStatus{})
+		},
+	}))
+
+	_, err := client.VNetWireGuardPeerStatus.GetByPeer(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/volume.go
+++ b/volume.go
@@ -55,7 +55,7 @@ func (s *VolumeService) Get(ctx context.Context, id string) (*Volume, error) {
 
 // GetByName returns a single volume by name within a service.
 func (s *VolumeService) GetByName(ctx context.Context, serviceID int, name string) (*Volume, error) {
-	volumes, err := s.List(ctx, WithFilter(fmt.Sprintf("service eq %d and name eq '%s'", serviceID, name)))
+	volumes, err := s.List(ctx, WithFilter(fmt.Sprintf("service eq %d and name eq '%s'", serviceID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/volume.go
+++ b/volume.go
@@ -134,7 +134,7 @@ func (s *VolumeService) Enable(ctx context.Context, id string) error {
 	action := volumeAction{
 		Volume: id,
 		Action: "enable",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	if err := s.client.post(ctx, "/volume_actions", action, nil); err != nil {
@@ -148,7 +148,7 @@ func (s *VolumeService) Disable(ctx context.Context, id string) error {
 	action := volumeAction{
 		Volume: id,
 		Action: "disable",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	if err := s.client.post(ctx, "/volume_actions", action, nil); err != nil {
@@ -162,7 +162,7 @@ func (s *VolumeService) Reset(ctx context.Context, id string) error {
 	action := volumeAction{
 		Volume: id,
 		Action: "reset",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	if err := s.client.post(ctx, "/volume_actions", action, nil); err != nil {
@@ -175,7 +175,7 @@ func (s *VolumeService) Reset(ctx context.Context, id string) error {
 type volumeAction struct {
 	Volume string                 `json:"volume"`
 	Action string                 `json:"action"`
-	Params map[string]interface{} `json:"params"`
+	Params map[string]any `json:"params"`
 }
 
 // getStringKey extracts a string key from an API response.

--- a/volume_browser.go
+++ b/volume_browser.go
@@ -183,5 +183,5 @@ func (s *VolumeBrowserService) List(ctx context.Context, opts ...ListOption) ([]
 
 // ListByVolume returns all browse jobs for a specific volume.
 func (s *VolumeBrowserService) ListByVolume(ctx context.Context, volumeID string, opts ...ListOption) ([]VolumeBrowserJob, error) {
-	return s.List(ctx, append(opts, WithFilter(fmt.Sprintf("volume eq '%s'", volumeID)))...)
+	return s.List(ctx, append(opts, WithFilter(fmt.Sprintf("volume eq '%s'", escapeFilterValue(volumeID))))...)
 }

--- a/volume_browser_test.go
+++ b/volume_browser_test.go
@@ -1,0 +1,297 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestVolumeBrowserService_CreateJob(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/volume_browser": func(w http.ResponseWriter, r *http.Request) {
+			var req VolumeBrowserRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Volume == "" {
+				t.Error("expected volume in request")
+			}
+			if req.Query != VolumeBrowserQueryGetDir {
+				t.Errorf("expected query 'get-dir', got %q", req.Query)
+			}
+			// Return the job ID as a string key
+			jsonResponse(w, 200, map[string]interface{}{
+				"$key": "abc123sha1hash",
+			})
+		},
+	}))
+
+	job, err := client.VolumeBrowser.CreateJob(context.Background(), &VolumeBrowserRequest{
+		Volume: "vol-sha1",
+		Query:  VolumeBrowserQueryGetDir,
+		Params: &VolumeBrowserParams{
+			Dir:   "",
+			Limit: 100,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateJob failed: %v", err)
+	}
+	if job.ID == "" {
+		t.Error("expected non-empty job ID")
+	}
+	if job.Status != VolumeBrowserStatusRunning {
+		t.Errorf("expected status 'running', got %q", job.Status)
+	}
+	if job.Volume != "vol-sha1" {
+		t.Errorf("expected volume 'vol-sha1', got %q", job.Volume)
+	}
+}
+
+func TestVolumeBrowserService_CreateJob_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeBrowser.CreateJob(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeBrowserService_CreateJob_EmptyVolume(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeBrowser.CreateJob(context.Background(), &VolumeBrowserRequest{
+		Query:  VolumeBrowserQueryGetDir,
+		Params: &VolumeBrowserParams{},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty volume")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeBrowserService_CreateJob_EmptyQuery(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeBrowser.CreateJob(context.Background(), &VolumeBrowserRequest{
+		Volume: "vol-sha1",
+		Params: &VolumeBrowserParams{},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty query")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeBrowserService_CreateJob_NilParams(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeBrowser.CreateJob(context.Background(), &VolumeBrowserRequest{
+		Volume: "vol-sha1",
+		Query:  VolumeBrowserQueryGetDir,
+	})
+	if err == nil {
+		t.Fatal("expected error for nil params")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeBrowserService_GetJob(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_browser/abc123": func(w http.ResponseWriter, r *http.Request) {
+			fields := r.URL.Query().Get("fields")
+			if fields != volumeBrowserGetFields {
+				t.Errorf("expected get fields, got %q", fields)
+			}
+			jsonResponse(w, 200, VolumeBrowserJob{
+				Key:    "abc123",
+				ID:     "abc123",
+				Volume: "vol-sha1",
+				Status: VolumeBrowserStatusComplete,
+				Result: json.RawMessage(`[{"name":"file1.txt","size":1024,"date":1700000000,"type":"file"}]`),
+			})
+		},
+	}))
+
+	job, err := client.VolumeBrowser.GetJob(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("GetJob failed: %v", err)
+	}
+	if job.Status != VolumeBrowserStatusComplete {
+		t.Errorf("expected status 'complete', got %q", job.Status)
+	}
+	if job.Volume != "vol-sha1" {
+		t.Errorf("expected volume 'vol-sha1', got %q", job.Volume)
+	}
+}
+
+func TestVolumeBrowserService_GetJob_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_browser/nonexistent": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VolumeBrowser.GetJob(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeBrowserService_WaitForResult_Complete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_browser/job1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeBrowserJob{
+				Key:    "job1",
+				ID:     "job1",
+				Status: VolumeBrowserStatusComplete,
+				Result: json.RawMessage(`[{"name":"docs","size":0,"date":1700000000,"type":"directory"},{"name":"readme.txt","size":512,"date":1700000001,"type":"file"}]`),
+			})
+		},
+	}))
+
+	entries, err := client.VolumeBrowser.WaitForResult(context.Background(), "job1", 5*1e9)
+	if err != nil {
+		t.Fatalf("WaitForResult failed: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Name != "docs" {
+		t.Errorf("expected name 'docs', got %q", entries[0].Name)
+	}
+	if entries[0].Type != "directory" {
+		t.Errorf("expected type 'directory', got %q", entries[0].Type)
+	}
+	if entries[1].Size != 512 {
+		t.Errorf("expected size 512, got %d", entries[1].Size)
+	}
+}
+
+func TestVolumeBrowserService_WaitForResult_EmptyDir(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_browser/job2": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeBrowserJob{
+				Key:    "job2",
+				ID:     "job2",
+				Status: VolumeBrowserStatusComplete,
+				Result: json.RawMessage(`null`),
+			})
+		},
+	}))
+
+	entries, err := client.VolumeBrowser.WaitForResult(context.Background(), "job2", 5*1e9)
+	if err != nil {
+		t.Fatalf("WaitForResult failed: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected 0 entries for empty dir, got %d", len(entries))
+	}
+}
+
+func TestVolumeBrowserService_WaitForResult_Error(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_browser/joberr": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeBrowserJob{
+				Key:    "joberr",
+				ID:     "joberr",
+				Status: VolumeBrowserStatusError,
+				Result: json.RawMessage(`"NAS service not running"`),
+			})
+		},
+	}))
+
+	_, err := client.VolumeBrowser.WaitForResult(context.Background(), "joberr", 5*1e9)
+	if err == nil {
+		t.Fatal("expected error for error status")
+	}
+}
+
+func TestVolumeBrowserService_WaitForResult_ContextCanceled(t *testing.T) {
+	callCount := 0
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_browser/jobslow": func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			jsonResponse(w, 200, VolumeBrowserJob{
+				Key:    "jobslow",
+				ID:     "jobslow",
+				Status: VolumeBrowserStatusRunning,
+			})
+		},
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := client.VolumeBrowser.WaitForResult(ctx, "jobslow", 30*1e9)
+	if err == nil {
+		t.Fatal("expected error for canceled context")
+	}
+}
+
+func TestVolumeBrowserService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_browser": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VolumeBrowserJob{
+				{Key: "j1", ID: "j1", Status: VolumeBrowserStatusComplete},
+				{Key: "j2", ID: "j2", Status: VolumeBrowserStatusRunning},
+			})
+		},
+	}))
+
+	jobs, err := client.VolumeBrowser.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("expected 2 jobs, got %d", len(jobs))
+	}
+}
+
+func TestVolumeBrowserService_ListByVolume(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_browser": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "volume eq 'vol-abc'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VolumeBrowserJob{{Key: "j1", Volume: "vol-abc"}})
+		},
+	}))
+
+	jobs, err := client.VolumeBrowser.ListByVolume(context.Background(), "vol-abc")
+	if err != nil {
+		t.Fatalf("ListByVolume failed: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+}
+
+func TestVolumeBrowserService_WaitForResult_UnexpectedStatus(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_browser/jobweird": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeBrowserJob{
+				Key:    "jobweird",
+				ID:     "jobweird",
+				Status: "unknown_status",
+			})
+		},
+	}))
+
+	_, err := client.VolumeBrowser.WaitForResult(context.Background(), "jobweird", 5*1e9)
+	if err == nil {
+		t.Fatal("expected error for unexpected status")
+	}
+}

--- a/volume_browser_test.go
+++ b/volume_browser_test.go
@@ -19,7 +19,7 @@ func TestVolumeBrowserService_CreateJob(t *testing.T) {
 				t.Errorf("expected query 'get-dir', got %q", req.Query)
 			}
 			// Return the job ID as a string key
-			jsonResponse(w, 200, map[string]interface{}{
+			jsonResponse(w, 200, map[string]any{
 				"$key": "abc123sha1hash",
 			})
 		},

--- a/volume_share.go
+++ b/volume_share.go
@@ -32,7 +32,7 @@ func (s *VolumeCIFSShareService) List(ctx context.Context, opts ...ListOption) (
 
 // ListByVolume returns all CIFS shares belonging to a specific volume.
 func (s *VolumeCIFSShareService) ListByVolume(ctx context.Context, volumeID string, opts ...ListOption) ([]VolumeCIFSShare, error) {
-	return s.List(ctx, append(opts, WithFilter(fmt.Sprintf("volume eq '%s'", volumeID)))...)
+	return s.List(ctx, append(opts, WithFilter(fmt.Sprintf("volume eq '%s'", escapeFilterValue(volumeID))))...)
 }
 
 // Get returns a single CIFS share by its SHA1 ID.
@@ -54,7 +54,7 @@ func (s *VolumeCIFSShareService) Get(ctx context.Context, id string) (*VolumeCIF
 
 // GetByName returns a single CIFS share by name within a volume.
 func (s *VolumeCIFSShareService) GetByName(ctx context.Context, volumeID, name string) (*VolumeCIFSShare, error) {
-	shares, err := s.List(ctx, WithFilter(fmt.Sprintf("volume eq '%s' and name eq '%s'", volumeID, name)))
+	shares, err := s.List(ctx, WithFilter(fmt.Sprintf("volume eq '%s' and name eq '%s'", escapeFilterValue(volumeID), escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func (s *VolumeNFSShareService) List(ctx context.Context, opts ...ListOption) ([
 
 // ListByVolume returns all NFS shares belonging to a specific volume.
 func (s *VolumeNFSShareService) ListByVolume(ctx context.Context, volumeID string, opts ...ListOption) ([]VolumeNFSShare, error) {
-	return s.List(ctx, append(opts, WithFilter(fmt.Sprintf("volume eq '%s'", volumeID)))...)
+	return s.List(ctx, append(opts, WithFilter(fmt.Sprintf("volume eq '%s'", escapeFilterValue(volumeID))))...)
 }
 
 // Get returns a single NFS share by its SHA1 ID.
@@ -176,7 +176,7 @@ func (s *VolumeNFSShareService) Get(ctx context.Context, id string) (*VolumeNFSS
 
 // GetByName returns a single NFS share by name within a volume.
 func (s *VolumeNFSShareService) GetByName(ctx context.Context, volumeID, name string) (*VolumeNFSShare, error) {
-	shares, err := s.List(ctx, WithFilter(fmt.Sprintf("volume eq '%s' and name eq '%s'", volumeID, name)))
+	shares, err := s.List(ctx, WithFilter(fmt.Sprintf("volume eq '%s' and name eq '%s'", escapeFilterValue(volumeID), escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/volume_share_test.go
+++ b/volume_share_test.go
@@ -1,0 +1,524 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// --- CIFS Share Tests ---
+
+func TestVolumeCIFSShareService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_cifs_shares": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VolumeCIFSShare{
+				{Key: "cifs1", ID: "cifs1", Name: "share1", Enabled: true},
+				{Key: "cifs2", ID: "cifs2", Name: "share2", Enabled: false},
+			})
+		},
+	}))
+
+	shares, err := client.VolumeCIFSShares.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(shares) != 2 {
+		t.Fatalf("expected 2 shares, got %d", len(shares))
+	}
+	if shares[0].Name != "share1" {
+		t.Errorf("expected name 'share1', got %q", shares[0].Name)
+	}
+}
+
+func TestVolumeCIFSShareService_ListByVolume(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_cifs_shares": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "volume eq 'volhash'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VolumeCIFSShare{{Key: "cifs1", ID: "cifs1", Name: "share1"}})
+		},
+	}))
+
+	shares, err := client.VolumeCIFSShares.ListByVolume(context.Background(), "volhash")
+	if err != nil {
+		t.Fatalf("ListByVolume failed: %v", err)
+	}
+	if len(shares) != 1 {
+		t.Fatalf("expected 1 share, got %d", len(shares))
+	}
+}
+
+func TestVolumeCIFSShareService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_cifs_shares/cifs1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeCIFSShare{Key: "cifs1", ID: "cifs1", Name: "share1", Browseable: true})
+		},
+	}))
+
+	share, err := client.VolumeCIFSShares.Get(context.Background(), "cifs1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if share.Name != "share1" {
+		t.Errorf("expected name 'share1', got %q", share.Name)
+	}
+	if !share.Browseable {
+		t.Error("expected browseable to be true")
+	}
+}
+
+func TestVolumeCIFSShareService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_cifs_shares/missing": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VolumeCIFSShares.Get(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeCIFSShareService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_cifs_shares": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VolumeCIFSShare{{Key: "cifs1", ID: "cifs1", Name: "share1"}})
+		},
+		"GET /api/v4/volume_cifs_shares/cifs1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeCIFSShare{Key: "cifs1", ID: "cifs1", Name: "share1"})
+		},
+	}))
+
+	share, err := client.VolumeCIFSShares.GetByName(context.Background(), "volhash", "share1")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if share.Name != "share1" {
+		t.Errorf("expected name 'share1', got %q", share.Name)
+	}
+}
+
+func TestVolumeCIFSShareService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_cifs_shares": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VolumeCIFSShare{})
+		},
+	}))
+
+	_, err := client.VolumeCIFSShares.GetByName(context.Background(), "volhash", "missing")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeCIFSShareService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/volume_cifs_shares": func(w http.ResponseWriter, r *http.Request) {
+			var req VolumeCIFSShareCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "myshare" {
+				t.Errorf("expected name 'myshare', got %q", req.Name)
+			}
+			if req.Volume != "volhash" {
+				t.Errorf("expected volume 'volhash', got %q", req.Volume)
+			}
+			jsonResponse(w, 200, apiResponse{Key: "newcifs"})
+		},
+		"GET /api/v4/volume_cifs_shares/newcifs": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeCIFSShare{Key: "newcifs", ID: "newcifs", Name: "myshare", Enabled: true})
+		},
+	}))
+
+	share, err := client.VolumeCIFSShares.Create(context.Background(), &VolumeCIFSShareCreateRequest{
+		Name:   "myshare",
+		Volume: "volhash",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if share.Name != "myshare" {
+		t.Errorf("expected name 'myshare', got %q", share.Name)
+	}
+}
+
+func TestVolumeCIFSShareService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeCIFSShares.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeCIFSShareService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeCIFSShares.Create(context.Background(), &VolumeCIFSShareCreateRequest{Volume: "volhash"})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeCIFSShareService_Create_MissingVolume(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeCIFSShares.Create(context.Background(), &VolumeCIFSShareCreateRequest{Name: "share1"})
+	if err == nil {
+		t.Fatal("expected error for missing volume")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeCIFSShareService_Update(t *testing.T) {
+	newComment := "updated comment"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/volume_cifs_shares/cifs1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/volume_cifs_shares/cifs1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeCIFSShare{Key: "cifs1", ID: "cifs1", Name: "share1", Comment: newComment})
+		},
+	}))
+
+	share, err := client.VolumeCIFSShares.Update(context.Background(), "cifs1", &VolumeCIFSShareUpdateRequest{Comment: &newComment})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if share.Comment != newComment {
+		t.Errorf("expected comment %q, got %q", newComment, share.Comment)
+	}
+}
+
+func TestVolumeCIFSShareService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeCIFSShares.Update(context.Background(), "cifs1", nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeCIFSShareService_Update_NotFound(t *testing.T) {
+	name := "test"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/volume_cifs_shares/missing": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VolumeCIFSShares.Update(context.Background(), "missing", &VolumeCIFSShareUpdateRequest{Name: &name})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeCIFSShareService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/volume_cifs_shares/cifs1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VolumeCIFSShares.Delete(context.Background(), "cifs1")
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVolumeCIFSShareService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/volume_cifs_shares/missing": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VolumeCIFSShares.Delete(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// --- NFS Share Tests ---
+
+func TestVolumeNFSShareService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_nfs_shares": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VolumeNFSShare{
+				{Key: "nfs1", ID: "nfs1", Name: "export1", Enabled: true},
+				{Key: "nfs2", ID: "nfs2", Name: "export2", Enabled: false},
+			})
+		},
+	}))
+
+	shares, err := client.VolumeNFSShares.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(shares) != 2 {
+		t.Fatalf("expected 2 shares, got %d", len(shares))
+	}
+	if shares[0].Name != "export1" {
+		t.Errorf("expected name 'export1', got %q", shares[0].Name)
+	}
+}
+
+func TestVolumeNFSShareService_ListByVolume(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_nfs_shares": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "volume eq 'volhash'" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VolumeNFSShare{{Key: "nfs1", ID: "nfs1", Name: "export1"}})
+		},
+	}))
+
+	shares, err := client.VolumeNFSShares.ListByVolume(context.Background(), "volhash")
+	if err != nil {
+		t.Fatalf("ListByVolume failed: %v", err)
+	}
+	if len(shares) != 1 {
+		t.Fatalf("expected 1 share, got %d", len(shares))
+	}
+}
+
+func TestVolumeNFSShareService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_nfs_shares/nfs1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeNFSShare{Key: "nfs1", ID: "nfs1", Name: "export1", Squash: "root_squash"})
+		},
+	}))
+
+	share, err := client.VolumeNFSShares.Get(context.Background(), "nfs1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if share.Name != "export1" {
+		t.Errorf("expected name 'export1', got %q", share.Name)
+	}
+	if share.Squash != "root_squash" {
+		t.Errorf("expected squash 'root_squash', got %q", share.Squash)
+	}
+}
+
+func TestVolumeNFSShareService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_nfs_shares/missing": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VolumeNFSShares.Get(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeNFSShareService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_nfs_shares": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VolumeNFSShare{{Key: "nfs1", ID: "nfs1", Name: "export1"}})
+		},
+		"GET /api/v4/volume_nfs_shares/nfs1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeNFSShare{Key: "nfs1", ID: "nfs1", Name: "export1"})
+		},
+	}))
+
+	share, err := client.VolumeNFSShares.GetByName(context.Background(), "volhash", "export1")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if share.Name != "export1" {
+		t.Errorf("expected name 'export1', got %q", share.Name)
+	}
+}
+
+func TestVolumeNFSShareService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_nfs_shares": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VolumeNFSShare{})
+		},
+	}))
+
+	_, err := client.VolumeNFSShares.GetByName(context.Background(), "volhash", "missing")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeNFSShareService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/volume_nfs_shares": func(w http.ResponseWriter, r *http.Request) {
+			var req VolumeNFSShareCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "export1" {
+				t.Errorf("expected name 'export1', got %q", req.Name)
+			}
+			if req.Volume != "volhash" {
+				t.Errorf("expected volume 'volhash', got %q", req.Volume)
+			}
+			jsonResponse(w, 200, apiResponse{Key: "newnfs"})
+		},
+		"GET /api/v4/volume_nfs_shares/newnfs": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeNFSShare{Key: "newnfs", ID: "newnfs", Name: "export1", Enabled: true})
+		},
+	}))
+
+	share, err := client.VolumeNFSShares.Create(context.Background(), &VolumeNFSShareCreateRequest{
+		Name:   "export1",
+		Volume: "volhash",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if share.Name != "export1" {
+		t.Errorf("expected name 'export1', got %q", share.Name)
+	}
+}
+
+func TestVolumeNFSShareService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeNFSShares.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeNFSShareService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeNFSShares.Create(context.Background(), &VolumeNFSShareCreateRequest{Volume: "volhash"})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeNFSShareService_Create_MissingVolume(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeNFSShares.Create(context.Background(), &VolumeNFSShareCreateRequest{Name: "export1"})
+	if err == nil {
+		t.Fatal("expected error for missing volume")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeNFSShareService_Update(t *testing.T) {
+	squash := "all_squash"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/volume_nfs_shares/nfs1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/volume_nfs_shares/nfs1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeNFSShare{Key: "nfs1", ID: "nfs1", Name: "export1", Squash: squash})
+		},
+	}))
+
+	share, err := client.VolumeNFSShares.Update(context.Background(), "nfs1", &VolumeNFSShareUpdateRequest{Squash: &squash})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if share.Squash != squash {
+		t.Errorf("expected squash %q, got %q", squash, share.Squash)
+	}
+}
+
+func TestVolumeNFSShareService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeNFSShares.Update(context.Background(), "nfs1", nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeNFSShareService_Update_NotFound(t *testing.T) {
+	name := "test"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/volume_nfs_shares/missing": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VolumeNFSShares.Update(context.Background(), "missing", &VolumeNFSShareUpdateRequest{Name: &name})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeNFSShareService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/volume_nfs_shares/nfs1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VolumeNFSShares.Delete(context.Background(), "nfs1")
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVolumeNFSShareService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/volume_nfs_shares/missing": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VolumeNFSShares.Delete(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/volume_snapshot.go
+++ b/volume_snapshot.go
@@ -70,7 +70,7 @@ func (s *VolumeSnapshotService) Get(ctx context.Context, id int) (*VolumeSnapsho
 
 // GetByName returns a volume snapshot by name within a specific volume.
 func (s *VolumeSnapshotService) GetByName(ctx context.Context, volumeID int, name string) (*VolumeSnapshot, error) {
-	snapshots, err := s.List(ctx, WithFilter(fmt.Sprintf("volume eq %d and name eq '%s'", volumeID, name)))
+	snapshots, err := s.List(ctx, WithFilter(fmt.Sprintf("volume eq %d and name eq '%s'", volumeID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/volume_snapshot_test.go
+++ b/volume_snapshot_test.go
@@ -1,0 +1,398 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestVolumeSnapshotService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VolumeSnapshot{
+				{Key: 1, Name: "snap-daily", Enabled: true},
+				{Key: 2, Name: "snap-manual", Enabled: false},
+			})
+		},
+	}))
+
+	snaps, err := client.VolumeSnapshots.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(snaps) != 2 {
+		t.Fatalf("expected 2 snapshots, got %d", len(snaps))
+	}
+	if snaps[0].Name != "snap-daily" {
+		t.Errorf("expected name 'snap-daily', got %q", snaps[0].Name)
+	}
+}
+
+func TestVolumeSnapshotService_ListByVolume(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "volume eq 42" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VolumeSnapshot{{Key: 1, Name: "snap1"}})
+		},
+	}))
+
+	snaps, err := client.VolumeSnapshots.ListByVolume(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ListByVolume failed: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(snaps))
+	}
+}
+
+func TestVolumeSnapshotService_ListExpiring(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter for expiring snapshots")
+			}
+			jsonResponse(w, 200, []VolumeSnapshot{{Key: 1, Name: "expiring-snap", ExpiresType: "date"}})
+		},
+	}))
+
+	snaps, err := client.VolumeSnapshots.ListExpiring(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("ListExpiring failed: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(snaps))
+	}
+}
+
+func TestVolumeSnapshotService_ListManual(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "created_manually eq true" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VolumeSnapshot{{Key: 1, Name: "manual-snap", CreatedManually: true}})
+		},
+	}))
+
+	snaps, err := client.VolumeSnapshots.ListManual(context.Background())
+	if err != nil {
+		t.Fatalf("ListManual failed: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(snaps))
+	}
+}
+
+func TestVolumeSnapshotService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeSnapshot{Key: 1, Name: "snap1", ExpiresType: "never"})
+		},
+	}))
+
+	snap, err := client.VolumeSnapshots.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if snap.Name != "snap1" {
+		t.Errorf("expected name 'snap1', got %q", snap.Name)
+	}
+	if snap.ExpiresType != "never" {
+		t.Errorf("expected expires_type 'never', got %q", snap.ExpiresType)
+	}
+}
+
+func TestVolumeSnapshotService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_snapshots/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VolumeSnapshots.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSnapshotService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VolumeSnapshot{{Key: 1, Name: "snap1"}})
+		},
+		"GET /api/v4/volume_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeSnapshot{Key: 1, Name: "snap1"})
+		},
+	}))
+
+	snap, err := client.VolumeSnapshots.GetByName(context.Background(), 42, "snap1")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if snap.Name != "snap1" {
+		t.Errorf("expected name 'snap1', got %q", snap.Name)
+	}
+}
+
+func TestVolumeSnapshotService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VolumeSnapshot{})
+		},
+	}))
+
+	_, err := client.VolumeSnapshots.GetByName(context.Background(), 42, "missing")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSnapshotService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/volume_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			var req VolumeSnapshotCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "new-snap" {
+				t.Errorf("expected name 'new-snap', got %q", req.Name)
+			}
+			if req.Volume != 42 {
+				t.Errorf("expected volume 42, got %d", req.Volume)
+			}
+			jsonResponse(w, 200, apiResponse{Key: float64(10)})
+		},
+		"GET /api/v4/volume_snapshots/10": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeSnapshot{Key: 10, Name: "new-snap", Enabled: true})
+		},
+	}))
+
+	snap, err := client.VolumeSnapshots.Create(context.Background(), &VolumeSnapshotCreateRequest{
+		Volume: 42,
+		Name:   "new-snap",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if snap.Name != "new-snap" {
+		t.Errorf("expected name 'new-snap', got %q", snap.Name)
+	}
+}
+
+func TestVolumeSnapshotService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeSnapshots.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSnapshotService_Create_MissingVolume(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeSnapshots.Create(context.Background(), &VolumeSnapshotCreateRequest{Name: "snap1"})
+	if err == nil {
+		t.Fatal("expected error for missing volume")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSnapshotService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeSnapshots.Create(context.Background(), &VolumeSnapshotCreateRequest{Volume: 42})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSnapshotService_Update(t *testing.T) {
+	newDesc := "updated snapshot"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/volume_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/volume_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeSnapshot{Key: 1, Name: "snap1", Description: newDesc})
+		},
+	}))
+
+	snap, err := client.VolumeSnapshots.Update(context.Background(), 1, &VolumeSnapshotUpdateRequest{Description: &newDesc})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if snap.Description != newDesc {
+		t.Errorf("expected description %q, got %q", newDesc, snap.Description)
+	}
+}
+
+func TestVolumeSnapshotService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeSnapshots.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSnapshotService_Update_NotFound(t *testing.T) {
+	name := "test"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/volume_snapshots/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VolumeSnapshots.Update(context.Background(), 999, &VolumeSnapshotUpdateRequest{Name: &name})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSnapshotService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/volume_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VolumeSnapshots.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVolumeSnapshotService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/volume_snapshots/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VolumeSnapshots.Delete(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSnapshotService_Enable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/volume_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VolumeSnapshotUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Enabled == nil || !*req.Enabled {
+				t.Error("expected enabled=true in update request")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/volume_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeSnapshot{Key: 1, Name: "snap1", Enabled: true})
+		},
+	}))
+
+	err := client.VolumeSnapshots.Enable(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Enable failed: %v", err)
+	}
+}
+
+func TestVolumeSnapshotService_Disable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/volume_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VolumeSnapshotUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Enabled == nil || *req.Enabled {
+				t.Error("expected enabled=false in update request")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/volume_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeSnapshot{Key: 1, Name: "snap1", Enabled: false})
+		},
+	}))
+
+	err := client.VolumeSnapshots.Disable(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Disable failed: %v", err)
+	}
+}
+
+func TestVolumeSnapshotService_SetNeverExpires(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/volume_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VolumeSnapshotUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.ExpiresType == nil || *req.ExpiresType != "never" {
+				t.Errorf("expected expires_type 'never', got %v", req.ExpiresType)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/volume_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeSnapshot{Key: 1, Name: "snap1", ExpiresType: "never"})
+		},
+	}))
+
+	snap, err := client.VolumeSnapshots.SetNeverExpires(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("SetNeverExpires failed: %v", err)
+	}
+	if snap.ExpiresType != "never" {
+		t.Errorf("expected expires_type 'never', got %q", snap.ExpiresType)
+	}
+}
+
+func TestVolumeSnapshotService_SetExpires(t *testing.T) {
+	expiresAt := int64(1735689600)
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/volume_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			var req VolumeSnapshotUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.ExpiresType == nil || *req.ExpiresType != "date" {
+				t.Errorf("expected expires_type 'date', got %v", req.ExpiresType)
+			}
+			if req.Expires == nil || *req.Expires != expiresAt {
+				t.Errorf("expected expires %d, got %v", expiresAt, req.Expires)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/volume_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeSnapshot{Key: 1, Name: "snap1", ExpiresType: "date", Expires: expiresAt})
+		},
+	}))
+
+	snap, err := client.VolumeSnapshots.SetExpires(context.Background(), 1, expiresAt)
+	if err != nil {
+		t.Fatalf("SetExpires failed: %v", err)
+	}
+	if snap.Expires != expiresAt {
+		t.Errorf("expected expires %d, got %d", expiresAt, snap.Expires)
+	}
+}

--- a/volume_sync.go
+++ b/volume_sync.go
@@ -156,7 +156,7 @@ func (s *VolumeSyncService) Disable(ctx context.Context, id string) error {
 type volumeSyncAction struct {
 	Sync   string                 `json:"sync"`
 	Action string                 `json:"action"`
-	Params map[string]interface{} `json:"params"`
+	Params map[string]any `json:"params"`
 }
 
 // Start starts a volume sync job immediately.
@@ -164,7 +164,7 @@ func (s *VolumeSyncService) Start(ctx context.Context, id string) error {
 	action := volumeSyncAction{
 		Sync:   id,
 		Action: "start",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	if err := s.client.post(ctx, "/volume_sync_actions", action, nil); err != nil {
@@ -178,7 +178,7 @@ func (s *VolumeSyncService) Stop(ctx context.Context, id string) error {
 	action := volumeSyncAction{
 		Sync:   id,
 		Action: "stop",
-		Params: map[string]interface{}{},
+		Params: map[string]any{},
 	}
 
 	if err := s.client.post(ctx, "/volume_sync_actions", action, nil); err != nil {

--- a/volume_sync.go
+++ b/volume_sync.go
@@ -60,7 +60,7 @@ func (s *VolumeSyncService) Get(ctx context.Context, id string) (*VolumeSync, er
 
 // GetByName returns a volume sync by name within a specific service.
 func (s *VolumeSyncService) GetByName(ctx context.Context, serviceID int, name string) (*VolumeSync, error) {
-	syncs, err := s.List(ctx, WithFilter(fmt.Sprintf("service eq %d and name eq '%s'", serviceID, name)))
+	syncs, err := s.List(ctx, WithFilter(fmt.Sprintf("service eq %d and name eq '%s'", serviceID, escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}

--- a/volume_sync_test.go
+++ b/volume_sync_test.go
@@ -1,0 +1,416 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestVolumeSyncService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_syncs": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VolumeSync{
+				{Key: "sync1", ID: "sync1", Name: "daily-backup", Enabled: true},
+				{Key: "sync2", ID: "sync2", Name: "hourly-mirror", Enabled: false},
+			})
+		},
+	}))
+
+	syncs, err := client.VolumeSyncs.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(syncs) != 2 {
+		t.Fatalf("expected 2 syncs, got %d", len(syncs))
+	}
+	if syncs[0].Name != "daily-backup" {
+		t.Errorf("expected name 'daily-backup', got %q", syncs[0].Name)
+	}
+}
+
+func TestVolumeSyncService_ListByService(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_syncs": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "service eq 3" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VolumeSync{{Key: "sync1", ID: "sync1", Name: "daily-backup"}})
+		},
+	}))
+
+	syncs, err := client.VolumeSyncs.ListByService(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("ListByService failed: %v", err)
+	}
+	if len(syncs) != 1 {
+		t.Fatalf("expected 1 sync, got %d", len(syncs))
+	}
+}
+
+func TestVolumeSyncService_ListEnabled(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_syncs": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "enabled eq true" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []VolumeSync{{Key: "sync1", ID: "sync1", Name: "daily-backup", Enabled: true}})
+		},
+	}))
+
+	syncs, err := client.VolumeSyncs.ListEnabled(context.Background())
+	if err != nil {
+		t.Fatalf("ListEnabled failed: %v", err)
+	}
+	if len(syncs) != 1 {
+		t.Fatalf("expected 1 sync, got %d", len(syncs))
+	}
+}
+
+func TestVolumeSyncService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_syncs/sync1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeSync{Key: "sync1", ID: "sync1", Name: "daily-backup", SyncMethod: "rsync"})
+		},
+	}))
+
+	sync, err := client.VolumeSyncs.Get(context.Background(), "sync1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if sync.Name != "daily-backup" {
+		t.Errorf("expected name 'daily-backup', got %q", sync.Name)
+	}
+	if sync.SyncMethod != "rsync" {
+		t.Errorf("expected sync_method 'rsync', got %q", sync.SyncMethod)
+	}
+}
+
+func TestVolumeSyncService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_syncs/missing": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VolumeSyncs.Get(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSyncService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_syncs": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VolumeSync{{Key: "sync1", ID: "sync1", Name: "daily-backup"}})
+		},
+		"GET /api/v4/volume_syncs/sync1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeSync{Key: "sync1", ID: "sync1", Name: "daily-backup"})
+		},
+	}))
+
+	sync, err := client.VolumeSyncs.GetByName(context.Background(), 3, "daily-backup")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if sync.Name != "daily-backup" {
+		t.Errorf("expected name 'daily-backup', got %q", sync.Name)
+	}
+}
+
+func TestVolumeSyncService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volume_syncs": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VolumeSync{})
+		},
+	}))
+
+	_, err := client.VolumeSyncs.GetByName(context.Background(), 3, "missing")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSyncService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/volume_syncs": func(w http.ResponseWriter, r *http.Request) {
+			var req VolumeSyncCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "daily-backup" {
+				t.Errorf("expected name 'daily-backup', got %q", req.Name)
+			}
+			if req.Service != 3 {
+				t.Errorf("expected service 3, got %d", req.Service)
+			}
+			if req.SourceVolume != 10 {
+				t.Errorf("expected source_volume 10, got %d", req.SourceVolume)
+			}
+			if req.DestinationVolume != 20 {
+				t.Errorf("expected destination_volume 20, got %d", req.DestinationVolume)
+			}
+			jsonResponse(w, 200, apiResponse{Key: "newsync"})
+		},
+		"GET /api/v4/volume_syncs/newsync": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeSync{Key: "newsync", ID: "newsync", Name: "daily-backup", Enabled: true})
+		},
+	}))
+
+	sync, err := client.VolumeSyncs.Create(context.Background(), &VolumeSyncCreateRequest{
+		Service:           3,
+		Name:              "daily-backup",
+		SourceVolume:      10,
+		DestinationVolume: 20,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if sync.Name != "daily-backup" {
+		t.Errorf("expected name 'daily-backup', got %q", sync.Name)
+	}
+}
+
+func TestVolumeSyncService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeSyncs.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSyncService_Create_MissingService(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeSyncs.Create(context.Background(), &VolumeSyncCreateRequest{
+		Name:              "sync1",
+		SourceVolume:      10,
+		DestinationVolume: 20,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing service")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSyncService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeSyncs.Create(context.Background(), &VolumeSyncCreateRequest{
+		Service:           3,
+		SourceVolume:      10,
+		DestinationVolume: 20,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSyncService_Create_MissingSourceVolume(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeSyncs.Create(context.Background(), &VolumeSyncCreateRequest{
+		Service:           3,
+		Name:              "sync1",
+		DestinationVolume: 20,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing source_volume")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSyncService_Create_MissingDestinationVolume(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeSyncs.Create(context.Background(), &VolumeSyncCreateRequest{
+		Service:      3,
+		Name:         "sync1",
+		SourceVolume: 10,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing destination_volume")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSyncService_Update(t *testing.T) {
+	newDesc := "updated sync"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/volume_syncs/sync1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/volume_syncs/sync1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeSync{Key: "sync1", ID: "sync1", Name: "daily-backup", Description: newDesc})
+		},
+	}))
+
+	sync, err := client.VolumeSyncs.Update(context.Background(), "sync1", &VolumeSyncUpdateRequest{Description: &newDesc})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if sync.Description != newDesc {
+		t.Errorf("expected description %q, got %q", newDesc, sync.Description)
+	}
+}
+
+func TestVolumeSyncService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.VolumeSyncs.Update(context.Background(), "sync1", nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSyncService_Update_NotFound(t *testing.T) {
+	name := "test"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/volume_syncs/missing": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VolumeSyncs.Update(context.Background(), "missing", &VolumeSyncUpdateRequest{Name: &name})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSyncService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/volume_syncs/sync1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VolumeSyncs.Delete(context.Background(), "sync1")
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVolumeSyncService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/volume_syncs/missing": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.VolumeSyncs.Delete(context.Background(), "missing")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeSyncService_Enable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/volume_syncs/sync1": func(w http.ResponseWriter, r *http.Request) {
+			var req VolumeSyncUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Enabled == nil || !*req.Enabled {
+				t.Error("expected enabled=true in update request")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/volume_syncs/sync1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeSync{Key: "sync1", ID: "sync1", Name: "daily-backup", Enabled: true})
+		},
+	}))
+
+	err := client.VolumeSyncs.Enable(context.Background(), "sync1")
+	if err != nil {
+		t.Fatalf("Enable failed: %v", err)
+	}
+}
+
+func TestVolumeSyncService_Disable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/volume_syncs/sync1": func(w http.ResponseWriter, r *http.Request) {
+			var req VolumeSyncUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Enabled == nil || *req.Enabled {
+				t.Error("expected enabled=false in update request")
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/volume_syncs/sync1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VolumeSync{Key: "sync1", ID: "sync1", Name: "daily-backup", Enabled: false})
+		},
+	}))
+
+	err := client.VolumeSyncs.Disable(context.Background(), "sync1")
+	if err != nil {
+		t.Fatalf("Disable failed: %v", err)
+	}
+}
+
+func TestVolumeSyncService_Start(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/volume_sync_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body volumeSyncAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Sync != "sync1" {
+				t.Errorf("expected sync 'sync1', got %q", body.Sync)
+			}
+			if body.Action != "start" {
+				t.Errorf("expected action 'start', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VolumeSyncs.Start(context.Background(), "sync1")
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+}
+
+func TestVolumeSyncService_Stop(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/volume_sync_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body volumeSyncAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Sync != "sync1" {
+				t.Errorf("expected sync 'sync1', got %q", body.Sync)
+			}
+			if body.Action != "stop" {
+				t.Errorf("expected action 'stop', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.VolumeSyncs.Stop(context.Background(), "sync1")
+	if err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+}

--- a/volume_test.go
+++ b/volume_test.go
@@ -1,0 +1,335 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestVolumeService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volumes": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Volume{
+				{Key: "abc123", ID: "abc123", Name: "vol1", Enabled: true},
+				{Key: "def456", ID: "def456", Name: "vol2", Enabled: false},
+			})
+		},
+	}))
+
+	volumes, err := client.Volumes.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(volumes) != 2 {
+		t.Fatalf("expected 2 volumes, got %d", len(volumes))
+	}
+	if volumes[0].Name != "vol1" {
+		t.Errorf("expected name 'vol1', got %q", volumes[0].Name)
+	}
+}
+
+func TestVolumeService_ListByService(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volumes": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "service eq 5" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []Volume{{Key: "abc123", ID: "abc123", Name: "vol1"}})
+		},
+	}))
+
+	volumes, err := client.Volumes.ListByService(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("ListByService failed: %v", err)
+	}
+	if len(volumes) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(volumes))
+	}
+}
+
+func TestVolumeService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volumes/abc123": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Volume{Key: "abc123", ID: "abc123", Name: "vol1", FSType: "ext4"})
+		},
+	}))
+
+	vol, err := client.Volumes.Get(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if vol.Name != "vol1" {
+		t.Errorf("expected name 'vol1', got %q", vol.Name)
+	}
+	if vol.FSType != "ext4" {
+		t.Errorf("expected fs_type 'ext4', got %q", vol.FSType)
+	}
+}
+
+func TestVolumeService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volumes/nonexistent": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Volumes.Get(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volumes": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Volume{{Key: "abc123", ID: "abc123", Name: "vol1"}})
+		},
+		"GET /api/v4/volumes/abc123": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Volume{Key: "abc123", ID: "abc123", Name: "vol1", FSType: "ext4"})
+		},
+	}))
+
+	vol, err := client.Volumes.GetByName(context.Background(), 5, "vol1")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if vol.Name != "vol1" {
+		t.Errorf("expected name 'vol1', got %q", vol.Name)
+	}
+}
+
+func TestVolumeService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/volumes": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Volume{})
+		},
+	}))
+
+	_, err := client.Volumes.GetByName(context.Background(), 5, "missing")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/volumes": func(w http.ResponseWriter, r *http.Request) {
+			var req VolumeCreateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Name != "newvol" {
+				t.Errorf("expected name 'newvol', got %q", req.Name)
+			}
+			if req.Service != 5 {
+				t.Errorf("expected service 5, got %d", req.Service)
+			}
+			jsonResponse(w, 200, apiResponse{Key: "sha1hash"})
+		},
+		"GET /api/v4/volumes/sha1hash": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Volume{Key: "sha1hash", ID: "sha1hash", Name: "newvol", Enabled: true})
+		},
+	}))
+
+	vol, err := client.Volumes.Create(context.Background(), &VolumeCreateRequest{
+		Name:    "newvol",
+		Service: 5,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if vol.Name != "newvol" {
+		t.Errorf("expected name 'newvol', got %q", vol.Name)
+	}
+	if vol.ID != "sha1hash" {
+		t.Errorf("expected ID 'sha1hash', got %q", vol.ID)
+	}
+}
+
+func TestVolumeService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Volumes.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Volumes.Create(context.Background(), &VolumeCreateRequest{Service: 5})
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeService_Create_MissingService(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Volumes.Create(context.Background(), &VolumeCreateRequest{Name: "vol1"})
+	if err == nil {
+		t.Fatal("expected error for missing service")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeService_Update(t *testing.T) {
+	newDesc := "updated description"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/volumes/abc123": func(w http.ResponseWriter, r *http.Request) {
+			var req VolumeUpdateRequest
+			json.NewDecoder(r.Body).Decode(&req)
+			if req.Description == nil || *req.Description != newDesc {
+				t.Errorf("expected description %q, got %v", newDesc, req.Description)
+			}
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/volumes/abc123": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Volume{Key: "abc123", ID: "abc123", Name: "vol1", Description: newDesc})
+		},
+	}))
+
+	vol, err := client.Volumes.Update(context.Background(), "abc123", &VolumeUpdateRequest{Description: &newDesc})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if vol.Description != newDesc {
+		t.Errorf("expected description %q, got %q", newDesc, vol.Description)
+	}
+}
+
+func TestVolumeService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.Volumes.Update(context.Background(), "abc123", nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeService_Update_NotFound(t *testing.T) {
+	newDesc := "test"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/volumes/nonexistent": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.Volumes.Update(context.Background(), "nonexistent", &VolumeUpdateRequest{Description: &newDesc})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/volumes/abc123": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Volumes.Delete(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestVolumeService_Delete_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/volumes/nonexistent": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	err := client.Volumes.Delete(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVolumeService_Enable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/volume_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body volumeAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Volume != "abc123" {
+				t.Errorf("expected volume 'abc123', got %q", body.Volume)
+			}
+			if body.Action != "enable" {
+				t.Errorf("expected action 'enable', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Volumes.Enable(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("Enable failed: %v", err)
+	}
+}
+
+func TestVolumeService_Disable(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/volume_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body volumeAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Volume != "abc123" {
+				t.Errorf("expected volume 'abc123', got %q", body.Volume)
+			}
+			if body.Action != "disable" {
+				t.Errorf("expected action 'disable', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Volumes.Disable(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("Disable failed: %v", err)
+	}
+}
+
+func TestVolumeService_Reset(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/volume_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body volumeAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Volume != "abc123" {
+				t.Errorf("expected volume 'abc123', got %q", body.Volume)
+			}
+			if body.Action != "reset" {
+				t.Errorf("expected action 'reset', got %q", body.Action)
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Volumes.Reset(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("Reset failed: %v", err)
+	}
+}

--- a/vsan_service_test.go
+++ b/vsan_service_test.go
@@ -1,0 +1,544 @@
+package vergeos
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// --- StorageTierService ---
+
+func TestStorageTierService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/storage_tiers": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []StorageTier{
+				{Key: 0, Tier: 0, Description: "SSD", Capacity: 1000000},
+				{Key: 1, Tier: 1, Description: "HDD", Capacity: 5000000},
+			})
+		},
+	}))
+
+	tiers, err := client.StorageTiers.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(tiers) != 2 {
+		t.Fatalf("expected 2 tiers, got %d", len(tiers))
+	}
+	if tiers[0].Description != "SSD" {
+		t.Errorf("expected description 'SSD', got %q", tiers[0].Description)
+	}
+}
+
+func TestStorageTierService_List_WithFields(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/storage_tiers": func(w http.ResponseWriter, r *http.Request) {
+			fields := r.URL.Query().Get("fields")
+			if fields != "all" {
+				t.Errorf("expected fields 'all', got %q", fields)
+			}
+			jsonResponse(w, 200, []StorageTier{{Key: 0}})
+		},
+	}))
+
+	_, err := client.StorageTiers.List(context.Background(), WithFields("all"))
+	if err != nil {
+		t.Fatalf("List with fields failed: %v", err)
+	}
+}
+
+func TestStorageTierService_List_DefaultFields(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/storage_tiers": func(w http.ResponseWriter, r *http.Request) {
+			fields := r.URL.Query().Get("fields")
+			if fields != storageTierListFields {
+				t.Errorf("expected default fields, got %q", fields)
+			}
+			jsonResponse(w, 200, []StorageTier{})
+		},
+	}))
+
+	_, err := client.StorageTiers.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+}
+
+func TestStorageTierService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/storage_tiers/0": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, StorageTier{Key: 0, Tier: 0, Description: "SSD", Capacity: 1000000})
+		},
+	}))
+
+	tier, err := client.StorageTiers.Get(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if tier.Description != "SSD" {
+		t.Errorf("expected description 'SSD', got %q", tier.Description)
+	}
+	if tier.Capacity != 1000000 {
+		t.Errorf("expected capacity 1000000, got %d", tier.Capacity)
+	}
+}
+
+func TestStorageTierService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/storage_tiers/99": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.StorageTiers.Get(context.Background(), 99)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// --- ClusterTierService ---
+
+func TestClusterTierService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cluster_tiers": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []ClusterTier{
+				{Key: FlexInt(1), Tier: 0, Description: "SSD"},
+				{Key: FlexInt(2), Tier: 1, Description: "HDD"},
+			})
+		},
+	}))
+
+	tiers, err := client.ClusterTiers.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(tiers) != 2 {
+		t.Fatalf("expected 2 tiers, got %d", len(tiers))
+	}
+}
+
+func TestClusterTierService_ListByCluster(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cluster_tiers": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "cluster eq 5" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []ClusterTier{{Key: FlexInt(1), Tier: 0}})
+		},
+	}))
+
+	tiers, err := client.ClusterTiers.ListByCluster(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("ListByCluster failed: %v", err)
+	}
+	if len(tiers) != 1 {
+		t.Fatalf("expected 1 tier, got %d", len(tiers))
+	}
+}
+
+func TestClusterTierService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cluster_tiers/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, ClusterTier{Key: FlexInt(1), Tier: 0, Description: "SSD"})
+		},
+	}))
+
+	tier, err := client.ClusterTiers.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if tier.Description != "SSD" {
+		t.Errorf("expected description 'SSD', got %q", tier.Description)
+	}
+}
+
+func TestClusterTierService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cluster_tiers/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.ClusterTiers.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestClusterTierService_GetByClusterAndTier(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cluster_tiers": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "cluster eq 5 and tier eq 2" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []ClusterTier{{Key: FlexInt(10), Tier: 2}})
+		},
+	}))
+
+	tier, err := client.ClusterTiers.GetByClusterAndTier(context.Background(), 5, 2)
+	if err != nil {
+		t.Fatalf("GetByClusterAndTier failed: %v", err)
+	}
+	if tier.Tier != 2 {
+		t.Errorf("expected tier 2, got %d", tier.Tier)
+	}
+}
+
+func TestClusterTierService_GetByClusterAndTier_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cluster_tiers": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []ClusterTier{})
+		},
+	}))
+
+	_, err := client.ClusterTiers.GetByClusterAndTier(context.Background(), 99, 99)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// --- MachineDrivePhysService ---
+
+func TestMachineDrivePhysService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drive_phys": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []MachineDrivePhys{
+				{Key: FlexInt(1), Serial: "ABC123"},
+				{Key: FlexInt(2), Serial: "DEF456"},
+			})
+		},
+	}))
+
+	drives, err := client.MachineDrivePhys.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(drives) != 2 {
+		t.Fatalf("expected 2 drives, got %d", len(drives))
+	}
+	if drives[0].Serial != "ABC123" {
+		t.Errorf("expected serial 'ABC123', got %q", drives[0].Serial)
+	}
+}
+
+func TestMachineDrivePhysService_ListByVSANTier(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drive_phys": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "vsan_tier eq 0" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []MachineDrivePhys{{Key: FlexInt(1)}})
+		},
+	}))
+
+	drives, err := client.MachineDrivePhys.ListByVSANTier(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("ListByVSANTier failed: %v", err)
+	}
+	if len(drives) != 1 {
+		t.Fatalf("expected 1 drive, got %d", len(drives))
+	}
+}
+
+func TestMachineDrivePhysService_ListSpares(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drive_phys": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "spare eq true" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []MachineDrivePhys{{Key: FlexInt(3)}})
+		},
+	}))
+
+	drives, err := client.MachineDrivePhys.ListSpares(context.Background())
+	if err != nil {
+		t.Fatalf("ListSpares failed: %v", err)
+	}
+	if len(drives) != 1 {
+		t.Fatalf("expected 1 drive, got %d", len(drives))
+	}
+}
+
+func TestMachineDrivePhysService_ListWithWarnings(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drive_phys": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter == "" {
+				t.Error("expected filter for warnings query")
+			}
+			jsonResponse(w, 200, []MachineDrivePhys{{Key: FlexInt(1)}})
+		},
+	}))
+
+	drives, err := client.MachineDrivePhys.ListWithWarnings(context.Background())
+	if err != nil {
+		t.Fatalf("ListWithWarnings failed: %v", err)
+	}
+	if len(drives) != 1 {
+		t.Fatalf("expected 1 drive, got %d", len(drives))
+	}
+}
+
+func TestMachineDrivePhysService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drive_phys/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, MachineDrivePhys{Key: FlexInt(1), Serial: "ABC123"})
+		},
+	}))
+
+	drive, err := client.MachineDrivePhys.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if drive.Serial != "ABC123" {
+		t.Errorf("expected serial 'ABC123', got %q", drive.Serial)
+	}
+}
+
+func TestMachineDrivePhysService_Get_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drive_phys/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.MachineDrivePhys.Get(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestMachineDrivePhysService_GetByParentDrive(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drive_phys": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "parent_drive eq 42" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []MachineDrivePhys{{Key: 1, Serial: "XYZ"}})
+		},
+	}))
+
+	drive, err := client.MachineDrivePhys.GetByParentDrive(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("GetByParentDrive failed: %v", err)
+	}
+	if drive.Serial != "XYZ" {
+		t.Errorf("expected serial 'XYZ', got %q", drive.Serial)
+	}
+}
+
+func TestMachineDrivePhysService_GetByParentDrive_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drive_phys": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []MachineDrivePhys{})
+		},
+	}))
+
+	_, err := client.MachineDrivePhys.GetByParentDrive(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+// --- ClusterStatsHistoryService ---
+
+func TestClusterStatsHistoryService_ListShort(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cluster_stats_history_short": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []ClusterStatsHistory{
+				{Key: FlexInt(1), TotalNodes: 3, OnlineNodes: 3},
+				{Key: FlexInt(2), TotalNodes: 3, OnlineNodes: 2},
+			})
+		},
+	}))
+
+	stats, err := client.ClusterStatsHistory.ListShort(context.Background())
+	if err != nil {
+		t.Fatalf("ListShort failed: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("expected 2 stats, got %d", len(stats))
+	}
+}
+
+func TestClusterStatsHistoryService_ListShortByCluster(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cluster_stats_history_short": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "cluster eq 5" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []ClusterStatsHistory{{Key: FlexInt(1)}})
+		},
+	}))
+
+	stats, err := client.ClusterStatsHistory.ListShortByCluster(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("ListShortByCluster failed: %v", err)
+	}
+	if len(stats) != 1 {
+		t.Fatalf("expected 1 stats, got %d", len(stats))
+	}
+}
+
+func TestClusterStatsHistoryService_ListLong(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cluster_stats_history_long": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []ClusterStatsHistory{
+				{Key: FlexInt(1), TotalNodes: 4},
+			})
+		},
+	}))
+
+	stats, err := client.ClusterStatsHistory.ListLong(context.Background())
+	if err != nil {
+		t.Fatalf("ListLong failed: %v", err)
+	}
+	if len(stats) != 1 {
+		t.Fatalf("expected 1 stats, got %d", len(stats))
+	}
+}
+
+func TestClusterStatsHistoryService_ListLongByCluster(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cluster_stats_history_long": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			if filter != "cluster eq 10" {
+				t.Errorf("unexpected filter: %s", filter)
+			}
+			jsonResponse(w, 200, []ClusterStatsHistory{{Key: FlexInt(1)}})
+		},
+	}))
+
+	stats, err := client.ClusterStatsHistory.ListLongByCluster(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListLongByCluster failed: %v", err)
+	}
+	if len(stats) != 1 {
+		t.Fatalf("expected 1 stat, got %d", len(stats))
+	}
+}
+
+func TestClusterStatsHistoryService_GetLatestShort(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cluster_stats_history_short": func(w http.ResponseWriter, r *http.Request) {
+			sort := r.URL.Query().Get("sort")
+			if sort != "-timestamp" {
+				t.Errorf("expected sort '-timestamp', got %q", sort)
+			}
+			limit := r.URL.Query().Get("limit")
+			if limit != "1" {
+				t.Errorf("expected limit '1', got %q", limit)
+			}
+			jsonResponse(w, 200, []ClusterStatsHistory{{Key: FlexInt(99), TotalNodes: 3}})
+		},
+	}))
+
+	stat, err := client.ClusterStatsHistory.GetLatestShort(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("GetLatestShort failed: %v", err)
+	}
+	if stat.TotalNodes != 3 {
+		t.Errorf("expected TotalNodes 3, got %d", stat.TotalNodes)
+	}
+}
+
+func TestClusterStatsHistoryService_GetLatestShort_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cluster_stats_history_short": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []ClusterStatsHistory{})
+		},
+	}))
+
+	_, err := client.ClusterStatsHistory.GetLatestShort(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestClusterStatsHistoryService_GetShort(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cluster_stats_history_short/42": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, ClusterStatsHistory{Key: FlexInt(42), TotalNodes: 3})
+		},
+	}))
+
+	stat, err := client.ClusterStatsHistory.GetShort(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("GetShort failed: %v", err)
+	}
+	if stat.Key != 42 {
+		t.Errorf("expected key 42, got %d", stat.Key)
+	}
+}
+
+func TestClusterStatsHistoryService_GetShort_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cluster_stats_history_short/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.ClusterStatsHistory.GetShort(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestClusterStatsHistoryService_GetLong(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cluster_stats_history_long/7": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, ClusterStatsHistory{Key: FlexInt(7), OnlineNodes: 2})
+		},
+	}))
+
+	stat, err := client.ClusterStatsHistory.GetLong(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("GetLong failed: %v", err)
+	}
+	if stat.OnlineNodes != 2 {
+		t.Errorf("expected OnlineNodes 2, got %d", stat.OnlineNodes)
+	}
+}
+
+func TestClusterStatsHistoryService_GetLong_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/cluster_stats_history_long/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.ClusterStatsHistory.GetLong(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}

--- a/webhook.go
+++ b/webhook.go
@@ -38,7 +38,7 @@ func (s *WebhookURLService) Get(ctx context.Context, id int) (*WebhookURL, error
 	endpoint := fmt.Sprintf("/webhook_urls/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &webhook); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "WebhookURL", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "WebhookURL", ID: id}
 		}
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (s *WebhookURLService) Update(ctx context.Context, id int, req *WebhookURLU
 	endpoint := fmt.Sprintf("/webhook_urls/%d", id)
 	if err := s.client.put(ctx, endpoint, req, nil); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "WebhookURL", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "WebhookURL", ID: id}
 		}
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (s *WebhookURLService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/webhook_urls/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "WebhookURL", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "WebhookURL", ID: id}
 		}
 		return err
 	}
@@ -192,7 +192,7 @@ func (s *WebhookService) Get(ctx context.Context, id int) (*Webhook, error) {
 	endpoint := fmt.Sprintf("/webhooks/%d", id)
 	if err := s.client.get(ctx, endpoint, params, &webhook); err != nil {
 		if IsNotFoundError(err) {
-			return nil, &NotFoundError{Resource: "Webhook", ID: fmt.Sprintf("%d", id)}
+			return nil, &NotFoundError{Resource: "Webhook", ID: id}
 		}
 		return nil, err
 	}
@@ -205,7 +205,7 @@ func (s *WebhookService) Delete(ctx context.Context, id int) error {
 	endpoint := fmt.Sprintf("/webhooks/%d", id)
 	if err := s.client.delete(ctx, endpoint); err != nil {
 		if IsNotFoundError(err) {
-			return &NotFoundError{Resource: "Webhook", ID: fmt.Sprintf("%d", id)}
+			return &NotFoundError{Resource: "Webhook", ID: id}
 		}
 		return err
 	}

--- a/webhook.go
+++ b/webhook.go
@@ -48,7 +48,7 @@ func (s *WebhookURLService) Get(ctx context.Context, id int) (*WebhookURL, error
 
 // GetByName returns a webhook URL by name.
 func (s *WebhookURLService) GetByName(ctx context.Context, name string) (*WebhookURL, error) {
-	webhooks, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", name)))
+	webhooks, err := s.List(ctx, WithFilter(fmt.Sprintf("name eq '%s'", escapeFilterValue(name))))
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func (s *WebhookService) ListByWebhookURL(ctx context.Context, webhookURLID int,
 
 // ListByStatus returns all webhook messages with a specific status.
 func (s *WebhookService) ListByStatus(ctx context.Context, status string, opts ...ListOption) ([]Webhook, error) {
-	filterOpts := []ListOption{WithFilter(fmt.Sprintf("status eq '%s'", status))}
+	filterOpts := []ListOption{WithFilter(fmt.Sprintf("status eq '%s'", escapeFilterValue(status)))}
 	filterOpts = append(filterOpts, opts...)
 	return s.List(ctx, filterOpts...)
 }

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -177,7 +177,7 @@ func TestWebhookURLService_Delete(t *testing.T) {
 func TestWebhookURLService_Send(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/webhook_url_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]interface{}
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
 			if body["action"] != "send" {
 				t.Errorf("expected action 'send', got %v", body["action"])

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -1,0 +1,307 @@
+package vergeos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestWebhookURLService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/webhook_urls": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []WebhookURL{
+				{Key: 1, Name: "slack", URL: "https://hooks.slack.com/test"},
+				{Key: 2, Name: "pagerduty", URL: "https://events.pagerduty.com/test"},
+			})
+		},
+	}))
+
+	webhooks, err := client.WebhookURLs.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(webhooks) != 2 {
+		t.Fatalf("expected 2 webhook URLs, got %d", len(webhooks))
+	}
+}
+
+func TestWebhookURLService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/webhook_urls/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, WebhookURL{Key: 1, Name: "slack", URL: "https://hooks.slack.com/test"})
+		},
+	}))
+
+	wh, err := client.WebhookURLs.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if wh.Name != "slack" {
+		t.Errorf("expected name 'slack', got %q", wh.Name)
+	}
+}
+
+func TestWebhookURLService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/webhook_urls": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []WebhookURL{{Key: 1, Name: "slack"}})
+		},
+		"GET /api/v4/webhook_urls/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, WebhookURL{Key: 1, Name: "slack", URL: "https://hooks.slack.com"})
+		},
+	}))
+
+	wh, err := client.WebhookURLs.GetByName(context.Background(), "slack")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if wh.Name != "slack" {
+		t.Errorf("expected name 'slack', got %q", wh.Name)
+	}
+}
+
+func TestWebhookURLService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/webhook_urls": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []WebhookURL{})
+		},
+	}))
+
+	_, err := client.WebhookURLs.GetByName(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestWebhookURLService_Create(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/webhook_urls": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, apiResponse{Key: float64(1)})
+		},
+		"GET /api/v4/webhook_urls/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, WebhookURL{Key: 1, Name: "slack", URL: "https://hooks.slack.com"})
+		},
+	}))
+
+	wh, err := client.WebhookURLs.Create(context.Background(), &WebhookURLCreateRequest{
+		Name: "slack",
+		URL:  "https://hooks.slack.com",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if wh.Name != "slack" {
+		t.Errorf("expected name 'slack', got %q", wh.Name)
+	}
+}
+
+func TestWebhookURLService_Create_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.WebhookURLs.Create(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for nil request")
+	}
+}
+
+func TestWebhookURLService_Create_MissingName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.WebhookURLs.Create(context.Background(), &WebhookURLCreateRequest{URL: "https://example.com"})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestWebhookURLService_Create_MissingURL(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.WebhookURLs.Create(context.Background(), &WebhookURLCreateRequest{Name: "test"})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestWebhookURLService_Update(t *testing.T) {
+	newName := "updated-slack"
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"PUT /api/v4/webhook_urls/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+		"GET /api/v4/webhook_urls/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, WebhookURL{Key: 1, Name: newName})
+		},
+	}))
+
+	wh, err := client.WebhookURLs.Update(context.Background(), 1, &WebhookURLUpdateRequest{Name: &newName})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if wh.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, wh.Name)
+	}
+}
+
+func TestWebhookURLService_Update_NilRequest(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{}))
+
+	_, err := client.WebhookURLs.Update(context.Background(), 1, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestWebhookURLService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/webhook_urls/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.WebhookURLs.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestWebhookURLService_Send(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/webhook_url_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]interface{}
+			json.NewDecoder(r.Body).Decode(&body)
+			if body["action"] != "send" {
+				t.Errorf("expected action 'send', got %v", body["action"])
+			}
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.WebhookURLs.Send(context.Background(), 1, "test message")
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+}
+
+// Webhook (message log) tests
+
+func TestWebhookService_List(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/webhooks": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Webhook{
+				{Key: 1, Status: "sent", Message: "test"},
+				{Key: 2, Status: "queued", Message: "test2"},
+			})
+		},
+	}))
+
+	webhooks, err := client.Webhooks.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(webhooks) != 2 {
+		t.Fatalf("expected 2 webhooks, got %d", len(webhooks))
+	}
+}
+
+func TestWebhookService_ListByWebhookURL(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/webhooks": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Webhook{{Key: 1, WebhookURL: 5}})
+		},
+	}))
+
+	webhooks, err := client.Webhooks.ListByWebhookURL(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("ListByWebhookURL failed: %v", err)
+	}
+	if len(webhooks) != 1 {
+		t.Fatalf("expected 1 webhook, got %d", len(webhooks))
+	}
+}
+
+func TestWebhookService_ListByStatus(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/webhooks": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Webhook{{Key: 1, Status: "error"}})
+		},
+	}))
+
+	webhooks, err := client.Webhooks.ListByStatus(context.Background(), "error")
+	if err != nil {
+		t.Fatalf("ListByStatus failed: %v", err)
+	}
+	if len(webhooks) != 1 {
+		t.Fatalf("expected 1 webhook, got %d", len(webhooks))
+	}
+}
+
+func TestWebhookService_ListPending(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/webhooks": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Webhook{{Key: 1, Status: "queued"}})
+		},
+	}))
+
+	webhooks, err := client.Webhooks.ListPending(context.Background())
+	if err != nil {
+		t.Fatalf("ListPending failed: %v", err)
+	}
+	if len(webhooks) != 1 {
+		t.Fatalf("expected 1 webhook, got %d", len(webhooks))
+	}
+}
+
+func TestWebhookService_ListFailed(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/webhooks": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []Webhook{{Key: 1, Status: "error"}})
+		},
+	}))
+
+	webhooks, err := client.Webhooks.ListFailed(context.Background())
+	if err != nil {
+		t.Fatalf("ListFailed failed: %v", err)
+	}
+	if len(webhooks) != 1 {
+		t.Fatalf("expected 1 webhook, got %d", len(webhooks))
+	}
+}
+
+func TestWebhookService_Get(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/webhooks/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Webhook{Key: 1, Status: "sent", Message: "payload"})
+		},
+	}))
+
+	wh, err := client.Webhooks.Get(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if wh.Status != "sent" {
+		t.Errorf("expected status 'sent', got %q", wh.Status)
+	}
+}
+
+func TestWebhookService_Delete(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"DELETE /api/v4/webhooks/1": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+		},
+	}))
+
+	err := client.Webhooks.Delete(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+}


### PR DESCRIPTION
Quality and stability pass preparing the SDK for 1.0. Adds unit test coverage for all 77 services, addresses security and correctness issues found during review, and includes breaking changes to clean up the API surface.

Closes #23

## Breaking Changes

- **`NotFoundError.ID` is now `int`** — standardizes the type across all Delete methods
- **`VMDrive.List` / `VMDevice.List`** — parameter renamed `vmID` → `machineID` to match actual semantics
- **`FlexInt` / `FlexFK` unmarshal** — returns error on unexpected JSON types instead of silently zero-valuing
- **`WithFilter()` is additive** — multiple calls append filters instead of last-one-wins
- **HTTP 3xx responses** are now treated as errors
- **`GetDashboard` removed** — replaced by per-node VM resource aggregates
- **`interface{}` → `any`** throughout

## Security & Correctness

- Escape filter values before sending to API to prevent injection
- Bound response body reads to 100 MB to prevent OOM
- Clone existing HTTP transport instead of replacing it
- Respect context cancellation in `SystemService.GetInfo` and polling loops
- Propagate errors that were previously silently swallowed
- Add nil request guard on `GroupService.Create`
- Check state before first sleep in polling loops
- Standardize Delete to return `NotFoundError` consistently
- `TenantLayer2Network` Enable/Disable now return error
- `Certificate.ListExpiring` expiry filter implemented

## New Features

- `TimeoutError` type for polling timeouts
- `VMDriveService.ListAll` for batch drive listing across VMs
- `TenantStatus` and `TenantStatsHistoryShort` services
- `FlexFK` type for foreign key field deserialization
- `ClusterTier` default fields include `nodes_online` / `drives_online`
- Per-node VM resource aggregates

## Tests

- Unit tests for all 77 services
- Integration tests for computed field expressions
- Compile-time interface satisfaction checks

## Other

- License updated to Apache 2.0 with CLA