### PR TITLE
feat: expose vnet machine status on Network; fix network power/DNS actions

### DIFF
--- a/network.go
+++ b/network.go
@@ -13,7 +13,7 @@ const (
 	networkActionPowerOff = "poweroff"
 	networkActionKill     = "kill"
 	networkActionReset    = "reset"
-	networkActionApply = "refresh"
+	networkActionApply    = "refresh"
 
 	// Network power state polling
 	networkPowerStateMaxRetries   = 30

--- a/network.go
+++ b/network.go
@@ -11,7 +11,7 @@ const (
 	// Network action constants
 	networkActionPowerOn  = "poweron"
 	networkActionPowerOff = "poweroff"
-	networkActionKill     = "killpower"
+	networkActionKill     = "kill"
 	networkActionReset    = "reset"
 	networkActionApply    = "refresh"
 	networkActionApplyDNS = "applydns"
@@ -131,18 +131,17 @@ func (s *NetworkService) PowerOn(ctx context.Context, id int) error {
 	}
 
 	// Already running
-	if network.PowerState {
+	if network.Running {
 		return nil
 	}
 
-	// Power on is typically done by enabling the network
-	enabled := true
-	updateReq := &NetworkUpdateRequest{
-		Enabled: &enabled,
+	action := vnetAction{
+		VNet:   id,
+		Action: networkActionPowerOn,
+		Params: struct{}{},
 	}
 
-	_, err = s.Update(ctx, id, updateReq)
-	if err != nil {
+	if err := s.client.post(ctx, "/vnet_actions", action, nil); err != nil {
 		return fmt.Errorf("vergeos: failed to power on network %d: %w", id, err)
 	}
 
@@ -159,14 +158,14 @@ func (s *NetworkService) PowerOff(ctx context.Context, id int) error {
 	}
 
 	// Already stopped
-	if !network.PowerState {
+	if !network.Running {
 		return nil
 	}
 
-	// Send kill action
+	// Graceful ACPI shutdown; use Kill for immediate termination
 	action := vnetAction{
 		VNet:   id,
-		Action: networkActionKill,
+		Action: networkActionPowerOff,
 		Params: struct{}{},
 	}
 
@@ -191,7 +190,7 @@ func (s *NetworkService) waitForPowerState(ctx context.Context, id int, desiredS
 			return err
 		}
 
-		if network.PowerState == desiredState {
+		if network.Running == desiredState {
 			return nil
 		}
 

--- a/network.go
+++ b/network.go
@@ -13,8 +13,7 @@ const (
 	networkActionPowerOff = "poweroff"
 	networkActionKill     = "kill"
 	networkActionReset    = "reset"
-	networkActionApply    = "refresh"
-	networkActionApplyDNS = "applydns"
+	networkActionApply = "refresh"
 
 	// Network power state polling
 	networkPowerStateMaxRetries   = 30
@@ -257,10 +256,14 @@ func (s *NetworkService) ApplyRules(ctx context.Context, id int) error {
 
 // ApplyDNS applies DNS configuration to a running network.
 func (s *NetworkService) ApplyDNS(ctx context.Context, id int) error {
+	// DNS-only apply is a refresh scoped to target=dnsonly (there is no
+	// applydns value in the vnet_actions enum).
 	action := vnetAction{
 		VNet:   id,
-		Action: networkActionApplyDNS,
-		Params: struct{}{},
+		Action: networkActionApply,
+		Params: struct {
+			Target string `json:"target"`
+		}{Target: "dnsonly"},
 	}
 
 	if err := s.client.post(ctx, "/vnet_actions", action, nil); err != nil {

--- a/network_test.go
+++ b/network_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -64,6 +65,33 @@ func TestNetworkService_List_Empty(t *testing.T) {
 	}
 	if len(networks) != 0 {
 		t.Fatalf("expected 0 networks, got %d", len(networks))
+	}
+}
+
+func TestNetworkService_List_MachineStatus(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnets": func(w http.ResponseWriter, r *http.Request) {
+			for _, f := range []string{"machine", "nic", "nic_dmz", "machine#status#running as running", "machine#status#status as status"} {
+				if !strings.Contains(r.URL.Query().Get("fields"), f) {
+					t.Errorf("expected fields to contain %q", f)
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			w.Write([]byte(`[{"$key":1,"name":"internal","powerstate":false,"machine":42,"nic":7,"nic_dmz":8,"running":true,"status":"running"}]`))
+		},
+	}))
+
+	networks, err := client.Networks.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	n := networks[0]
+	if n.Machine != 42 || n.NIC != 7 || n.NICDMZ != 8 {
+		t.Errorf("expected machine=42 nic=7 nic_dmz=8, got %d/%d/%d", n.Machine, n.NIC, n.NICDMZ)
+	}
+	if !n.Running || n.Status != "running" {
+		t.Errorf("expected running=true status=running, got %v/%q", n.Running, n.Status)
 	}
 }
 

--- a/network_test.go
+++ b/network_test.go
@@ -298,8 +298,8 @@ func TestNetworkService_Kill(t *testing.T) {
 			if body.VNet != 5 {
 				t.Errorf("expected vnet 5, got %d", body.VNet)
 			}
-			if body.Action != "killpower" {
-				t.Errorf("expected action 'killpower', got %q", body.Action)
+			if body.Action != "kill" {
+				t.Errorf("expected action 'kill', got %q", body.Action)
 			}
 			w.WriteHeader(200)
 		},
@@ -764,7 +764,7 @@ func TestNetworkService_GetLatestStatistics_Empty(t *testing.T) {
 func TestNetworkService_PowerOn_AlreadyRunning(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"GET /api/v4/vnets/1": func(w http.ResponseWriter, r *http.Request) {
-			jsonResponse(w, 200, Network{ID: 1, Name: "net", PowerState: true})
+			jsonResponse(w, 200, Network{ID: 1, Name: "net", Running: true})
 		},
 	}))
 
@@ -775,12 +775,62 @@ func TestNetworkService_PowerOn_AlreadyRunning(t *testing.T) {
 	}
 }
 
+func TestNetworkService_PowerOn(t *testing.T) {
+	powered := false
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Network{ID: 1, Name: "net", Running: powered})
+		},
+		"POST /api/v4/vnet_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body vnetAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "poweron" {
+				t.Errorf("expected action 'poweron', got %q", body.Action)
+			}
+			powered = true
+			w.WriteHeader(200)
+		},
+	}))
+
+	if err := client.Networks.PowerOn(context.Background(), 1); err != nil {
+		t.Fatalf("PowerOn failed: %v", err)
+	}
+	if !powered {
+		t.Error("expected poweron action to be posted")
+	}
+}
+
 // --- PowerOff ---
