### PR TITLE
release: merge dev into main

### DIFF
--- a/cloud_snapshot.go
+++ b/cloud_snapshot.go
@@ -4,7 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"time"
 )
+
+// cloudSnapshotDefaultExpirySeconds matches the VergeOS server-side default
+// (expires = $now + 259200) for cloud_snapshots.expires.
+const cloudSnapshotDefaultExpirySeconds = 259200
 
 // CloudSnapshotService handles cloud snapshot (system snapshot) operations.
 type CloudSnapshotService struct {
@@ -93,9 +98,24 @@ func (s *CloudSnapshotService) Create(ctx context.Context, req *CloudSnapshotCre
 	if req.Description != "" {
 		tableAction["description"] = req.Description
 	}
-	if req.Retention != nil {
-		tableAction["retention"] = *req.Retention
+
+	// Expiry fields: VergeOS ignores "retention" on create and instead reads
+	// "expires" (absolute Unix timestamp) together with "expires_type" ("never"
+	// or "date"). Translate the caller-facing Retention / NeverExpire knobs into
+	// those wire fields so snapshots honor the requested lifetime instead of
+	// silently falling back to the server default.
+	switch {
+	case req.NeverExpire:
+		tableAction["expires"] = 0
+		tableAction["expires_type"] = "never"
+	case req.Retention != nil:
+		tableAction["expires"] = time.Now().Unix() + int64(*req.Retention)
+		tableAction["expires_type"] = "date"
+	default:
+		tableAction["expires"] = time.Now().Unix() + cloudSnapshotDefaultExpirySeconds
+		tableAction["expires_type"] = "date"
 	}
+
 	if req.MinSnapshots != nil {
 		tableAction["min_snapshots"] = *req.MinSnapshots
 	}

--- a/cloud_snapshot_test.go
+++ b/cloud_snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 )
 
 // ---------------------------------------------------------------------------
@@ -183,6 +184,118 @@ func TestCloudSnapshotService_Create(t *testing.T) {
 	}
 	if snap.Name != "manual-snap" {
 		t.Errorf("expected name 'manual-snap', got %q", snap.Name)
+	}
+}
+
+func TestCloudSnapshotService_Create_NeverExpire(t *testing.T) {
+	var captured map[string]any
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/cloud_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			json.NewDecoder(r.Body).Decode(&captured)
+			jsonResponse(w, 200, map[string]any{"$key": 1})
+		},
+		"GET /api/v4/cloud_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, CloudSnapshot{Key: 1, Name: "immortal", Expires: 0})
+		},
+	}))
+
+	_, err := client.CloudSnapshots.Create(context.Background(), &CloudSnapshotCreateRequest{
+		Name:        "immortal",
+		NeverExpire: true,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if _, has := captured["retention"]; has {
+		t.Error("request body must not include 'retention' (API ignores it)")
+	}
+	if captured["expires_type"] != "never" {
+		t.Errorf("expected expires_type 'never', got %v", captured["expires_type"])
+	}
+	// JSON numbers decode to float64 in map[string]any
+	expires, ok := captured["expires"].(float64)
+	if !ok || expires != 0 {
+		t.Errorf("expected expires 0, got %v", captured["expires"])
+	}
+}
+
+func TestCloudSnapshotService_Create_WithRetention(t *testing.T) {
+	var captured map[string]any
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/cloud_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			json.NewDecoder(r.Body).Decode(&captured)
+			jsonResponse(w, 200, map[string]any{"$key": 1})
+		},
+		"GET /api/v4/cloud_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, CloudSnapshot{Key: 1, Name: "week-snap"})
+		},
+	}))
+
+	retention := 7 * 24 * 60 * 60 // 7 days
+	before := time.Now().Unix()
+	_, err := client.CloudSnapshots.Create(context.Background(), &CloudSnapshotCreateRequest{
+		Name:      "week-snap",
+		Retention: &retention,
+	})
+	after := time.Now().Unix()
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if _, has := captured["retention"]; has {
+		t.Error("request body must not include 'retention' (API ignores it)")
+	}
+	if captured["expires_type"] != "date" {
+		t.Errorf("expected expires_type 'date', got %v", captured["expires_type"])
+	}
+	expires, ok := captured["expires"].(float64)
+	if !ok {
+		t.Fatalf("expected numeric expires, got %T", captured["expires"])
+	}
+	minExpires := float64(before + int64(retention))
+	maxExpires := float64(after + int64(retention))
+	if expires < minExpires || expires > maxExpires {
+		t.Errorf("expires %v outside expected window [%v, %v]", expires, minExpires, maxExpires)
+	}
+}
+
+func TestCloudSnapshotService_Create_DefaultExpiry(t *testing.T) {
+	var captured map[string]any
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"POST /api/v4/cloud_snapshots": func(w http.ResponseWriter, r *http.Request) {
+			json.NewDecoder(r.Body).Decode(&captured)
+			jsonResponse(w, 200, map[string]any{"$key": 1})
+		},
+		"GET /api/v4/cloud_snapshots/1": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, CloudSnapshot{Key: 1, Name: "default-snap"})
+		},
+	}))
+
+	before := time.Now().Unix()
+	_, err := client.CloudSnapshots.Create(context.Background(), &CloudSnapshotCreateRequest{
+		Name: "default-snap",
+	})
+	after := time.Now().Unix()
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if _, has := captured["retention"]; has {
+		t.Error("request body must not include 'retention' (API ignores it)")
+	}
+	if captured["expires_type"] != "date" {
+		t.Errorf("expected expires_type 'date', got %v", captured["expires_type"])
+	}
+	expires, ok := captured["expires"].(float64)
+	if !ok {
+		t.Fatalf("expected numeric expires, got %T", captured["expires"])
+	}
+	// Default must match VergeOS server default of now + 259200s (3 days).
+	minExpires := float64(before + cloudSnapshotDefaultExpirySeconds)
+	maxExpires := float64(after + cloudSnapshotDefaultExpirySeconds)
+	if expires < minExpires || expires > maxExpires {
+		t.Errorf("default expires %v outside [%v, %v]", expires, minExpires, maxExpires)
 	}
 }
 

