### PR TITLE
fix(cloud_snapshot): send expires/expires_type on create (#29)

### DIFF
--- a/cloud_snapshot.go
+++ b/cloud_snapshot.go
@@ -4,7 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"time"
 )
+
+// cloudSnapshotDefaultExpirySeconds matches the VergeOS server-side default
+// (expires = $now + 259200) for cloud_snapshots.expires.
+const cloudSnapshotDefaultExpirySeconds = 259200
 
 // CloudSnapshotService handles cloud snapshot (system snapshot) operations.
 type CloudSnapshotService struct {
@@ -93,9 +98,24 @@ func (s *CloudSnapshotService) Create(ctx context.Context, req *CloudSnapshotCre
 	if req.Description != "" {
 		tableAction["description"] = req.Description
 	}
-	if req.Retention != nil {
-		tableAction["retention"] = *req.Retention
+
+	// Expiry fields: VergeOS ignores "retention" on create and instead reads
+	// "expires" (absolute Unix timestamp) together with "expires_type" ("never"
+	// or "date"). Translate the caller-facing Retention / NeverExpire knobs into
+	// those wire fields so snapshots honor the requested lifetime instead of
+	// silently falling back to the server default.
+	switch {
+	case req.NeverExpire:
+		tableAction["expires"] = 0
+		tableAction["expires_type"] = "never"
+	case req.Retention != nil:
+		tableAction["expires"] = time.Now().Unix() + int64(*req.Retention)
+		tableAction["expires_type"] = "date"
+	default:
+		tableAction["expires"] = time.Now().Unix() + cloudSnapshotDefaultExpirySeconds
+		tableAction["expires_type"] = "date"
 	}
+
 	if req.MinSnapshots != nil {
 		tableAction["min_snapshots"] = *req.MinSnapshots
 	}

--- a/cloud_snapshot_test.go
+++ b/cloud_snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 )
 
 // ---------------------------------------------------------------------------
@@ -183,6 +184,118 @@ func TestCloudSnapshotService_Create(t *testing.T) {
 	}
 	if snap.Name != "manual-snap" {
 		t.Errorf("expected name 'manual-snap', got %q", snap.Name)
+	}
+}
+
+func TestCloudSnapshotService_Create_NeverExpire(t *testing.T) {
+	var captured map[string]any
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/cloud_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			json.NewDecoder(r.Body).Decode(&captured)
+			jsonResponse(w, 200, map[string]any{"$key": 1})
+		},
+		"GET /api/v4/cloud_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, CloudSnapshot{Key: 1, Name: "immortal", Expires: 0})
+		},
+	}))
+
+	_, err := client.CloudSnapshots.Create(context.Background(), &CloudSnapshotCreateRequest{
+		Name:        "immortal",
+		NeverExpire: true,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if _, has := captured["retention"]; has {
+		t.Error("request body must not include 'retention' (API ignores it)")
+	}
+	if captured["expires_type"] != "never" {
+		t.Errorf("expected expires_type 'never', got %v", captured["expires_type"])
+	}
+	// JSON numbers decode to float64 in map[string]any
+	expires, ok := captured["expires"].(float64)
+	if !ok || expires != 0 {
+		t.Errorf("expected expires 0, got %v", captured["expires"])
+	}
+}
+
+func TestCloudSnapshotService_Create_WithRetention(t *testing.T) {
+	var captured map[string]any
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/cloud_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			json.NewDecoder(r.Body).Decode(&captured)
+			jsonResponse(w, 200, map[string]any{"$key": 1})
+		},
+		"GET /api/v4/cloud_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, CloudSnapshot{Key: 1, Name: "week-snap"})
+		},
+	}))
+
+	retention := 7 * 24 * 60 * 60 // 7 days
+	before := time.Now().Unix()
+	_, err := client.CloudSnapshots.Create(context.Background(), &CloudSnapshotCreateRequest{
+		Name:      "week-snap",
+		Retention: &retention,
+	})
+	after := time.Now().Unix()
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if _, has := captured["retention"]; has {
+		t.Error("request body must not include 'retention' (API ignores it)")
+	}
+	if captured["expires_type"] != "date" {
+		t.Errorf("expected expires_type 'date', got %v", captured["expires_type"])
+	}
+	expires, ok := captured["expires"].(float64)
+	if !ok {
+		t.Fatalf("expected numeric expires, got %T", captured["expires"])
+	}
+	minExpires := float64(before + int64(retention))
+	maxExpires := float64(after + int64(retention))
+	if expires < minExpires || expires > maxExpires {
+		t.Errorf("expires %v outside expected window [%v, %v]", expires, minExpires, maxExpires)
+	}
+}
+
+func TestCloudSnapshotService_Create_DefaultExpiry(t *testing.T) {
+	var captured map[string]any
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/cloud_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			json.NewDecoder(r.Body).Decode(&captured)
+			jsonResponse(w, 200, map[string]any{"$key": 1})
+		},
+		"GET /api/v4/cloud_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, CloudSnapshot{Key: 1, Name: "default-snap"})
+		},
+	}))
+
+	before := time.Now().Unix()
+	_, err := client.CloudSnapshots.Create(context.Background(), &CloudSnapshotCreateRequest{
+		Name: "default-snap",
+	})
+	after := time.Now().Unix()
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if _, has := captured["retention"]; has {
+		t.Error("request body must not include 'retention' (API ignores it)")
+	}
+	if captured["expires_type"] != "date" {
+		t.Errorf("expected expires_type 'date', got %v", captured["expires_type"])
+	}
+	expires, ok := captured["expires"].(float64)
+	if !ok {
+		t.Fatalf("expected numeric expires, got %T", captured["expires"])
+	}
+	// Default must match VergeOS server default of now + 259200s (3 days).
+	minExpires := float64(before + cloudSnapshotDefaultExpirySeconds)
+	maxExpires := float64(after + cloudSnapshotDefaultExpirySeconds)
+	if expires < minExpires || expires > maxExpires {
+		t.Errorf("default expires %v outside [%v, %v]", expires, minExpires, maxExpires)
 	}
 }
 

