### PR TITLE
feat: add GetByName method to VMDriveService

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -57,6 +57,7 @@ type VMDriveServiceInterface interface {
 	List(ctx context.Context, machineID int) ([]VMDrive, error)
 	ListAll(ctx context.Context, opts ...ListOption) ([]VMDrive, error)
 	Get(ctx context.Context, driveID int) (*VMDrive, error)
+	GetByName(ctx context.Context, vmID int, name string) (*VMDrive, error)
 	Create(ctx context.Context, vmID int, req *VMDriveCreateRequest) (*VMDrive, error)
 	Update(ctx context.Context, driveID int, req *VMDriveUpdateRequest) (*VMDrive, error)
 	Delete(ctx context.Context, driveID int) error

--- a/vm_drive.go
+++ b/vm_drive.go
@@ -85,6 +85,21 @@ func (s *VMDriveService) Get(ctx context.Context, driveID int) (*VMDrive, error)
 	return &drive, nil
 }
 
+// GetByName returns a drive by name within a specific VM.
+// Drive names are scoped to a VM (every VM can have a "disk0"), so vmID is required.
+// Returns NotFoundError if no drive with the given name exists on the VM.
+func (s *VMDriveService) GetByName(ctx context.Context, vmID int, name string) (*VMDrive, error) {
+	drives, err := s.ListAll(ctx, WithFilter(fmt.Sprintf("machine eq %d and name eq '%s'", vmID, escapeFilterValue(name))))
+	if err != nil {
+		return nil, err
+	}
+	if len(drives) == 0 {
+		return nil, &NotFoundError{Resource: "VMDrive", ID: name}
+	}
+	// Fetch full details (Get returns additional fields like power state and status).
+	return s.Get(ctx, drives[0].ID.Int())
+}
+
 // Create creates a new drive and returns the created drive.
 // For import media, this method waits for the import to complete.
 func (s *VMDriveService) Create(ctx context.Context, vmID int, req *VMDriveCreateRequest) (*VMDrive, error) {

--- a/vm_drive_test.go
+++ b/vm_drive_test.go
@@ -108,6 +108,81 @@ func TestVMDriveService_Get(t *testing.T) {
 	}
 }
 
+func TestVMDriveService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drives": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			expected := "machine eq 42 and name eq 'disk0'"
+			if filter != expected {
+				t.Errorf("expected filter %q, got %q", expected, filter)
+			}
+			jsonResponse(w, 200, []VMDrive{
+				{ID: FlexInt(7), Machine: 42, Name: "disk0", SizeBytes: 10 * bytesPerGB},
+			})
+		},
+		"GET /api/v4/machine_drives/7": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMDrive{
+				ID:        FlexInt(7),
+				Machine:   42,
+				Name:      "disk0",
+				SizeBytes: 10 * bytesPerGB,
+				Interface: "virtio-scsi",
+			})
+		},
+	}))
+
+	drive, err := client.VMDrives.GetByName(context.Background(), 42, "disk0")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if drive.Name != "disk0" {
+		t.Errorf("expected name 'disk0', got %q", drive.Name)
+	}
+	if drive.ID.Int() != 7 {
+		t.Errorf("expected ID 7, got %d", drive.ID.Int())
+	}
+	if drive.SizeGB != 10 {
+		t.Errorf("expected SizeGB 10, got %d", drive.SizeGB)
+	}
+}
+
+func TestVMDriveService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drives": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VMDrive{})
+		},
+	}))
+
+	_, err := client.VMDrives.GetByName(context.Background(), 42, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVMDriveService_GetByName_EscapesName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drives": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			expected := "machine eq 42 and name eq 'o''malley'"
+			if filter != expected {
+				t.Errorf("expected filter %q, got %q", expected, filter)
+			}
+			jsonResponse(w, 200, []VMDrive{})
+		},
+	}))
+
+	_, err := client.VMDrives.GetByName(context.Background(), 42, "o'malley")
+	if err == nil {
+		t.Fatal("expected NotFoundError")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
 func TestVMDriveService_Get_NotFound(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"GET /api/v4/machine_drives/999": func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Adds `VMDriveService.GetByName(ctx, vmID, name)` to look up a drive by name within a specific VM, matching the convention already used by `VMSnapshots.GetByName`, `VNetRules.GetByName`, and `Volumes.GetByName`.

Closes #12

## Changes

- `interfaces.go` — adds `GetByName` to `VMDriveServiceInterface`
- `vm_drive.go` — implements `VMDriveService.GetByName`; filters via `machine eq <vmID> and name eq '<name>'`, escapes the name value, returns `NotFoundError` on empty result, and rehydrates the match via `Get` so callers receive the same field set as `Get` (including power state and status)
- `vm_drive_test.go` — three new tests:
  - happy path: asserts filter shape and returns a fully hydrated drive
  - `NotFoundError` when no match
  - filter-value escaping for names containing single quotes

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` green
- [x] Live validation against dev VergeOS (`192.168.10.74`):
  - `GetByName(ctx, 2, "nvme0n1")` returns the expected drive
  - `GetByName(ctx, 2, "does-not-exist-xyz")` returns `NotFoundError`

## Notes / downstream impact

- Additive change only — no existing signatures affected.
- VMDriveServiceInterface gains a method; any downstream mock must add `GetByName` to compile.
- Pattern is identical to the existing `VNetRule.GetByName` / `Volume.GetByName` (filter + rehydrate via `Get`).