--- a/interfaces.go
+++ b/interfaces.go
@@ -25,6 +25,7 @@ type VMServiceInterface interface {
 	Snapshot(ctx context.Context, id int, opts *VMSnapshotOptions) error
 	Migrate(ctx context.Context, id int, opts *VMMigrateOptions) error
 	GetConsoleURL(ctx context.Context, id int) (string, error)
+	GetGuestAgentInfo(ctx context.Context, id int) (*VMGuestAgentInfo, error)
 }
 
 // VMSnapshotServiceInterface defines the interface for VM Snapshot operations.

--- a/interfaces.go
+++ b/interfaces.go
@@ -25,7 +25,7 @@ type VMServiceInterface interface {
 	Snapshot(ctx context.Context, id int, opts *VMSnapshotOptions) error
 	Migrate(ctx context.Context, id int, opts *VMMigrateOptions) error
 	GetConsoleURL(ctx context.Context, id int) (string, error)
-	GetGuestAgentInfo(ctx context.Context, id int) (*VMGuestAgentInfo, error)
+	GetGuestAgentInfo(ctx context.Context, id int) (*GuestInfo, error)
 }
 
 // VMSnapshotServiceInterface defines the interface for VM Snapshot operations.

--- a/interfaces.go
+++ b/interfaces.go
@@ -57,6 +57,7 @@ type VMDriveServiceInterface interface {
 	List(ctx context.Context, machineID int) ([]VMDrive, error)
 	ListAll(ctx context.Context, opts ...ListOption) ([]VMDrive, error)
 	Get(ctx context.Context, driveID int) (*VMDrive, error)
+	GetByName(ctx context.Context, vmID int, name string) (*VMDrive, error)
 	Create(ctx context.Context, vmID int, req *VMDriveCreateRequest) (*VMDrive, error)
 	Update(ctx context.Context, driveID int, req *VMDriveUpdateRequest) (*VMDrive, error)
 	Delete(ctx context.Context, driveID int) error

--- a/types_cloud_snapshot.go
+++ b/types_cloud_snapshot.go
@@ -24,11 +24,16 @@ type CloudSnapshot struct {
 }
 
 // CloudSnapshotCreateRequest represents the request body for creating a cloud snapshot.
-// Note: Cloud snapshots are typically created via table_actions/create, which uses different field names.
+// Note: Cloud snapshots are created via the table_actions/create endpoint. The VergeOS
+// API does not accept a "retention" field directly — the Create service translates
+// Retention/NeverExpire into the wire-level "expires" (absolute Unix timestamp) and
+// "expires_type" ("never" or "date") fields. When both Retention and NeverExpire are
+// unset, Create applies the VergeOS default of 3 days (259200 seconds).
 type CloudSnapshotCreateRequest struct {
 	Name         string `json:"name"` // Required: snapshot name (supports date format like "Snapshot_%Y%m%d_%H%M")
 	Description  string `json:"description,omitempty"`
-	Retention    *int   `json:"retention,omitempty"`     // Seconds until expiration (default 259200 = 3 days)
+	Retention    *int   `json:"-"`                       // Seconds until expiration (default 259200 = 3 days). Translated to expires/expires_type.
+	NeverExpire  bool   `json:"-"`                       // When true, snapshot never expires. Overrides Retention.
 	MinSnapshots *int   `json:"min_snapshots,omitempty"` // Minimum snapshots to retain (default 1)
 	Immutable    *bool  `json:"immutable,omitempty"`     // Lock snapshot
 	Private      *bool  `json:"private,omitempty"`       // Hide from tenants

--- a/types_machine_status.go
+++ b/types_machine_status.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // MachineStatus represents the runtime status of a VergeOS machine (VM).
@@ -141,6 +142,25 @@ func unmarshalFlexList[T any](data json.RawMessage) ([]T, error) {
 	}
 
 	return nil, fmt.Errorf("expected JSON array or object, got: %.50s", data)
+}
+
+// IPsForMAC returns the IP addresses of the guest interfaces whose hardware
+// address matches mac (case-insensitive). This is the reliable way to find a
+// VM's real IP: match on the MAC of a known VM NIC rather than interface
+// names, which are OS-dependent ("eth0", "ens1", "Ethernet 2") and drowned
+// out by container bridges and veths on busy guests. Returns nil when the
+// MAC is not found or g is nil.
+func (g *GuestInfo) IPsForMAC(mac string) []GuestIPAddress {
+	if g == nil {
+		return nil
+	}
+	var ips []GuestIPAddress
+	for _, nic := range g.Network {
+		if strings.EqualFold(nic.HardwareAddress, mac) {
+			ips = append(ips, nic.IPAddresses...)
+		}
+	}
+	return ips
 }
 
 // GuestOSInfo contains operating system information from the guest agent.

--- a/types_vm.go
+++ b/types_vm.go
@@ -388,6 +388,46 @@ type vmActionParams struct {
 	Unplug bool   `json:"unplug,omitempty"`
 }
 
+// VMGuestAgentInfo contains guest agent information reported by a running VM,
+// parsed from the dashboard view's machine.status.agent_guest_info field.
+// Fields beyond Network (osinfo, fsinfo, hostname, timezone, last_refresh) are
+// currently not exposed.
+type VMGuestAgentInfo struct {
+	// Network is the list of network interfaces reported by the guest agent.
+	Network []VMGuestNetwork `json:"network,omitempty"`
+}
+
+// VMGuestNetwork represents a network interface reported by the guest agent.
+type VMGuestNetwork struct {
+	// Name is the interface name inside the guest (e.g., "lo", "ens1").
+	Name string `json:"name,omitempty"`
+	// HardwareAddress is the interface MAC address.
+	HardwareAddress string `json:"hardware-address,omitempty"`
+	// IPAddresses is the list of IP addresses assigned to the interface.
+	// Interfaces without an IP (e.g., unconfigured) will have an empty list.
+	IPAddresses []VMGuestIPAddress `json:"ip-addresses,omitempty"`
+}
+
+// VMGuestIPAddress represents an IP address reported by the guest agent.
+type VMGuestIPAddress struct {
+	// IPAddressType is the address family: "ipv4" or "ipv6".
+	IPAddressType string `json:"ip-address-type,omitempty"`
+	// IPAddress is the address in standard string form.
+	IPAddress string `json:"ip-address,omitempty"`
+	// Prefix is the CIDR prefix length.
+	Prefix int `json:"prefix,omitempty"`
+}
+
+// vmDashboardResponse is the internal response structure for the dashboard
+// view, narrowed to the fields we parse for GetGuestAgentInfo.
+type vmDashboardResponse struct {
+	Machine struct {
+		Status struct {
+			AgentGuestInfo *VMGuestAgentInfo `json:"agent_guest_info,omitempty"`
+		} `json:"status,omitempty"`
+	} `json:"machine,omitempty"`
+}
+
 // vmListFields are the fields to request when listing VMs.
 const vmListFields = "$key,uuid,machine,name,description,enabled,created,modified,is_snapshot,owner,owner_user,creator,cluster,cluster_failover,cpu_cores,cpu_type,ram,machine_type,iommu,usb_legacy,uefi,secure_boot,boot_order,boot_delay,console,video,sound,serial_port,os_family,os_description,rtc_base,allow_hotplug,guest_agent,nested_virtualization,disable_hypervisor,allow_export,cloudinit_datasource,preferred_node,ha_group,snapshot_profile,on_power_loss,migration_method,power_cycle_timeout,need_restart,created_from,imported,machine#status#running as powerstate"
 

--- a/types_vm.go
+++ b/types_vm.go
@@ -388,42 +388,14 @@ type vmActionParams struct {
 	Unplug bool   `json:"unplug,omitempty"`
 }
 
-// VMGuestAgentInfo contains guest agent information reported by a running VM,
-// parsed from the dashboard view's machine.status.agent_guest_info field.
-// Fields beyond Network (osinfo, fsinfo, hostname, timezone, last_refresh) are
-// currently not exposed.
-type VMGuestAgentInfo struct {
-	// Network is the list of network interfaces reported by the guest agent.
-	Network []VMGuestNetwork `json:"network,omitempty"`
-}
-
-// VMGuestNetwork represents a network interface reported by the guest agent.
-type VMGuestNetwork struct {
-	// Name is the interface name inside the guest (e.g., "lo", "ens1").
-	Name string `json:"name,omitempty"`
-	// HardwareAddress is the interface MAC address.
-	HardwareAddress string `json:"hardware-address,omitempty"`
-	// IPAddresses is the list of IP addresses assigned to the interface.
-	// Interfaces without an IP (e.g., unconfigured) will have an empty list.
-	IPAddresses []VMGuestIPAddress `json:"ip-addresses,omitempty"`
-}
-
-// VMGuestIPAddress represents an IP address reported by the guest agent.
-type VMGuestIPAddress struct {
-	// IPAddressType is the address family: "ipv4" or "ipv6".
-	IPAddressType string `json:"ip-address-type,omitempty"`
-	// IPAddress is the address in standard string form.
-	IPAddress string `json:"ip-address,omitempty"`
-	// Prefix is the CIDR prefix length.
-	Prefix int `json:"prefix,omitempty"`
-}
-
 // vmDashboardResponse is the internal response structure for the dashboard
-// view, narrowed to the fields we parse for GetGuestAgentInfo.
+// view, narrowed to the fields we parse for GetGuestAgentInfo. GuestInfo
+// (types_machine_status.go) handles the API's wire-shape quirks: [] when the
+// agent has not reported, and network/fsinfo as either array or object.
 type vmDashboardResponse struct {
 	Machine struct {
 		Status struct {
-			AgentGuestInfo *VMGuestAgentInfo `json:"agent_guest_info,omitempty"`
+			AgentGuestInfo *GuestInfo `json:"agent_guest_info,omitempty"`
 		} `json:"status,omitempty"`
 	} `json:"machine,omitempty"`
 }

--- a/vm.go
+++ b/vm.go
@@ -372,7 +372,7 @@ func (s *VMService) Migrate(ctx context.Context, id int, opts *VMMigrateOptions)
 // Returns nil (with a nil error) when the guest agent has not reported — for
 // example, when the VM is powered off, the agent is not installed, or the
 // agent has not yet delivered an update.
-func (s *VMService) GetGuestAgentInfo(ctx context.Context, id int) (*VMGuestAgentInfo, error) {
+func (s *VMService) GetGuestAgentInfo(ctx context.Context, id int) (*GuestInfo, error) {
 	params := url.Values{}
 	params.Set("fields", "dashboard")
 
@@ -385,7 +385,15 @@ func (s *VMService) GetGuestAgentInfo(ctx context.Context, id int) (*VMGuestAgen
 		return nil, err
 	}
 
-	return resp.Machine.Status.AgentGuestInfo, nil
+	info := resp.Machine.Status.AgentGuestInfo
+	// The API sends agent_guest_info: [] when the agent has not reported;
+	// GuestInfo.UnmarshalJSON decodes that to a zero value. Normalize to nil
+	// so callers get a single "not reported" signal.
+	if info != nil && info.OSInfo == nil && info.Network == nil && info.FSInfo == nil &&
+		info.MemInfo == nil && info.Hostname == "" && info.LastRefresh == 0 {
+		return nil, nil
+	}
+	return info, nil
 }
 
 // GetConsoleURL returns the console URL for a VM.

--- a/vm.go
+++ b/vm.go
@@ -367,6 +367,27 @@ func (s *VMService) Migrate(ctx context.Context, id int, opts *VMMigrateOptions)
 	return nil
 }
 
+// GetGuestAgentInfo returns guest agent information for a VM, including
+// network interfaces and IP addresses reported by the in-guest qemu-guest-agent.
+// Returns nil (with a nil error) when the guest agent has not reported — for
+// example, when the VM is powered off, the agent is not installed, or the
+// agent has not yet delivered an update.
+func (s *VMService) GetGuestAgentInfo(ctx context.Context, id int) (*VMGuestAgentInfo, error) {
+	params := url.Values{}
+	params.Set("fields", "dashboard")
+
+	var resp vmDashboardResponse
+	endpoint := fmt.Sprintf("/vms/%d", id)
+	if err := s.client.get(ctx, endpoint, params, &resp); err != nil {
+		if IsNotFoundError(err) {
+			return nil, &NotFoundError{Resource: "VM", ID: id}
+		}
+		return nil, err
+	}
+
+	return resp.Machine.Status.AgentGuestInfo, nil
+}
+
 // GetConsoleURL returns the console URL for a VM.
 func (s *VMService) GetConsoleURL(ctx context.Context, id int) (string, error) {
 	vm, err := s.Get(ctx, id)

--- a/vm_drive.go
+++ b/vm_drive.go
@@ -85,6 +85,21 @@ func (s *VMDriveService) Get(ctx context.Context, driveID int) (*VMDrive, error)
 	return &drive, nil
 }
 
+// GetByName returns a drive by name within a specific VM.
+// Drive names are scoped to a VM (every VM can have a "disk0"), so vmID is required.
+// Returns NotFoundError if no drive with the given name exists on the VM.
+func (s *VMDriveService) GetByName(ctx context.Context, vmID int, name string) (*VMDrive, error) {
+	drives, err := s.ListAll(ctx, WithFilter(fmt.Sprintf("machine eq %d and name eq '%s'", vmID, escapeFilterValue(name))))
+	if err != nil {
+		return nil, err
+	}
+	if len(drives) == 0 {
+		return nil, &NotFoundError{Resource: "VMDrive", ID: name}
+	}
+	// Fetch full details (Get returns additional fields like power state and status).
+	return s.Get(ctx, drives[0].ID.Int())
+}
+
 // Create creates a new drive and returns the created drive.
 // For import media, this method waits for the import to complete.
 func (s *VMDriveService) Create(ctx context.Context, vmID int, req *VMDriveCreateRequest) (*VMDrive, error) {

--- a/vm_drive_test.go
+++ b/vm_drive_test.go
@@ -108,6 +108,81 @@ func TestVMDriveService_Get(t *testing.T) {
 	}
 }
 
+func TestVMDriveService_GetByName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drives": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			expected := "machine eq 42 and name eq 'disk0'"
+			if filter != expected {
+				t.Errorf("expected filter %q, got %q", expected, filter)
+			}
+			jsonResponse(w, 200, []VMDrive{
+				{ID: FlexInt(7), Machine: 42, Name: "disk0", SizeBytes: 10 * bytesPerGB},
+			})
+		},
+		"GET /api/v4/machine_drives/7": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, VMDrive{
+				ID:        FlexInt(7),
+				Machine:   42,
+				Name:      "disk0",
+				SizeBytes: 10 * bytesPerGB,
+				Interface: "virtio-scsi",
+			})
+		},
+	}))
+
+	drive, err := client.VMDrives.GetByName(context.Background(), 42, "disk0")
+	if err != nil {
+		t.Fatalf("GetByName failed: %v", err)
+	}
+	if drive.Name != "disk0" {
+		t.Errorf("expected name 'disk0', got %q", drive.Name)
+	}
+	if drive.ID.Int() != 7 {
+		t.Errorf("expected ID 7, got %d", drive.ID.Int())
+	}
+	if drive.SizeGB != 10 {
+		t.Errorf("expected SizeGB 10, got %d", drive.SizeGB)
+	}
+}
+
+func TestVMDriveService_GetByName_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drives": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, []VMDrive{})
+		},
+	}))
+
+	_, err := client.VMDrives.GetByName(context.Background(), 42, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
+func TestVMDriveService_GetByName_EscapesName(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/machine_drives": func(w http.ResponseWriter, r *http.Request) {
+			filter := r.URL.Query().Get("filter")
+			expected := "machine eq 42 and name eq 'o''malley'"
+			if filter != expected {
+				t.Errorf("expected filter %q, got %q", expected, filter)
+			}
+			jsonResponse(w, 200, []VMDrive{})
+		},
+	}))
+
+	_, err := client.VMDrives.GetByName(context.Background(), 42, "o'malley")
+	if err == nil {
+		t.Fatal("expected NotFoundError")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}
+
 func TestVMDriveService_Get_NotFound(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"GET /api/v4/machine_drives/999": func(w http.ResponseWriter, r *http.Request) {

--- a/vm_test.go
+++ b/vm_test.go
@@ -988,6 +988,35 @@ func TestVMService_GetGuestAgentInfo_NotReported(t *testing.T) {
 	}
 }
 
+func TestGuestInfo_IPsForMAC(t *testing.T) {
+	info := &GuestInfo{
+		Network: []GuestNetworkInterface{
+			{Name: "lo", HardwareAddress: "00:00:00:00:00:00", IPAddresses: []GuestIPAddress{{Type: "ipv4", Address: "127.0.0.1"}}},
+			{Name: "docker0", HardwareAddress: "86:8f:54:f5:b9:00", IPAddresses: []GuestIPAddress{{Type: "ipv4", Address: "172.17.0.1"}}},
+			{Name: "Ethernet 2", HardwareAddress: "F0:DB:30:BD:95:0E", IPAddresses: []GuestIPAddress{
+				{Type: "ipv6", Address: "fe80::1%14"},
+				{Type: "ipv4", Address: "192.168.10.176"},
+			}},
+		},
+	}
+
+	ips := info.IPsForMAC("f0:db:30:bd:95:0e")
+	if len(ips) != 2 {
+		t.Fatalf("expected 2 IPs (case-insensitive match), got %d", len(ips))
+	}
+	if ips[1].Address != "192.168.10.176" {
+		t.Errorf("expected '192.168.10.176', got %q", ips[1].Address)
+	}
+
+	if got := info.IPsForMAC("aa:bb:cc:dd:ee:ff"); got != nil {
+		t.Errorf("expected nil for unknown MAC, got %v", got)
+	}
+	var nilInfo *GuestInfo
+	if got := nilInfo.IPsForMAC("f0:db:30:bd:95:0e"); got != nil {
+		t.Errorf("expected nil for nil GuestInfo, got %v", got)
+	}
+}
+
 func TestVMService_GetGuestAgentInfo_NotFound(t *testing.T) {
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"GET /api/v4/vms/999": func(w http.ResponseWriter, r *http.Request) {

--- a/vm_test.go
+++ b/vm_test.go
@@ -907,17 +907,33 @@ func TestVMService_GetGuestAgentInfo(t *testing.T) {
 	if len(info.Network[1].IPAddresses) != 2 {
 		t.Fatalf("expected 2 IPs on ens1, got %d", len(info.Network[1].IPAddresses))
 	}
-	if info.Network[1].IPAddresses[0].IPAddress != "10.0.0.42" {
-		t.Errorf("expected IP '10.0.0.42', got %q", info.Network[1].IPAddresses[0].IPAddress)
+	if info.Network[1].IPAddresses[0].Address != "10.0.0.42" {
+		t.Errorf("expected IP '10.0.0.42', got %q", info.Network[1].IPAddresses[0].Address)
 	}
-	if info.Network[1].IPAddresses[0].IPAddressType != "ipv4" {
-		t.Errorf("expected type 'ipv4', got %q", info.Network[1].IPAddresses[0].IPAddressType)
+	if info.Network[1].IPAddresses[0].Type != "ipv4" {
+		t.Errorf("expected type 'ipv4', got %q", info.Network[1].IPAddresses[0].Type)
 	}
 }
 
-func TestVMService_GetGuestAgentInfo_NotReported(t *testing.T) {
-	// Dashboard response where the guest agent hasn't reported yet: agent_guest_info is absent.
-	const body = `{"machine": {"status": {"status": "running"}}}`
+func TestVMService_GetGuestAgentInfo_NetworkAsObject(t *testing.T) {
+	// Some guest agent versions report network as an object keyed by interface
+	// name instead of an array.
+	const body = `{
+		"machine": {
+			"status": {
+				"agent_guest_info": {
+					"network": {
+						"ens1": {
+							"name": "ens1",
+							"ip-addresses": [
+								{"ip-address-type": "ipv4", "ip-address": "10.0.0.42"}
+							]
+						}
+					}
+				}
+			}
+		}
+	}`
 
 	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
 		"GET /api/v4/vms/45": func(w http.ResponseWriter, r *http.Request) {
@@ -931,8 +947,44 @@ func TestVMService_GetGuestAgentInfo_NotReported(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetGuestAgentInfo failed: %v", err)
 	}
-	if info != nil {
-		t.Errorf("expected nil info when guest agent has not reported, got %+v", info)
+	if info == nil {
+		t.Fatal("expected non-nil info")
+	}
+	if len(info.Network) != 1 {
+		t.Fatalf("expected 1 network interface, got %d", len(info.Network))
+	}
+	if info.Network[0].Name != "ens1" {
+		t.Errorf("expected interface name 'ens1', got %q", info.Network[0].Name)
+	}
+	if info.Network[0].IPAddresses[0].Address != "10.0.0.42" {
+		t.Errorf("expected IP '10.0.0.42', got %q", info.Network[0].IPAddresses[0].Address)
+	}
+}
+
+func TestVMService_GetGuestAgentInfo_NotReported(t *testing.T) {
+	// Two "not reported" wire shapes: agent_guest_info absent entirely, and
+	// the API's agent_guest_info: [] placeholder. Both must yield nil.
+	for name, body := range map[string]string{
+		"absent":     `{"machine": {"status": {"status": "running"}}}`,
+		"emptyArray": `{"machine": {"status": {"status": "running", "agent_guest_info": []}}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+				"GET /api/v4/vms/45": func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(200)
+					w.Write([]byte(body))
+				},
+			}))
+
+			info, err := client.VMs.GetGuestAgentInfo(context.Background(), 45)
+			if err != nil {
+				t.Fatalf("GetGuestAgentInfo failed: %v", err)
+			}
+			if info != nil {
+				t.Errorf("expected nil info when guest agent has not reported, got %+v", info)
+			}
+		})
 	}
 }
 

--- a/vm_test.go
+++ b/vm_test.go
@@ -850,3 +850,104 @@ func TestVMService_GetConsoleURL_NotFound(t *testing.T) {
 		t.Errorf("expected NotFoundError, got %T: %v", err, err)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// GetGuestAgentInfo
+// ---------------------------------------------------------------------------
+
+func TestVMService_GetGuestAgentInfo(t *testing.T) {
+	const body = `{
+		"machine": {
+			"status": {
+				"agent_guest_info": {
+					"network": [
+						{
+							"name": "lo",
+							"ip-addresses": [
+								{"ip-address-type": "ipv4", "ip-address": "127.0.0.1"}
+							]
+						},
+						{
+							"name": "ens1",
+							"ip-addresses": [
+								{"ip-address-type": "ipv4", "ip-address": "10.0.0.42"},
+								{"ip-address-type": "ipv6", "ip-address": "fe80::1"}
+							]
+						}
+					]
+				}
+			}
+		}
+	}`
+
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/45": func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("fields"); got != "dashboard" {
+				t.Errorf("expected fields=dashboard, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			w.Write([]byte(body))
+		},
+	}))
+
+	info, err := client.VMs.GetGuestAgentInfo(context.Background(), 45)
+	if err != nil {
+		t.Fatalf("GetGuestAgentInfo failed: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected non-nil info")
+	}
+	if len(info.Network) != 2 {
+		t.Fatalf("expected 2 network interfaces, got %d", len(info.Network))
+	}
+	if info.Network[1].Name != "ens1" {
+		t.Errorf("expected interface name 'ens1', got %q", info.Network[1].Name)
+	}
+	if len(info.Network[1].IPAddresses) != 2 {
+		t.Fatalf("expected 2 IPs on ens1, got %d", len(info.Network[1].IPAddresses))
+	}
+	if info.Network[1].IPAddresses[0].IPAddress != "10.0.0.42" {
+		t.Errorf("expected IP '10.0.0.42', got %q", info.Network[1].IPAddresses[0].IPAddress)
+	}
+	if info.Network[1].IPAddresses[0].IPAddressType != "ipv4" {
+		t.Errorf("expected type 'ipv4', got %q", info.Network[1].IPAddresses[0].IPAddressType)
+	}
+}
+
+func TestVMService_GetGuestAgentInfo_NotReported(t *testing.T) {
+	// Dashboard response where the guest agent hasn't reported yet: agent_guest_info is absent.
+	const body = `{"machine": {"status": {"status": "running"}}}`
+
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/45": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			w.Write([]byte(body))
+		},
+	}))
+
+	info, err := client.VMs.GetGuestAgentInfo(context.Background(), 45)
+	if err != nil {
+		t.Fatalf("GetGuestAgentInfo failed: %v", err)
+	}
+	if info != nil {
+		t.Errorf("expected nil info when guest agent has not reported, got %+v", info)
+	}
+}
+
+func TestVMService_GetGuestAgentInfo_NotFound(t *testing.T) {
+	client := newTestClient(t, apiMux(map[string]http.HandlerFunc{
+		"GET /api/v4/vms/999": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 404, map[string]string{"err": "not found"})
+		},
+	}))
+
+	_, err := client.VMs.GetGuestAgentInfo(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+	if !IsNotFoundError(err) {
+		t.Errorf("expected NotFoundError, got %T: %v", err, err)
+	}
+}


### PR DESCRIPTION
## Summary

Brings main up to date with dev for the next release. Three changes:

- **#32 — VM guest agent info & IP discovery**: `VMService.GetGuestAgentInfo` returning `*GuestInfo` (handles all API wire shapes: empty-array placeholder, network as array or object), plus `GuestInfo.IPsForMAC(mac)` for deterministic, cross-OS real-VM-IP lookup by NIC MAC. Live-validated against Linux, Windows, docker-host, no-agent, powered-off, and not-found VMs.
- **#31 — `VMDriveService.GetByName`**
- **#30 — cloud snapshot fix**: send `expires`/`expires_type` instead of the ignored `retention` field.

## Downstream impact

Additive except: `VMServiceInterface` gains `GetGuestAgentInfo`, so downstream mocks of that interface (e.g. vergeos-exporter) need a stub.

## Test plan

- [x] `go vet ./...` / `go test ./...` pass on dev
- [x] Live validation of guest agent paths against dev environment (see PR #32 resolution comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)