--- a/types_cloud_snapshot.go
+++ b/types_cloud_snapshot.go
@@ -24,11 +24,16 @@ type CloudSnapshot struct {
 }
 
 // CloudSnapshotCreateRequest represents the request body for creating a cloud snapshot.
-// Note: Cloud snapshots are typically created via table_actions/create, which uses different field names.
+// Note: Cloud snapshots are created via the table_actions/create endpoint. The VergeOS
+// API does not accept a "retention" field directly — the Create service translates
+// Retention/NeverExpire into the wire-level "expires" (absolute Unix timestamp) and
+// "expires_type" ("never" or "date") fields. When both Retention and NeverExpire are
+// unset, Create applies the VergeOS default of 3 days (259200 seconds).
 type CloudSnapshotCreateRequest struct {
 	Name         string `json:"name"` // Required: snapshot name (supports date format like "Snapshot_%Y%m%d_%H%M")
 	Description  string `json:"description,omitempty"`
-	Retention    *int   `json:"retention,omitempty"`     // Seconds until expiration (default 259200 = 3 days)
+	Retention    *int   `json:"-"`                       // Seconds until expiration (default 259200 = 3 days). Translated to expires/expires_type.
+	NeverExpire  bool   `json:"-"`                       // When true, snapshot never expires. Overrides Retention.
 	MinSnapshots *int   `json:"min_snapshots,omitempty"` // Minimum snapshots to retain (default 1)
 	Immutable    *bool  `json:"immutable,omitempty"`     // Lock snapshot
 	Private      *bool  `json:"private,omitempty"`       // Hide from tenants


### PR DESCRIPTION
## Summary

- `CloudSnapshotService.Create()` was sending `retention` in the request body, which the VergeOS API silently ignores. All cloud snapshots fell back to the schema-default 72h expiry regardless of what the caller requested.
- Translate the caller-facing `Retention` and new `NeverExpire` knobs into the wire-level `expires` (absolute Unix timestamp) + `expires_type` (`never` / `date`) fields that the server actually reads.
- Preserves the 72h default when neither knob is set (matches the VergeOS `cloud_snapshots.expires` `on_default` of `$now + 259200`).
- Aligns with the same fix in pyVergeOS#50.

## Changes

- `types_cloud_snapshot.go` — add `NeverExpire bool`, mark `Retention` as a non-JSON field (it is translated by the Create service, not serialized directly).
- `cloud_snapshot.go` — replace `retention` mapping with a `switch` that writes `expires` + `expires_type` for the three cases (never, retention, default).

Public API surface: additive only — existing `Retention` callers continue to work, and `NeverExpire` defaults to `false`.

## Downstream impact

- VergeOSExporter / Terraform provider: no breaking change. Create-path callers that relied on `Retention` now actually get the retention they asked for (previously a silent 72h).
- `CloudSnapshotUpdateRequest` is unaffected — it already uses `Expires *int64` correctly.

## Test plan

- [x] `go vet ./...`
- [x] `go test .` (full suite green)
- [x] New unit tests: `TestCloudSnapshotService_Create_NeverExpire`, `_WithRetention`, `_DefaultExpiry` — each asserts the `retention` field is absent and `expires`/`expires_type` are correct.
- [x] Live validation against dev environment: `TestCloudSnapshotsCRUD` with `Retention: 60` — created snapshot returned `Expires=<now+60>`, confirming the retention is honored end-to-end (previously would have been `<now+259200>`).

Refs: verge-io/govergeos#29

🤖 Generated with [Claude Code](https://claude.com/claude-code)