+
+func TestNetworkService_PowerOff(t *testing.T) {
+	powered := true
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vnets/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, Network{ID: 1, Name: "net", Running: powered})
+		},
+		"POST /api/v4/vnet_actions": func(w http.ResponseWriter, r *http.Request) {
+			var body vnetAction
+			json.NewDecoder(r.Body).Decode(&body)
+			if body.Action != "poweroff" {
+				t.Errorf("expected action 'poweroff', got %q", body.Action)
+			}
+			powered = false
+			w.WriteHeader(200)
+		},
+	}))
+
+	if err := client.Networks.PowerOff(context.Background(), 1); err != nil {
+		t.Fatalf("PowerOff failed: %v", err)
+	}
+	if powered {
+		t.Error("expected poweroff action to be posted")
+	}
+}
 
 func TestNetworkService_PowerOff_AlreadyStopped(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"GET /api/v4/vnets/1": func(w http.ResponseWriter, r *http.Request) {
-			jsonResponse(w, 200, Network{ID: 1, Name: "net", PowerState: false})
+			jsonResponse(w, 200, Network{ID: 1, Name: "net", Running: false})
 		},
 	}))
 

--- a/network_test.go
+++ b/network_test.go
@@ -385,13 +385,17 @@ func TestNetworkService_ApplyRules(t *testing.T) {
 func TestNetworkService_ApplyDNS(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"POST /api/v4/vnet_actions": func(w http.ResponseWriter, r *http.Request) {
-			var body vnetAction
+			var body map[string]any
 			json.NewDecoder(r.Body).Decode(&body)
-			if body.VNet != 7 {
-				t.Errorf("expected vnet 7, got %d", body.VNet)
+			if body["vnet"] != float64(7) {
+				t.Errorf("expected vnet 7, got %v", body["vnet"])
 			}
-			if body.Action != "applydns" {
-				t.Errorf("expected action 'applydns', got %q", body.Action)
+			if body["action"] != "refresh" {
+				t.Errorf("expected action 'refresh', got %v", body["action"])
+			}
+			params, _ := body["params"].(map[string]any)
+			if params["target"] != "dnsonly" {
+				t.Errorf("expected params.target 'dnsonly', got %v", params["target"])
 			}
 			w.WriteHeader(200)
 		},

--- a/types_network.go
+++ b/types_network.go
@@ -437,9 +437,9 @@ type NetworkUpdateRequest struct {
 
 // vnetAction represents a network action request.
 type vnetAction struct {
-	VNet   int         `json:"vnet"`
-	Action string      `json:"action"`
-	Params any `json:"params"`
+	VNet   int    `json:"vnet"`
+	Action string `json:"action"`
+	Params any    `json:"params"`
 }
 
 // networkListFields are the fields to request when listing networks.

--- a/types_network.go
+++ b/types_network.go
@@ -77,7 +77,20 @@ type Network struct {
 	// OnPowerLoss is the behavior on power loss (power_on, last_state, leave_off).
 	OnPowerLoss string `json:"on_power_loss,omitempty"`
 	// PowerState indicates whether the network is running.
+	// Note: this DB field is not maintained by the platform and may read
+	// false for running networks. Use Running/Status (derived from the
+	// router machine status) for the true state.
 	PowerState bool `json:"powerstate,omitempty"`
+	// Machine is the router machine ID (FK to machines).
+	Machine FlexInt `json:"machine,omitempty"`
+	// NIC is the router NIC ID (FK to machine_nics).
+	NIC FlexInt `json:"nic,omitempty"`
+	// NICDMZ is the router DMZ NIC ID (FK to machine_nics).
+	NICDMZ FlexInt `json:"nic_dmz,omitempty"`
+	// Running indicates whether the router machine is running (machine#status#running).
+	Running bool `json:"running,omitempty"`
+	// Status is the router machine status (machine#status#status), e.g. "running".
+	Status string `json:"status,omitempty"`
 	// Cluster is the cluster ID for this network.
 	Cluster FlexInt `json:"cluster,omitempty"`
 	// ClusterFailover is the failover cluster ID (0 = none).
@@ -430,7 +443,7 @@ type vnetAction struct {
 }
 
 // networkListFields are the fields to request when listing networks.
-const networkListFields = "$key,name,description,enabled,creator,ipaddress,dmz_ipaddress,macaddress,network,gateway,ipaddress_type,hostname,dns,domain,dnslist,override_dhcp_dns,network_dns,dhcp_enabled,dhcp_dynamic,dhcp_sequential,dhcp_start,dhcp_stop,type,layer2_type,layer2_id,vxlan_multicast,mtu,interface_vnet,physical_bridged,on_power_loss,powerstate,cluster,cluster_failover,preferred_node,ha_group,enable_bonding,port_mirroring,port_mirroring_vnet,statistics,dmz_statistics,trace,mirror_logs,need_restart,need_fw_apply,need_dns_apply,need_proxy_apply,rate_limit,rate_limit_type,rate_limit_burst,bgp_asn,ipsec_enabled,proxy_enabled,proxy_listen_address,pxe,tftp_server,monitor_gateway,monitor_ip,monitor_interval_ms,note"
+const networkListFields = "$key,name,description,enabled,creator,ipaddress,dmz_ipaddress,macaddress,network,gateway,ipaddress_type,hostname,dns,domain,dnslist,override_dhcp_dns,network_dns,dhcp_enabled,dhcp_dynamic,dhcp_sequential,dhcp_start,dhcp_stop,type,layer2_type,layer2_id,vxlan_multicast,mtu,interface_vnet,physical_bridged,on_power_loss,powerstate,machine,nic,nic_dmz,machine#status#running as running,machine#status#status as status,cluster,cluster_failover,preferred_node,ha_group,enable_bonding,port_mirroring,port_mirroring_vnet,statistics,dmz_statistics,trace,mirror_logs,need_restart,need_fw_apply,need_dns_apply,need_proxy_apply,rate_limit,rate_limit_type,rate_limit_burst,bgp_asn,ipsec_enabled,proxy_enabled,proxy_listen_address,pxe,tftp_server,monitor_gateway,monitor_ip,monitor_interval_ms,note"
 
 // networkGetFields are the fields to request when getting a single network.
 const networkGetFields = networkListFields + ",vnet_default_gateway,bond_interfaces_args"


### PR DESCRIPTION
Resolves #34.

## Changes

### Expose machine status and router NIC linkage (#34)
- Add `Machine`, `NIC`, `NICDMZ` (FlexInt FKs) to the `Network` struct
- Add `Running bool` / `Status string`, populated via `machine#status#running as running` / `machine#status#status as status` field aliases (same pattern as `types_machine_status.go` and `types_vm_drive.go`)
- Request all five in `networkListFields` (Get inherits via `networkGetFields`)
- Document that `powerstate` is not maintained by the platform and `Running`/`Status` should be used for true state

### Fix pre-existing network action bugs (found during review of this branch)
The live `vnet_actions.action` enum only accepts `poweron`, `poweroff`, `reset`, `refresh`, `kill`, `migrate`, `execute`, `clear_statistics`. Several methods posted vnets *record action* names or keyed decisions off the unmaintained `powerstate` field:

- **PowerOn** posted `PUT enabled=true` instead of the `poweron` action, and short-circuited on `powerstate` — meaning it silently no-oped incorrectly. Now posts `poweron` and checks `Running`.
- **PowerOff** short-circuited on `powerstate` (always false on live systems, so it returned nil without stopping anything) and sent a hard kill. Now checks `Running` and posts `poweroff` (graceful ACPI shutdown).
- **Kill** posted `killpower` (the vnets record action name), which the server rejects with "value 'killpower' is not in list for field 'action'". Now posts `kill`.
- **ApplyDNS** posted `applydns`, rejected the same way. The record action expands to `refresh` with `params.target=dnsonly`; now posts that directly.
- **waitForPowerState** polled `powerstate` (never converges on live systems); now polls `Running`.

## Test plan
- New/updated unit tests cover the new fields, `poweron`/`poweroff` post-and-poll paths, `kill`, and the `refresh`+`dnsonly` payload
- `go test ./...` and `go vet ./...` pass
- **Live-verified against VergeOS 26.x** (vnet 11): `killpower`/`applydns` rejected by the enum; `kill`, `poweroff`, `poweron`, `refresh`+`dnsonly` all succeed; `running`/`status` track every power transition while `powerstate` never appears in responses